### PR TITLE
[HOTFIX] - Inverted Y axis for RenderObjects.

### DIFF
--- a/src/GeoBounds.cpp
+++ b/src/GeoBounds.cpp
@@ -29,9 +29,9 @@ GeoVector<float> GeoBounds::getCornerInWorldSpace(const int index) const {
 
 GeoVector<float> GeoBounds::getCornerInOpenGLSurfaceSpace(const int index, const float screenScale) const {
   auto point = _corners[index];
-  float pointX = ((point.getX() * screenScale) / ((1920.0f * screenScale) / 2.0f)) - 1.0f;
+  float pointX = ((point.getX()) / ((1920.0f * screenScale) / 2.0f)) - 1.0f;
   point.setX(pointX);
-  float pointY = ((point.getY() * screenScale) / ((1080.0f * screenScale) / 2.0f)) - 1.0f;
+  float pointY = ((point.getY()) / ((1080.0f * screenScale) / 2.0f)) - 1.0f;
   point.setY(pointY);
   return point;
 }

--- a/src/GeoBounds.cpp
+++ b/src/GeoBounds.cpp
@@ -31,7 +31,7 @@ GeoVector<float> GeoBounds::getCornerInOpenGLSurfaceSpace(const int index, const
   auto point = _corners[index];
   float pointX = ((point.getX()) / ((1920.0f * screenScale) / 2.0f)) - 1.0f;
   point.setX(pointX);
-  float pointY = ((point.getY()) / ((1080.0f * screenScale) / 2.0f)) - 1.0f;
+  float pointY = ( ((1080.0f * screenScale) - (point.getY())) / ((1080.0f * screenScale) / 2.0f)) - 1.0f;
   point.setY(pointY);
   return point;
 }

--- a/src/NovelObject.cpp
+++ b/src/NovelObject.cpp
@@ -86,8 +86,8 @@ void NovelObject::setOrderInLayer(const int value) {
 GeoBounds NovelObject::getScreenSpaceObjectBounds() {
   if(_isDirty) {
   _isDirty = false;
-  GeoVector<float> position = getWorldSpacePosition() * _screenScale;
-  GeoVector<float> size = (getWorldSpaceSize() * getScale()) * _screenScale;
+  GeoVector<float> position = getScreenSpacePosition();
+  GeoVector<float> size = getScreenSpaceSize();
   _objectBounds = GeoBounds(position, size, getRotation());
   }
   return _objectBounds;

--- a/src/NovelObject.cpp
+++ b/src/NovelObject.cpp
@@ -86,8 +86,8 @@ void NovelObject::setOrderInLayer(const int value) {
 GeoBounds NovelObject::getScreenSpaceObjectBounds() {
   if(_isDirty) {
   _isDirty = false;
-  GeoVector<float> position = getWorldSpacePosition();
-  GeoVector<float> size = (getWorldSpaceSize() * getScale());
+  GeoVector<float> position = getWorldSpacePosition() * _screenScale;
+  GeoVector<float> size = (getWorldSpaceSize() * getScale()) * _screenScale;
   _objectBounds = GeoBounds(position, size, getRotation());
   }
   return _objectBounds;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,13 +53,14 @@ int main(int argc, char* argv[]) {
   auto rectArgs = NovelRT::NovelCommonArgs();
   rectArgs.startingPosition = novelChanArgs.startingPosition;
   rectArgs.startingPosition.setX(rectArgs.startingPosition.getX() + 400);
+  rectArgs.startingPosition.setY(rectArgs.startingPosition.getY() - 400);
   rectArgs.layer = 0;
   rectArgs.orderInLayer = 1;
   rectArgs.startingRotation = 0.0f;
 
-  //basicFillRect = runner.getRenderer()->getBasicFillRect(NovelRT::GeoVector<float>(200, 200), NovelRT::RGBAConfig(0, 255, 255, 255), rectArgs);
-  auto textRect = runner.getRenderer()->getTextRect(NovelRT::RGBAConfig(0, 255, 0, 255), 70, "Gayathri-Regular.ttf", rectArgs);
-  textRect->setText("RubyGnomer");
+  basicFillRect = runner.getRenderer()->getBasicFillRect(NovelRT::GeoVector<float>(200, 200), NovelRT::RGBAConfig(0, 255, 255, 255), rectArgs);
+/*  auto textRect = runner.getRenderer()->getTextRect(NovelRT::RGBAConfig(0, 255, 0, 255), 70, "Gayathri-Regular.ttf", rectArgs);
+  textRect->setText("RubyGnomer");*/
 
   runner.getDebugService()->setIsFpsCounterVisible(true);
 


### PR DESCRIPTION
This is a quick fix for an issue that cropped up in Discord around a few hours before this PR was created. This should resolve the Y axis being the other way around for rendering-based objects.