### PR TITLE
Fixing rendering for ImageRect by ensuring a size is set.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+###############################################################################
+# EditorConfig is awesome: http://EditorConfig.org
+###############################################################################
+
+###############################################################################
+# Top-most EditorConfig file
+###############################################################################
+root = true
+
+###############################################################################
+# Set default behavior to:
+#   a UTF-8 encoding,
+#   Unix-style line endings,
+#   a newline ending the file,
+#   2 space indentation, and
+#   trimming of trailing whitespace
+###############################################################################
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/src/NovelImageRect.h
+++ b/src/NovelImageRect.h
@@ -14,6 +14,7 @@ class NovelImageRect : public NovelRenderObject {
 public:
   NovelImageRect(NovelLayeringService* layeringService,
                  const float& screenScale,
+                 const GeoVector<float>& size,
                  const std::string_view imageDir,
                  const NovelCommonArgs& args, GLuint programId);
 

--- a/src/NovelRenderingService.cpp
+++ b/src/NovelRenderingService.cpp
@@ -190,8 +190,10 @@ void NovelRenderingService::endFrame() const {
   SDL_GL_SwapWindow(_window.get());
 }
 
-NovelImageRect* NovelRenderingService::getImageRect(const std::string_view filePath, const NovelCommonArgs& args) {
-  return new NovelImageRect(_layeringService, _screenScale, filePath, args, _texturedRectProgramId);
+NovelImageRect* NovelRenderingService::getImageRect(const GeoVector<float>& startingSize, 
+                                                    const std::string_view filePath,
+                                                    const NovelCommonArgs& args) {
+  return new NovelImageRect(_layeringService, _screenScale, startingSize, filePath, args, _texturedRectProgramId);
 }
 
 std::shared_ptr<SDL_Window> NovelRenderingService::getWindow() const {

--- a/src/NovelRenderingService.h
+++ b/src/NovelRenderingService.h
@@ -27,7 +27,9 @@ public:
 
   void tearDown() const;
 
-  NovelImageRect* getImageRect(const std::string_view filePath, const NovelCommonArgs& args);
+  NovelImageRect* getImageRect(const GeoVector<float>& startingSize, 
+                               const std::string_view filePath,
+                               const NovelCommonArgs& args);
   NovelBasicFillRect* getBasicFillRect(const GeoVector<float>& startingSize,
                                        const RGBAConfig& colourConfig,
                                        const NovelCommonArgs& args);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@ static int average(lua_State* L) {
 #endif
 
 NovelRT::NovelBasicFillRect* basicFillRect;
+NovelRT::NovelImageRect* yuri;
 
 int main(int argc, char* argv[]) {
   //setenv("DISPLAY", "localhost:0", true);
@@ -47,7 +48,7 @@ int main(int argc, char* argv[]) {
   yuriArgs.startingPosition.setX(1920 / 2);
   yuriArgs.startingPosition.setY(1080 / 2);
 
-  auto yuri = runner.getRenderer()->getImageRect("test-yuri.png", yuriArgs);
+  yuri = runner.getRenderer()->getImageRect(NovelRT::GeoVector<float>(200, 200), "test-yuri.png", yuriArgs);
 
   auto rectArgs = NovelRT::NovelCommonArgs();
   rectArgs.startingPosition = yuriArgs.startingPosition;
@@ -61,17 +62,18 @@ int main(int argc, char* argv[]) {
   basicFillRect = runner.getRenderer()->getBasicFillRect(NovelRT::GeoVector<float>(200, 200), NovelRT::RGBAConfig(0, 255, 255, 255), rectArgs);
 
   runner.runOnUpdate([](const float delta) {
-	  const float rotationAmount = 45.0f;
+    const float rotationAmount = 45.0f;
 
-	  auto rotation = basicFillRect->getRotation();
-	  rotation += rotationAmount * delta;
+    auto rotation = basicFillRect->getRotation();
+    rotation += rotationAmount * delta;
 
-	  if (rotation > 360.0f)
-	  {
-		  rotation -= 360.0f;
-	  }
+    if (rotation > 360.0f)
+    {
+      rotation -= 360.0f;
+    }
 
-	  basicFillRect->setRotation(rotation);
+    basicFillRect->setRotation(rotation);
+    yuri->setRotation(-rotation);
   });
 
 /*


### PR DESCRIPTION
This allows a world space size to be passed into the NovelImageRect constructor. This ensures it has a size so when rendered it is visible.

It might also be beneficial to expose a way to default to the image size, but I'll leave that to a future PR.