### PR TITLE
[WIP] Add support for rendering frame diagnostics.

### DIFF
--- a/include/NovelRT.h
+++ b/include/NovelRT.h
@@ -98,6 +98,7 @@ namespace NovelRT::Windowing {
 }
 
 //enums
+#include "NovelRT/Debug/MetricsLevel.h"
 #include "NovelRT/Input/KeyCode.h"
 #include "NovelRT/Input/KeyState.h"
 #include "NovelRT/Graphics/CameraFrameState.h"

--- a/include/NovelRT.h
+++ b/include/NovelRT.h
@@ -59,7 +59,6 @@
 
 namespace NovelRT {
   typedef void (*NovelUpdateSubscriber)(double deltaSeconds);
-  typedef class DebugService DebugService;
   typedef class LoggingService LoggingService;
   typedef class NovelRunner NovelRunner;
 }
@@ -68,6 +67,10 @@ namespace NovelRT::Audio {
   typedef std::vector<ALuint> SoundBank;
   typedef std::vector<ALuint> MusicBank;
   typedef class AudioService AudioService;
+}
+
+namespace NovelRT::Debug {
+  typedef class DebugService DebugService;
 }
 
 namespace NovelRT::DotNet {
@@ -135,7 +138,7 @@ namespace NovelRT::Windowing {
 
 //Engine service types
 #include "NovelRT/Audio/AudioService.h"
-#include "NovelRT/DebugService.h"
+#include "NovelRT/Debug/DebugService.h"
 #include "NovelRT/DotNet/RuntimeService.h"
 #include "NovelRT/Input/InteractionService.h"
 #include "NovelRT/Windowing/WindowingService.h"

--- a/include/NovelRT/Debug/DebugService.h
+++ b/include/NovelRT/Debug/DebugService.h
@@ -24,6 +24,8 @@ namespace NovelRT::Debug {
   public:
     DebugService(NovelRunner* const runner);
 
+    void recordMetrics();
+
     bool getIsFpsCounterVisible() const;
     void setIsFpsCounterVisible(bool value);
 

--- a/include/NovelRT/Debug/DebugService.h
+++ b/include/NovelRT/Debug/DebugService.h
@@ -1,13 +1,13 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
 
-#ifndef NOVELRT_NOVELDEBUGSERVICE_H
-#define NOVELRT_NOVELDEBUGSERVICE_H
+#ifndef NOVELRT_DEBUG_NOVELDEBUGSERVICE_H
+#define NOVELRT_DEBUG_NOVELDEBUGSERVICE_H
 
 #ifndef NOVELRT_H
 #error Please do not include this directly. Use the centralised header (NovelRT.h) instead!
 #endif
 
-namespace NovelRT {
+namespace NovelRT::Debug {
 
   class DebugService {
 
@@ -15,6 +15,7 @@ namespace NovelRT {
     NovelRunner* const _runner;
     std::unique_ptr<Graphics::TextRect> _fpsCounter;
     uint32_t _framesPerSecond;
+    MetricsLevel _metricsLevel;
 
     void updateFpsCounter();
 
@@ -26,6 +27,9 @@ namespace NovelRT {
     bool getIsFpsCounterVisible() const;
     void setIsFpsCounterVisible(bool value);
 
+    MetricsLevel getMetricsLevel() const;
+    void setMetricsLevel(const MetricsLevel& value);
+
     inline uint32_t getFramesPerSecond() const {
       return _framesPerSecond;
     }
@@ -33,4 +37,4 @@ namespace NovelRT {
   };
 }
 
-#endif // NOVELRT_NOVELDEBUGSERVICE_H
+#endif // NOVELRT_DEBUG_NOVELDEBUGSERVICE_H

--- a/include/NovelRT/Debug/MetricsLevel.h
+++ b/include/NovelRT/Debug/MetricsLevel.h
@@ -1,0 +1,20 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
+
+#ifndef NOVELRT_DEBUG_METRICSLEVEL_H
+#define NOVELRT_DEBUG_METRICSLEVEL_H
+
+#ifndef NOVELRT_H
+#error Please do not include this directly. Use the centralised header (NovelRT.h) instead!
+#endif
+
+namespace NovelRT::Debug {
+  enum class MetricsLevel : int32_t
+  {
+    None = 0,
+    FramesPerSecond = 1,
+    HardwareUsage = 2,
+    RenderingStatistics = 3,
+  };
+}
+
+#endif //NOVELRT_DEBUG_METRICSLEVEL_H

--- a/include/NovelRT/NovelRunner.h
+++ b/include/NovelRT/NovelRunner.h
@@ -65,6 +65,7 @@ namespace NovelRT {
     Audio::AudioService* getAudioService() const;
     DotNet::RuntimeService* getDotNetRuntimeService() const;
     Windowing::WindowingService* getWindowingService() const;
+    Timing::StepTimer* getStepTimer();
 
     ~NovelRunner();
   };

--- a/include/NovelRT/NovelRunner.h
+++ b/include/NovelRT/NovelRunner.h
@@ -19,7 +19,7 @@ namespace NovelRT {
     int _exitCode;
     Utilities::Lazy<std::unique_ptr<Timing::StepTimer>> _stepTimer;
     std::vector<NovelUpdateSubscriber> _updateSubscribers;
-    std::unique_ptr<DebugService> _novelDebugService;
+    std::unique_ptr<Debug::DebugService> _novelDebugService;
     std::unique_ptr<Input::InteractionService> _novelInteractionService;
     std::unique_ptr<Audio::AudioService> _novelAudioService;
     std::unique_ptr<DotNet::RuntimeService> _novelDotNetRuntimeService;
@@ -61,7 +61,7 @@ namespace NovelRT {
     /// The Interaction Service associated with this Runner
     Input::InteractionService* getInteractionService() const;
     /// The Debug Service associated with this Runner.
-    DebugService* getDebugService() const;
+    Debug::DebugService* getDebugService() const;
     Audio::AudioService* getAudioService() const;
     DotNet::RuntimeService* getDotNetRuntimeService() const;
     Windowing::WindowingService* getWindowingService() const;

--- a/src/NovelRT/DebugService.cpp
+++ b/src/NovelRT/DebugService.cpp
@@ -25,11 +25,12 @@ messageCallback(GLenum source,
 
 #include <NovelRT.h>
 
-namespace NovelRT {
+namespace NovelRT::Debug {
   DebugService::DebugService(NovelRunner* const runner) :
     _runner(runner),
     _fpsCounter(nullptr),
-    _framesPerSecond(0) {
+    _framesPerSecond(0),
+    _metricsLevel(MetricsLevel::None) {
     runner->subscribeToSceneConstructionRequested(std::bind(&DebugService::onSceneConstruction, this));
   }
 
@@ -54,6 +55,14 @@ namespace NovelRT {
     else {
       _fpsCounter->setActive(value);
     }
+  }
+
+  MetricsLevel DebugService::getMetricsLevel() const {
+    return _metricsLevel;
+  }
+
+  void DebugService::setMetricsLevel(const MetricsLevel& value) {
+    _metricsLevel = value;
   }
 
   void DebugService::setFramesPerSecond(uint32_t value) {

--- a/src/NovelRT/DebugService.cpp
+++ b/src/NovelRT/DebugService.cpp
@@ -34,6 +34,14 @@ namespace NovelRT::Debug {
     runner->subscribeToSceneConstructionRequested(std::bind(&DebugService::onSceneConstruction, this));
   }
 
+  void DebugService::recordMetrics() {
+    if (_metricsLevel >= MetricsLevel::FramesPerSecond) {
+      if (_runner->getStepTimer()) {
+        setFramesPerSecond(_runner->getStepTimer()->getFramesPerSecond());
+      }
+    }
+  }
+
   bool DebugService::getIsFpsCounterVisible() const {
     return (_fpsCounter != nullptr) && _fpsCounter->getActive();
   }

--- a/src/NovelRT/NovelRunner.cpp
+++ b/src/NovelRT/NovelRunner.cpp
@@ -7,7 +7,7 @@ namespace NovelRT {
     _exitCode(1),
     _stepTimer(Utilities::Lazy<std::unique_ptr<Timing::StepTimer>>(std::function<Timing::StepTimer*()>([targetFrameRate] {return new Timing::StepTimer(targetFrameRate); }))),
     _novelWindowingService(std::make_unique<Windowing::WindowingService>(this)),
-    _novelDebugService(std::make_unique<DebugService>(this)),
+    _novelDebugService(std::make_unique<Debug::DebugService>(this)),
     _novelInteractionService(std::make_unique<Input::InteractionService>(this)),
     _novelAudioService(std::make_unique<Audio::AudioService>()),
     _novelDotNetRuntimeService(std::make_unique<DotNet::RuntimeService>()),
@@ -71,7 +71,7 @@ namespace NovelRT {
     return _novelInteractionService.get();
   }
 
-  DebugService* NovelRunner::getDebugService() const {
+  Debug::DebugService* NovelRunner::getDebugService() const {
     return _novelDebugService.get();
   }
 

--- a/src/NovelRT/NovelRunner.cpp
+++ b/src/NovelRT/NovelRunner.cpp
@@ -87,6 +87,10 @@ namespace NovelRT {
 	  return _novelWindowingService.get();
   }
 
+  Timing::StepTimer* NovelRunner::getStepTimer() {
+    return _stepTimer.getActual();
+  }
+
   NovelRunner::~NovelRunner() {
     glfwTerminate();
   }


### PR DESCRIPTION
This PR resolves #30 and will contain the following steps:

- [X] Create a metrics level enum to determine what metrics to record and/or output.
- [ ] Overhaul the `DebugService` to record metrics it needs to.
- [ ] Implement new overhaul in `NovelRunner`'s update logic. 
- [ ] Output the `DebugService`'s metrics to the main window.

Feel free to suggest metrics it should be able to record below. For now, I'll start simple with framerate, hardware usage and rendering statistics. I might include sound cache too.  

Another thing that could be good to add is outputting metrics to a log file.