### PR TITLE
Enable building on macOS and enforce using the core profile.

### DIFF
--- a/src/NovelRenderObject.h
+++ b/src/NovelRenderObject.h
@@ -5,6 +5,7 @@
 #ifndef NOVELRT_NOVELRENDEROBJECT_H
 #define NOVELRT_NOVELRENDEROBJECT_H
 #include "NovelObject.h"
+#include <string>
 #include <glad/glad.h>
 
 namespace NovelRT {

--- a/src/NovelRenderingService.cpp
+++ b/src/NovelRenderingService.cpp
@@ -54,6 +54,9 @@ bool NovelRenderingService::initializeRenderPipeline(const int displayNumber) {
     return -1;
   }
 
+  std::cout << "GL_VERSION : " << glGetString(GL_VERSION) << std::endl;
+  std::cout << "GL_SHADING_LANGUAGE_VERSION: " << glGetString(GL_SHADING_LANGUAGE_VERSION) << std::endl;
+
   _programID = LoadShaders("BasicVertexShader.glsl", "BasicFragmentShader.glsl");
   return true;
 }

--- a/src/NovelRenderingService.cpp
+++ b/src/NovelRenderingService.cpp
@@ -25,6 +25,7 @@ bool NovelRenderingService::initializeRenderPipeline(const int displayNumber) {
     return false;
   }
 
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);

--- a/src/NovelRenderingService.cpp
+++ b/src/NovelRenderingService.cpp
@@ -25,6 +25,10 @@ bool NovelRenderingService::initializeRenderPipeline(const int displayNumber) {
     return false;
   }
 
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+
   SDL_DisplayMode displayData;
   SDL_GetCurrentDisplayMode(displayNumber, &displayData);
   _screenScale = (displayData.h * 0.7f) / 1080.0f;
@@ -49,6 +53,7 @@ bool NovelRenderingService::initializeRenderPipeline(const int displayNumber) {
     fprintf(stderr, "Failed to initialize glad\n");
     return -1;
   }
+
   _programID = LoadShaders("BasicVertexShader.glsl", "BasicFragmentShader.glsl");
   return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,6 @@ static int average(lua_State* L) {
 #endif
 
 int main(int argc, char* argv[]) {
-  setenv("MESA_GL_VERSION_OVERRIDE", "3.2", true);
   //setenv("DISPLAY", "localhost:0", true);
   L = luaL_newstate();
   luaL_openlibs(L);


### PR DESCRIPTION
This enables macOS to successfully build and ensures that the core profile is being used. macOS does not provide the compatibility profile and so using just the core profile is strictly required. 