### PR TITLE
Various correctness and reliability fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,8 @@ target_compile_options(NovelRT
     -Wdouble-promotion
     -Wshadow
     -Wformat=2
+    -Wno-error=unused-parameter
+    -Wno-error=unused-variable
 )
 
 add_library(NovelRTLib SHARED ${NOVELRT_LIBRARY_HEADERS} ${NOVELRT_LIBRARY_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.13)
-set(CMAKE_TOOLCHAIN_FILE /home/jarl/Programming/source-projects/vcpkg/scripts/buildsystems/vcpkg.cmake)
 
 project(NovelRT VERSION 0.0.1)
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,22 @@ set(NOVELRT_LIBRARY_LINK_LIBRARIES
   ${NOVELRT_LINK_LIBRARIES}
 )
 
+target_compile_options(NovelRT
+  PRIVATE
+    -Werror
+    -Wall
+    -Wextra
+    -Wduplicated-cond
+    -Wduplicated-branches
+    -Wlogical-op
+    -Wrestrict
+    -Wnull-dereference
+    -Wuseless-cast
+    -Wdouble-promotion
+    -Wshadow
+    -Wformat=2
+)
+
 add_library(NovelRTLib SHARED ${NOVELRT_LIBRARY_HEADERS} ${NOVELRT_LIBRARY_SOURCES})
 target_link_libraries(NovelRTLib ${NOVELRT_LIBRARY_LINK_LIBRARIES})
 set_target_properties(NovelRTLib PROPERTIES PUBLIC_HEADER include/NovelRTLib_C.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,66 @@ target_compile_options(NovelRT
     -Wno-error=unused-variable
 )
 
+set(SANITIZE_CODE ON)
+
+# Enable various sanitizer extensions
+if(${SANITIZE_CODE})
+  message("Enabling code sanitizer extensions.")
+
+  target_compile_options(NovelRT
+    PRIVATE
+      -fsanitize=undefined
+      -fsanitize=address
+      -fsanitize=shift
+      -fsanitize=shift-exponent
+      -fsanitize=shift-base
+      -fsanitize=integer-divide-by-zero
+      -fsanitize=unreachable
+      -fsanitize=vla-bound
+      -fsanitize=null
+      -fsanitize=return
+      -fsanitize=signed-integer-overflow
+      -fsanitize=bounds
+      -fsanitize=bounds-strict
+      -fsanitize=alignment
+      -fsanitize=object-size
+      -fsanitize=float-divide-by-zero
+      -fsanitize=float-cast-overflow
+      -fsanitize=nonnull-attribute
+      -fsanitize=returns-nonnull-attribute
+      -fsanitize=bool
+      -fsanitize=enum
+      -fsanitize=vptr
+          -fno-sanitize-recover
+  )
+
+  target_link_options(NovelRT
+    PRIVATE
+      -fsanitize=undefined
+      -fsanitize=address
+      -fsanitize=shift
+      -fsanitize=shift-exponent
+      -fsanitize=shift-base
+      -fsanitize=integer-divide-by-zero
+      -fsanitize=unreachable
+      -fsanitize=vla-bound
+      -fsanitize=null
+      -fsanitize=return
+      -fsanitize=signed-integer-overflow
+      -fsanitize=bounds
+      -fsanitize=bounds-strict
+      -fsanitize=alignment
+      -fsanitize=object-size
+      -fsanitize=float-divide-by-zero
+      -fsanitize=float-cast-overflow
+      -fsanitize=nonnull-attribute
+      -fsanitize=returns-nonnull-attribute
+      -fsanitize=bool
+      -fsanitize=enum
+      -fsanitize=vptr
+  )
+endif()
+
 add_library(NovelRTLib SHARED ${NOVELRT_LIBRARY_HEADERS} ${NOVELRT_LIBRARY_SOURCES})
 target_link_libraries(NovelRTLib ${NOVELRT_LIBRARY_LINK_LIBRARIES})
 set_target_properties(NovelRTLib PROPERTIES PUBLIC_HEADER include/NovelRTLib_C.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
+set(CMAKE_TOOLCHAIN_FILE /home/jarl/Programming/source-projects/vcpkg/scripts/buildsystems/vcpkg.cmake)
+
 project(NovelRT VERSION 0.0.1)
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,59 +151,33 @@ set(NOVELRT_LIBRARY_LINK_LIBRARIES
   ${NOVELRT_LINK_LIBRARIES}
 )
 
-target_compile_options(NovelRT
-  PRIVATE
-    -Werror
-    -Wall
-    -Wextra
-    -Wduplicated-cond
-    -Wduplicated-branches
-    -Wlogical-op
-    -Wrestrict
-    -Wnull-dereference
-    -Wuseless-cast
-    -Wdouble-promotion
-    -Wshadow
-    -Wformat=2
-    -Wno-error=unused-parameter
-    -Wno-error=unused-variable
-)
-
-set(SANITIZE_CODE ON)
-
-# Enable various sanitizer extensions
-if(${SANITIZE_CODE})
-  message("Enabling code sanitizer extensions.")
-
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   target_compile_options(NovelRT
     PRIVATE
-      -fsanitize=undefined
-      -fsanitize=address
-      -fsanitize=shift
-      -fsanitize=shift-exponent
-      -fsanitize=shift-base
-      -fsanitize=integer-divide-by-zero
-      -fsanitize=unreachable
-      -fsanitize=vla-bound
-      -fsanitize=null
-      -fsanitize=return
-      -fsanitize=signed-integer-overflow
-      -fsanitize=bounds
-      -fsanitize=bounds-strict
-      -fsanitize=alignment
-      -fsanitize=object-size
-      -fsanitize=float-divide-by-zero
-      -fsanitize=float-cast-overflow
-      -fsanitize=nonnull-attribute
-      -fsanitize=returns-nonnull-attribute
-      -fsanitize=bool
-      -fsanitize=enum
-      -fsanitize=vptr
-          -fno-sanitize-recover
+      -Werror
+      -Wall
+      -Wextra
+      -Wduplicated-cond
+      -Wduplicated-branches
+      -Wlogical-op
+      -Wrestrict
+      -Wnull-dereference
+      -Wuseless-cast
+      -Wdouble-promotion
+      -Wshadow
+      -Wformat=2
+      -Wno-error=unused-parameter
+      -Wno-error=unused-variable
   )
 
-  target_link_options(NovelRT
-    PRIVATE
+  set(SANITIZE_CODE ON)
+
+  # Enable various sanitizer extensions
+  if (${SANITIZE_CODE})
+    message("Enabling code sanitizer extensions.")
+
+    target_compile_options(NovelRT
+      PRIVATE
       -fsanitize=undefined
       -fsanitize=address
       -fsanitize=shift
@@ -226,8 +200,36 @@ if(${SANITIZE_CODE})
       -fsanitize=bool
       -fsanitize=enum
       -fsanitize=vptr
-  )
-endif()
+      -fno-sanitize-recover
+    )
+
+    target_link_options(NovelRT
+      PRIVATE
+        -fsanitize=undefined
+        -fsanitize=address
+        -fsanitize=shift
+        -fsanitize=shift-exponent
+        -fsanitize=shift-base
+        -fsanitize=integer-divide-by-zero
+        -fsanitize=unreachable
+        -fsanitize=vla-bound
+        -fsanitize=null
+        -fsanitize=return
+        -fsanitize=signed-integer-overflow
+        -fsanitize=bounds
+        -fsanitize=bounds-strict
+        -fsanitize=alignment
+        -fsanitize=object-size
+        -fsanitize=float-divide-by-zero
+        -fsanitize=float-cast-overflow
+        -fsanitize=nonnull-attribute
+        -fsanitize=returns-nonnull-attribute
+        -fsanitize=bool
+        -fsanitize=enum
+        -fsanitize=vptr
+    )
+  endif ()
+endif ()
 
 add_library(NovelRTLib SHARED ${NOVELRT_LIBRARY_HEADERS} ${NOVELRT_LIBRARY_SOURCES})
 target_link_libraries(NovelRTLib ${NOVELRT_LIBRARY_LINK_LIBRARIES})

--- a/src/NovelImageRect.cpp
+++ b/src/NovelImageRect.cpp
@@ -20,14 +20,15 @@ NovelImageRect::NovelImageRect(NovelLayeringService* layeringService,
                                                                                  size,
                                                                                  args,
                                                                                  programId),
-                                                               _imageDir(imageDir), _colourTint(colourTint),
-                                                               _uvBuffer(Lazy<GLuint>(generateStandardBuffer)),
-                                                               _colourTintBuffer(Lazy<GLuint>(generateStandardBuffer)),
+                                                               _imageDir(imageDir),
                                                                _textureId(Lazy<GLuint>([] {
                                                                  GLuint tempTexture;
                                                                  glGenTextures(1, &tempTexture);
                                                                  return tempTexture;
-                                                               })){
+                                                               })),
+                                                               _uvBuffer(Lazy<GLuint>(generateStandardBuffer)),
+                                                               _colourTintBuffer(Lazy<GLuint>(generateStandardBuffer)),
+                                                               _colourTint(colourTint){
 
 }
 

--- a/src/NovelInteractionService.cpp
+++ b/src/NovelInteractionService.cpp
@@ -6,7 +6,7 @@
 
 namespace NovelRT {
 NovelInteractionService::NovelInteractionService(NovelLayeringService* layeringService, const float screenScale)
-    : _layeringService(layeringService), _screenScale(screenScale), _clickTarget(nullptr) {
+    : _clickTarget(nullptr), _layeringService(layeringService), _screenScale(screenScale) {
   _mousePositionsOnScreenPerButton.insert({LeftMouseButton, GeoVector<float>(0, 0)});
   _keyStates.insert({LeftMouseButton, false});
 }

--- a/src/NovelObject.cpp
+++ b/src/NovelObject.cpp
@@ -20,6 +20,8 @@ NovelObject::NovelObject(NovelLayeringService* layeringService, const float& scr
   setActive(true);
 }
 
+NovelObject::~NovelObject() = default;
+
 GeoVector<float> NovelObject::getWorldSpacePosition() const {
   return _position;
 }

--- a/src/NovelObject.h
+++ b/src/NovelObject.h
@@ -16,6 +16,8 @@ public:
   NovelObject(NovelLayeringService* layeringService, const float& screenScale, const GeoVector<float>& size,
               const NovelCommonArgs& args);
 
+  virtual ~NovelObject();
+
   virtual GeoVector<float> getWorldSpacePosition() const;
 
   virtual void setWorldSpacePosition(const GeoVector<float>& value);

--- a/src/NovelObjectSortComparison.h
+++ b/src/NovelObjectSortComparison.h
@@ -9,7 +9,7 @@
 namespace NovelRT {
 struct NovelObjectSortComparison {
 public:
-  inline bool const operator()(NovelObject* lhs, NovelObject* rhs) const {
+  inline bool operator()(NovelObject* lhs, NovelObject* rhs) const {
     return lhs->getOrderInLayer() < rhs->getOrderInLayer();
   }
 };

--- a/src/NovelRenderObject.cpp
+++ b/src/NovelRenderObject.cpp
@@ -12,13 +12,13 @@ NovelRenderObject::NovelRenderObject(NovelLayeringService* layeringService,
                                      const GeoVector<float>& size,
                                      const NovelCommonArgs& args,
                                      const GLuint programId) : NovelObject(layeringService, screenScale, size, args),
-                                                               _programId(programId),
+                                                               _buffer(Lazy<GLuint>(generateStandardBuffer)),
                                                                _vertexArrayObject(Lazy<GLuint>([] {
                                                                  GLuint tempVao;
                                                                  glGenVertexArrays(1, &tempVao);
                                                                  return tempVao;
                                                                })),
-                                                               _buffer(Lazy<GLuint>(generateStandardBuffer)) {
+                                                               _programId(programId){
 }
 
 void NovelRenderObject::executeObjectBehaviour() {

--- a/src/NovelRenderingService.cpp
+++ b/src/NovelRenderingService.cpp
@@ -18,6 +18,24 @@
 #include <fstream>
 #include <sstream>
 
+void GLAPIENTRY
+MessageCallback( GLenum source,
+                 GLenum type,
+                 GLuint id,
+                 GLenum severity,
+                 GLsizei length,
+                 const GLchar* message,
+                 const void* userParam )
+{
+    if (severity < GL_DEBUG_SEVERITY_HIGH) {
+        return;
+    }
+
+    fprintf( stderr, "GL CALLBACK: %s type = 0x%x, severity = 0x%x, message = %s\n",
+             ( type == GL_DEBUG_TYPE_ERROR ? "** GL ERROR **" : "" ),
+             type, severity, message );
+}
+
 namespace NovelRT {
 bool NovelRenderingService::initializeRenderPipeline(const int displayNumber) {
 
@@ -52,12 +70,14 @@ bool NovelRenderingService::initializeRenderPipeline(const int displayNumber) {
   }
   _openGLContext = SDL_GL_CreateContext(_window.get());
   SDL_GL_MakeCurrent(_window.get(), _openGLContext);
-  SDL_GL_SetSwapInterval(0);
 
   if (!gladLoadGL()) {
     std::cerr << "ERROR: Failed to initialise glad." << std::endl;
     return -1;
   }
+    // During init, enable debug output
+    glEnable              ( GL_DEBUG_OUTPUT );
+    glDebugMessageCallback( MessageCallback, 0 );
 
   std::cout << "GL_VERSION : " << glGetString(GL_VERSION) << std::endl;
   std::cout << "GL_SHADING_LANGUAGE_VERSION: " << glGetString(GL_SHADING_LANGUAGE_VERSION) << std::endl;

--- a/src/NovelRenderingService.cpp
+++ b/src/NovelRenderingService.cpp
@@ -18,24 +18,6 @@
 #include <fstream>
 #include <sstream>
 
-void GLAPIENTRY
-MessageCallback( GLenum source,
-                 GLenum type,
-                 GLuint id,
-                 GLenum severity,
-                 GLsizei length,
-                 const GLchar* message,
-                 const void* userParam )
-{
-    if (severity < GL_DEBUG_SEVERITY_HIGH) {
-        return;
-    }
-
-    fprintf( stderr, "GL CALLBACK: %s type = 0x%x, severity = 0x%x, message = %s\n",
-             ( type == GL_DEBUG_TYPE_ERROR ? "** GL ERROR **" : "" ),
-             type, severity, message );
-}
-
 namespace NovelRT {
 bool NovelRenderingService::initializeRenderPipeline(const int displayNumber) {
 
@@ -75,9 +57,6 @@ bool NovelRenderingService::initializeRenderPipeline(const int displayNumber) {
     std::cerr << "ERROR: Failed to initialise glad." << std::endl;
     return -1;
   }
-    // During init, enable debug output
-    glEnable              ( GL_DEBUG_OUTPUT );
-    glDebugMessageCallback( MessageCallback, 0 );
 
   std::cout << "GL_VERSION : " << glGetString(GL_VERSION) << std::endl;
   std::cout << "GL_SHADING_LANGUAGE_VERSION: " << glGetString(GL_SHADING_LANGUAGE_VERSION) << std::endl;

--- a/src/NovelRunner.cpp
+++ b/src/NovelRunner.cpp
@@ -8,7 +8,7 @@
 
 namespace NovelRT {
   NovelRunner::NovelRunner(int displayNumber, NovelLayeringService* layeringService, uint32_t targetFrameRate)
-    : _layeringService(layeringService), _novelRenderer(std::make_unique<NovelRenderingService>(_layeringService)), _novelDebugService(std::make_unique<NovelDebugService>(this)), _stepTimer(StepTimer(targetFrameRate)) {
+    :  _stepTimer(StepTimer(targetFrameRate)), _layeringService(layeringService), _novelDebugService(std::make_unique<NovelDebugService>(this)), _novelRenderer(std::make_unique<NovelRenderingService>(_layeringService)) {
   _novelRenderer->initialiseRendering(displayNumber);
   _novelInteractionService = std::make_unique<NovelInteractionService>(_layeringService, _novelRenderer->getScreenScale());
   _novelInteractionService->subscribeToQuit([this]{_exitCode = 0;});

--- a/src/NovelStepTimer.cpp
+++ b/src/NovelStepTimer.cpp
@@ -58,12 +58,12 @@ namespace NovelRT {
       // the clock to exactly match the target value. This prevents tiny and irrelevant errors
       // from accumulating over time. Without this clamping, a game that requested a 60 fps
       // fixed update, running with vsync enabled on a 59.94 NTSC display, would eventually
-      // accumulate enough tiny errors that it would drop a frame. It is better to just round 
+      // accumulate enough tiny errors that it would drop a frame. It is better to just round
       // small deviations down to zero to leave things running smoothly.
 
       auto targetElapsedTicks = _targetElapsedTicks;
 
-      if (abs((int64_t)(ticksDelta - targetElapsedTicks)) < (TicksPerSecond / 4000)) {
+      if (abs((int64_t)(ticksDelta - targetElapsedTicks)) < (long)(TicksPerSecond / 4000)) {
         ticksDelta = targetElapsedTicks;
       }
 

--- a/src/NovelStepTimer.cpp
+++ b/src/NovelStepTimer.cpp
@@ -63,7 +63,7 @@ namespace NovelRT {
 
       auto targetElapsedTicks = _targetElapsedTicks;
 
-      if (abs((int64_t)(ticksDelta - targetElapsedTicks)) < (long)(TicksPerSecond / 4000)) {
+      if (abs((int64_t)(ticksDelta - targetElapsedTicks)) < (int64_t)(TicksPerSecond / 4000)) {
         ticksDelta = targetElapsedTicks;
       }
 

--- a/src/NovelTextRect.cpp
+++ b/src/NovelTextRect.cpp
@@ -142,7 +142,7 @@ void NovelTextRect::reloadText() {
     ttfOrigin.setX(ttfOrigin.getX() + (ch.advance >> 6));
   }
 
-  if (_letterRects.size() == i + 1)
+  if (_letterRects.size() == (uint)i + 1)
     return;
 
   auto beginIt = _letterRects.begin() + i;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,6 @@
 #include "NovelImageRect.h"
 #include "NovelCommonArgs.h"
 #include "NovelLayeringService.h"
-#include "NovelInteractionService.h"
 
 extern "C" {
 #include <lua.h>
@@ -14,14 +13,14 @@ extern "C" {
 
 lua_State* L;
 
-static int average(lua_State* L) {
-  int n = lua_gettop(L);
+static int average(lua_State* luaState) {
+  int n = lua_gettop(luaState);
   double sum = 0;
   for (int i = 1; i <= n; i++) {
-    sum += lua_tonumber(L, i);
+    sum += lua_tonumber(luaState, i);
   }
-  lua_pushnumber(L, sum / n);
-  lua_pushnumber(L, sum);
+  lua_pushnumber(luaState, sum / n);
+  lua_pushnumber(luaState, sum);
   return 2;
 }
 


### PR DESCRIPTION
RE: Our discussion on Discord earlier, I've enabled a variety of useful GCC options and fixed a number of issues raised by the enabled inspections. Among these are some signed-to-unsigned comparisons (which can produce unexpected results), some undefined behaviour (calling nonvirtual destructors on abstract classes), and some initialization ordering issues.