### PR TITLE
Adding some build scripts to the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@
 *.out
 *.app
 
+### Visual Studio ###
+.vs/
+.vscode/
+
 ### CLion ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
@@ -74,6 +78,8 @@
 # .idea/modules
 
 # CMake
+artifacts/
+build/
 cmake-build-*/
 
 # Mongo Explorer plugin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,9 +231,3 @@ endif ()
 
 add_library(NovelRTLib SHARED ${NOVELRT_LIBRARY_HEADERS} ${NOVELRT_LIBRARY_SOURCES})
 target_link_libraries(NovelRTLib ${NOVELRT_LIBRARY_LINK_LIBRARIES})
-set_target_properties(NovelRTLib PROPERTIES PUBLIC_HEADER include/NovelRTLib_C.h)
-
-install(TARGETS NovelRTLib
-        LIBRARY DESTINATION /lib/${PROJECT_NAME}
-        PUBLIC_HEADER DESTINATION /usr/include/${PROJECT_NAME})
-

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy ByPass -Command "& """%~dp0scripts\build.ps1""" -build %*"
+EXIT /B %ERRORLEVEL%

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$ScriptRoot/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+. "$ScriptRoot/scripts/build.sh" --build "$@"

--- a/generate.cmd
+++ b/generate.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy ByPass -Command "& """%~dp0scripts\build.ps1""" -generate %*"
+EXIT /B %ERRORLEVEL%

--- a/generate.sh
+++ b/generate.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$ScriptRoot/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+. "$ScriptRoot/scripts/build.sh" --generate "$@"

--- a/install.cmd
+++ b/install.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy ByPass -Command "& """%~dp0scripts\build.ps1""" -install %*"
+EXIT /B %ERRORLEVEL%

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$ScriptRoot/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+. "$ScriptRoot/scripts/build.sh" --install "$@"

--- a/scripts/azure-ci.yml
+++ b/scripts/azure-ci.yml
@@ -1,0 +1,5 @@
+trigger:
+- master
+
+jobs:
+- template: azure-pipelines.yml

--- a/scripts/azure-pipelines.yml
+++ b/scripts/azure-pipelines.yml
@@ -1,0 +1,24 @@
+jobs:
+- template: azure-windows.yml
+  parameters:
+    name: windows_debug_x64
+    pool: Hosted
+    configuration: Debug
+
+- template: azure-windows.yml
+  parameters:
+    name: windows_release_x64
+    pool: Hosted
+    configuration: Release
+
+- template: azure-unix.yml
+  parameters:
+    name: ubuntu_debug_x64
+    pool: Hosted Ubuntu 1604
+    configuration: Debug
+
+- template: azure-unix.yml
+  parameters:
+    name: ubuntu_release_x64
+    pool: Hosted Ubuntu 1604
+    configuration: Release

--- a/scripts/azure-pr.yml
+++ b/scripts/azure-pr.yml
@@ -1,0 +1,5 @@
+pr:
+- master
+
+jobs:
+- template: azure-pipelines.yml

--- a/scripts/azure-unix.yml
+++ b/scripts/azure-unix.yml
@@ -1,0 +1,11 @@
+jobs:
+- job: ${{parameters.name}}
+  pool:
+    name: ${{parameters.pool}}
+  steps:
+  - task: Bash@3
+    displayName: 'Run scripts/cibuild.sh'
+    inputs:
+      targetType: filePath
+      filePath: ./scripts/cibuild.sh
+      arguments: '--configuration ${{parameters.configuration}}'

--- a/scripts/azure-windows.yml
+++ b/scripts/azure-windows.yml
@@ -1,0 +1,11 @@
+jobs:
+- job: ${{parameters.name}}
+  pool:
+    name: ${{parameters.pool}}
+    demands: Cmd
+  steps:
+  - task: BatchScript@1
+    displayName: 'Run scripts/cibuild.cmd'
+    inputs:
+      filename: scripts/cibuild.cmd
+      arguments: '-configuration ${{parameters.configuration}}'

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -29,8 +29,8 @@ function Create-Directory([string[]] $Path) {
 
 function Generate() {
   if ($ci) {
-    $vcpkgToolchainFile = Join-Path -Path $VcpkgInstallDir -ChildPath "scripts/buildsystems/vcpkg.cmake"
-    $remaining = ,"-DCMAKE_TOOLCHAIN_FILE=$vcpkgToolchainFile" + $remaining
+    $VcpkgToolchainFile = Join-Path -Path $VcpkgInstallDir -ChildPath "scripts/buildsystems/vcpkg.cmake"
+    $remaining = ,"-DCMAKE_TOOLCHAIN_FILE=$VcpkgToolchainFile" + $remaining
   }
 
   & cmake -S $RepoRoot -B $BuildDir -Wdev -Werror=dev -Wdeprecated -Werror=deprecated -A x64 -DCMAKE_INSTALL_PREFIX=$InstallDir $remaining
@@ -95,13 +95,17 @@ try {
       & git clone https://github.com/microsoft/vcpkg $VcpkgInstallDir
     }
 
-    & $VcpkgInstallDir/bootstrap-vcpkg.bat
+    $VcpkgExe = Join-Path -Path $VcpkgInstallDir -ChildPath "vcpkg.exe"
 
-    if ($LastExitCode -ne 0) {
-      throw "'bootstrap-vcpkg' failed"
+    if (!(Test-Path -Path $VcpkgExe)) {
+      & $VcpkgInstallDir/bootstrap-vcpkg.bat
+
+      if ($LastExitCode -ne 0) {
+        throw "'bootstrap-vcpkg' failed"
+      }
     }
 
-    & $VcpkgInstallDir/vcpkg.exe install freetype glad glm lua sdl2 sdl2-image --triplet x64-windows
+    & $VcpkgExe install freetype glad glm lua sdl2 sdl2-image --triplet x64-windows
 
     if ($LastExitCode -ne 0) {
         throw "'vcpkg install' failed"

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,108 @@
+[CmdletBinding(PositionalBinding=$false)]
+Param(
+  [switch] $build,
+  [switch] $ci,
+  [ValidateSet("Debug", "Release", "RelWithDebInfo", "MinSizeRel")][string] $configuration = "Debug",
+  [switch] $generate,
+  [switch] $help,
+  [switch] $install,
+  [Parameter(ValueFromRemainingArguments=$true)][String[]]$remaining
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+function Build() {
+  & cmake --build $BuildDir
+
+  if ($LastExitCode -ne 0) {
+    throw "'Build' failed"
+  }
+}
+
+function Create-Directory([string[]] $Path) {
+  if (!(Test-Path -Path $Path)) {
+    New-Item -Path $Path -Force -ItemType "Directory" | Out-Null
+  }
+}
+
+function Generate() {
+  & cmake -S $RepoRoot -B $BuildDir -Wdev -Werror=dev -Wdeprecated -Werror=deprecated -DCMAKE_INSTALL_PREFIX=$InstallDir $remaining
+
+  if ($LastExitCode -ne 0) {
+    throw "'Generate' failed"
+  }
+}
+
+function Help() {
+    Write-Host -Object "Common settings:"
+    Write-Host -Object "  -configuration <value>  Build configuration (Debug, Release, RelWithDebInfo, MinSizeRel)"
+    Write-Host -Object "  -help                   Print help and exit"
+    Write-Host -Object ""
+    Write-Host -Object "Actions:"
+    Write-Host -Object "  -build                  Build repository"
+    Write-Host -Object "  -generate               Generate CMake cache"
+    Write-Host -Object "  -install                Install repository"
+    Write-Host -Object ""
+    Write-Host -Object "Advanced settings:"
+    Write-Host -Object "  -ci                     Set when running on CI server"
+    Write-Host -Object ""
+    Write-Host -Object "Command line arguments not listed above are passed through to CMake."
+    Write-Host -Object "The above arguments can be shortened as much as to be unambiguous (e.g. -co for configuration, -t for test, etc.)."
+}
+
+function Install() {
+  & cmake --install $BuildDir
+
+  if ($LastExitCode -ne 0) {
+    throw "'Install' failed"
+  }
+}
+
+try {
+  if ($help) {
+    Help
+    exit 0
+  }
+
+  if ($ci) {
+    $build = $true
+    $generate = $true
+    $install = $true
+  }
+
+  $RepoRoot = Join-Path -Path $PSScriptRoot -ChildPath ".."
+
+  $ArtifactsDir = Join-Path -Path $RepoRoot -ChildPath "artifacts"
+  Create-Directory -Path $ArtifactsDir
+
+  $BuildDir = Join-Path -Path $ArtifactsDir -ChildPath "build"
+  $BuildDir = Join-Path -Path $BuildDir -ChildPath $Configuration
+  Create-Directory -Path $BuildDir
+
+  $InstallDir = Join-Path -Path $ArtifactsDir -ChildPath "install"
+  $InstallDir = Join-Path -Path $InstallDir -ChildPath $Configuration
+  Create-Directory -Path $InstallDir
+
+  if ($ci) {
+  }
+
+  if ($generate) {
+    Generate
+  }
+
+  if ($build) {
+    Build
+  }
+
+  if ($install) {
+    Install
+  }
+}
+catch {
+  Write-Host -Object $_
+  Write-Host -Object $_.Exception
+  Write-Host -Object $_.ScriptStackTrace
+  exit 1
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -154,7 +154,7 @@ CreateDirectory "$InstallDir"
 if $ci; then
   VcpkgInstallDir="$ArtifactsDir/vcpkg"
 
-  if [ ! -d "$1" ]; then
+  if [ ! -d "$VcpkgInstallDir" ]; then
      git clone https://github.com/microsoft/vcpkg "$VcpkgInstallDir"
   fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$ScriptRoot/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+build=false
+ci=false
+configuration='Debug'
+generate=false
+help=false
+install=false
+remaining=''
+
+while [[ $# -gt 0 ]]; do
+  lower="$(echo "$1" | awk '{print tolower($0)}')"
+  case $lower in
+    --build)
+      build=true
+      shift 1
+      ;;
+    --ci)
+      ci=true
+      shift 1
+      ;;
+    --configuration)
+      configuration=$2
+      shift 2
+      ;;
+    --generate)
+      generate=true
+      shift 1
+      ;;
+    --help)
+      help=true
+      shift 1
+      ;;
+    --install)
+      install=true
+      shift 1
+      ;;
+    *)
+      if [ -z "$remaining" ]; then
+        remaining="$1"
+      else
+        remaining="$remaining $1"
+      fi
+      shift 1
+      ;;
+  esac
+done
+
+function Build {
+  if [[ -z "$remaining" ]]; then
+    cmake --build "$BuildDir"
+  else
+    cmake --build "$BuildDir" "${remaining[@]}"
+  fi
+
+  LASTEXITCODE=$?
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    echo "'Build' failed"
+    return "$LASTEXITCODE"
+  fi
+}
+
+function CreateDirectory {
+  if [ ! -d "$1" ]; then
+    mkdir -p "$1"
+  fi
+}
+
+function Generate {
+  if [[ -z "$remaining" ]]; then
+    cmake -S "$RepoRoot" -B "$BuildDir" -Wdev -Werror=dev -Wdeprecated -Werror=deprecated -DCMAKE_INSTALL_PREFIX="$InstallDir"
+  else
+    cmake -S "$RepoRoot" -B "$BuildDir" -Wdev -Werror=dev -Wdeprecated -Werror=deprecated -DCMAKE_INSTALL_PREFIX="$InstallDir" "${remaining[@]}"
+  fi
+
+  LASTEXITCODE=$?
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    echo "'Generate' failed"
+    return "$LASTEXITCODE"
+  fi
+}
+
+function Help {
+  echo "Common settings:"
+  echo "  --configuration <value>   Build configuration (Debug, Release, RelWithDebInfo, MinSizeRel)"
+  echo "  --help                    Print help and exit"
+  echo ""
+  echo "Actions:"
+  echo "  --build                   Build repository"
+  echo "  --generate                Generate CMake cache"
+  echo "  --install                 Install repository"
+  echo ""
+  echo "Advanced settings:"
+  echo "  --ci                      Set when running on CI server"
+  echo ""
+  echo "Command line arguments not listed above are passed through to CMake."
+}
+
+function Install {
+  if [[ -z "$remaining" ]]; then
+    sudo cmake --install "$BuildDir"
+  else
+    sudo cmake --install "$BuildDir" "${remaining[@]}"
+  fi
+
+  LASTEXITCODE=$?
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    echo "'Install' failed"
+    return "$LASTEXITCODE"
+  fi
+}
+
+if $help; then
+  Help
+  exit 0
+fi
+
+if $ci; then
+  build=true
+  generate=true
+  install=true
+fi
+
+RepoRoot="$ScriptRoot/.."
+
+ArtifactsDir="$RepoRoot/artifacts"
+CreateDirectory "$ArtifactsDir"
+
+BuildDir="$ArtifactsDir/build/$configuration"
+CreateDirectory "$BuildDir"
+
+InstallDir="$ArtifactsDir/install/$configuration"
+CreateDirectory "$InstallDir"
+
+if $ci; then
+  echo "ci nyi"
+fi
+
+if $generate; then
+  Generate
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    return "$LASTEXITCODE"
+  fi
+fi
+
+if $build; then
+  Build
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    return "$LASTEXITCODE"
+  fi
+fi
+
+if $install; then
+  Install
+
+  if [ "$LASTEXITCODE" != 0 ]; then
+    return "$LASTEXITCODE"
+  fi
+fi

--- a/scripts/cibuild.cmd
+++ b/scripts/cibuild.cmd
@@ -1,0 +1,3 @@
+@ECHO OFF
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy ByPass -Command "& """%~dp0build.ps1""" -ci %*"
+EXIT /B %ERRORLEVEL%

--- a/scripts/cibuild.sh
+++ b/scripts/cibuild.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$ScriptRoot/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+ScriptRoot="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+. "$ScriptRoot/build.sh" --ci "$@"


### PR DESCRIPTION
This adds some basic build scripts to the repository.

The current requirements are that a user first:
1) Install the C++ Toolset
2) Install Vcpkg
3) Use Vcpkg to install `freetype glad glm lua sdl2 sdl2-image`

After that, they need to run:
4) `./generate.sh -DCMAKE_TOOLCHAIN_FILE=$VcpkgDir/scripts/buildsystems/vcpkg.cmake`
5) `./build.sh`

This should produce the necessary build files, etc.

Users can also optionally run just `./build.sh --ci` (or `./scripts/cibuild.sh`) which will automatically do steps 2 thru 5 (inclusive).