### PR TITLE
InteractionService: fix out-of-range exception when pressing mouse buttons.

### DIFF
--- a/include/NovelRT/Input/InteractionService.h
+++ b/include/NovelRT/Input/InteractionService.h
@@ -23,7 +23,7 @@ namespace NovelRT::Input {
     LoggingService _logger;
     void validateIfKeyCached(KeyCode code);
     void processKeyState(KeyCode code, KeyState state);
-    void tryProcessMouseState(KeyCode code);
+    void processMouseStates();
     void acceptMouseButtonClickPush(int button, int action, const Maths::GeoVector<float>& mousePosition);
     void acceptKeyboardInputBindingPush(int key, int action);
 

--- a/include/NovelRT/Input/InteractionService.h
+++ b/include/NovelRT/Input/InteractionService.h
@@ -21,7 +21,9 @@ namespace NovelRT::Input {
     std::map<KeyCode, Maths::GeoVector<float>> _mousePositionsOnScreenPerButton;
     Maths::GeoVector<float> _screenSize;
     LoggingService _logger;
+    void validateIfKeyCached(KeyCode code);
     void processKeyState(KeyCode code, KeyState state);
+    void tryProcessMouseState(KeyCode code);
     void acceptMouseButtonClickPush(int button, int action, const Maths::GeoVector<float>& mousePosition);
     void acceptKeyboardInputBindingPush(int key, int action);
 

--- a/include/NovelRT/Input/KeyCode.h
+++ b/include/NovelRT/Input/KeyCode.h
@@ -141,6 +141,8 @@ namespace NovelRT::Input {
     MouseButtonSix = GLFW_MOUSE_BUTTON_6,
     MouseButtonSeven = GLFW_MOUSE_BUTTON_7,
     MouseButtonEight = GLFW_MOUSE_BUTTON_8,
+    FirstMouseButton = LeftMouseButton,
+    LastMouseButton = GLFW_MOUSE_BUTTON_LAST
   };
 }
 

--- a/include/NovelRT/Input/KeyCode.h
+++ b/include/NovelRT/Input/KeyCode.h
@@ -131,10 +131,16 @@ namespace NovelRT::Input {
 
     MenuKey = GLFW_KEY_MENU,
 
-    //The next two should only be used when checking MouseEvents
+    //The next members should only be used when checking MouseEvents
 
     LeftMouseButton = GLFW_MOUSE_BUTTON_LEFT,
-    RightMouseButton = GLFW_MOUSE_BUTTON_RIGHT
+    RightMouseButton = GLFW_MOUSE_BUTTON_RIGHT,
+    MiddleMouseButton = GLFW_MOUSE_BUTTON_MIDDLE,
+    MouseButtonFour = GLFW_MOUSE_BUTTON_4,
+    MouseButtonFive = GLFW_MOUSE_BUTTON_5,
+    MouseButtonSix = GLFW_MOUSE_BUTTON_6,
+    MouseButtonSeven = GLFW_MOUSE_BUTTON_7,
+    MouseButtonEight = GLFW_MOUSE_BUTTON_8,
   };
 }
 

--- a/samples/main.cpp
+++ b/samples/main.cpp
@@ -115,6 +115,9 @@ int main(int argc, char *argv[])
   });
 
   interactionRect = runner.getInteractionService()->createBasicInteractionRect(playButtonTransform, 2);
+  memeInteractionRect->setSubscribedKey(NovelRT::Input::KeyCode::LeftMouseButton);
+  interactionRect->setSubscribedKey(NovelRT::Input::KeyCode::RightMouseButton);
+
   auto loggingLevel = NovelRT::LogLevel::Debug;
 
   memeInteractionRect->subscribeToInteracted([&console] {

--- a/src/NovelRT/Input/InteractionService.cpp
+++ b/src/NovelRT/Input/InteractionService.cpp
@@ -37,12 +37,14 @@ namespace NovelRT::Input {
     }
   }
 
-  void InteractionService::tryProcessMouseState(KeyCode code) {
-    auto result = _keyStates.find(code);
+  void InteractionService::processMouseStates() {
+    for (int i = (int)KeyCode::FirstMouseButton; i < (int)KeyCode::LastMouseButton; i++) {
+      auto keyCode = static_cast<KeyCode>(i);
+      auto result = _keyStates.find(keyCode);
 
-    if (result != _keyStates.end() && (result->first >= KeyCode::FirstMouseButton && result->first <= KeyCode::LastMouseButton)) {
+      if (result == _keyStates.end()) continue;
       processKeyState(result->first, result->second);
-    }
+    }   
   }
 
   void InteractionService::acceptKeyboardInputBindingPush(int key, int action) {
@@ -89,9 +91,7 @@ namespace NovelRT::Input {
   }
 
 void InteractionService::consumePlayerInput() {
-  for (auto it : _keyStates) {
-    tryProcessMouseState(it.first);
-  }
+  processMouseStates();
   glfwPollEvents();
 }
 

--- a/src/NovelRT/Input/InteractionService.cpp
+++ b/src/NovelRT/Input/InteractionService.cpp
@@ -10,23 +10,25 @@ namespace NovelRT::Input {
   {}
 
   void InteractionService::processKeyState(KeyCode code, KeyState state) {
-    if (!_keyStates.count(code)) {
+    auto result = _keyStates.find(code);
+    
+    if (result == _keyStates.end()) {
       _keyStates.insert({ code, state });
       return;
     }
 
     switch (state) {
     case KeyState::KeyDown:
-      if (_keyStates.at(code) == KeyState::KeyDown) {
-        _keyStates.at(code) = KeyState::KeyDownHeld;
+      if (result->second == KeyState::KeyDown) {
+        result->second = KeyState::KeyDownHeld;
       }
-      else if (_keyStates.at(code) != KeyState::KeyDownHeld) {
-        _keyStates.at(code) = KeyState::KeyDown;
+      else if (result->second != KeyState::KeyDownHeld) {
+        result->second = KeyState::KeyDown;
       }
       break;
     case KeyState::KeyDownHeld:
     case KeyState::KeyUp:
-      _keyStates.at(code) = (_keyStates.at(code) == KeyState::KeyUp) ? KeyState::Idle : state; //lmao
+      result->second = (result->second == KeyState::KeyUp) ? KeyState::Idle : state; //lmao
       break;
     }
   }
@@ -51,11 +53,13 @@ namespace NovelRT::Input {
     auto keyCode = static_cast<KeyCode>(button);
     auto value = mousePosition.getVec4Value() * glm::scale(glm::vec3(1920.0f / _screenSize.getX(), 1080.0f / _screenSize.getY(), 0.0f));
 
-    if (!_mousePositionsOnScreenPerButton.count(keyCode)) {
+    auto result = _mousePositionsOnScreenPerButton.find(keyCode);
+
+    if (result == _mousePositionsOnScreenPerButton.end()) {
       _mousePositionsOnScreenPerButton.insert({ keyCode, value });
     }
     else {
-      _mousePositionsOnScreenPerButton.at(keyCode) = value;
+      result->second = value;
     }
 
     processKeyState(keyCode, keyState);


### PR DESCRIPTION
Fixes a small bug in the `InteractionService` where clicking a mouse button that wasn't inserted in `_keyStates` or `_mousePositionsOnScreenPerButton` would crash with an out of range exception due to the keys not existing. 

It'll now directly insert the key and value into the map if the key doesn't exist.