### PR TITLE
Cleaning up the QuadTree and adding SceneGraph integration

### DIFF
--- a/include/NovelRT.h
+++ b/include/NovelRT.h
@@ -119,6 +119,9 @@ namespace NovelRT::Input {
 }
 
 namespace NovelRT::SceneGraph {
+  typedef class QuadTreeNode QuadTreeNode;
+  typedef class QuadTreeScenePoint QuadTreeScenePoint;
+  typedef class RenderObjectNode RenderObjectNode;
   typedef class Scene Scene;
   typedef class SceneNode SceneNode;
 }
@@ -189,6 +192,9 @@ namespace NovelRT::Windowing {
 
 // Scene Graph types
 #include "NovelRT/SceneGraph/SceneNode.h"
+#include "NovelRT/SceneGraph/RenderObjectNode.h"
+#include "NovelRT/SceneGraph/QuadTreeScenePoint.h"
+#include "NovelRT/SceneGraph/QuadTreeNode.h"
 #include "NovelRT/SceneGraph/Scene.h"
 
 #endif //!NOVELRT_H

--- a/include/NovelRT/Maths/GeoBounds.h
+++ b/include/NovelRT/Maths/GeoBounds.h
@@ -13,7 +13,6 @@ namespace NovelRT::Maths {
     GeoVector<float> _position;
     float _rotation;
     GeoVector<float> _size;
-    GeoVector<float> _extents;
 
   public:
     GeoBounds(const GeoVector<float>& position, const GeoVector<float>& size, float rotation);

--- a/include/NovelRT/Maths/QuadTree.h
+++ b/include/NovelRT/Maths/QuadTree.h
@@ -92,6 +92,14 @@ namespace NovelRT::Maths {
       return result;
     }
 
+    template <typename TQuadTreePoint, typename... TArgs>
+    bool tryInsert(const GeoBounds& bounds, TArgs... args) {
+      return tryInsert(std::make_shared<TQuadTreePoint>(bounds.getCornerInWorldSpace(0), std::forward<TArgs>(args)...) ||
+             tryInsert(std::make_shared<TQuadTreePoint>(bounds.getCornerInWorldSpace(1), std::forward<TArgs>(args)...) ||
+             tryInsert(std::make_shared<TQuadTreePoint>(bounds.getCornerInWorldSpace(3), std::forward<TArgs>(args)...) ||
+             tryInsert(std::make_shared<TQuadTreePoint>(bounds.getCornerInWorldSpace(2), std::forward<TArgs>(args)...);
+    }
+
     bool tryRemove(std::shared_ptr<QuadTreePoint> point) noexcept {
       if (point == nullptr || !getBounds().pointIsWithinBounds(point->getPosition())) {
         return false;

--- a/include/NovelRT/Maths/QuadTree.h
+++ b/include/NovelRT/Maths/QuadTree.h
@@ -94,10 +94,10 @@ namespace NovelRT::Maths {
 
     template <typename TQuadTreePoint, typename... TArgs>
     bool tryInsert(const GeoBounds& bounds, TArgs... args) {
-      return tryInsert(std::make_shared<TQuadTreePoint>(bounds.getCornerInWorldSpace(0), std::forward<TArgs>(args)...) ||
-             tryInsert(std::make_shared<TQuadTreePoint>(bounds.getCornerInWorldSpace(1), std::forward<TArgs>(args)...) ||
-             tryInsert(std::make_shared<TQuadTreePoint>(bounds.getCornerInWorldSpace(3), std::forward<TArgs>(args)...) ||
-             tryInsert(std::make_shared<TQuadTreePoint>(bounds.getCornerInWorldSpace(2), std::forward<TArgs>(args)...);
+      return tryInsert(std::make_shared<TQuadTreePoint>(bounds.getCornerInWorldSpace(0), std::forward<TArgs>(args)...)) ||
+             tryInsert(std::make_shared<TQuadTreePoint>(bounds.getCornerInWorldSpace(1), std::forward<TArgs>(args)...)) ||
+             tryInsert(std::make_shared<TQuadTreePoint>(bounds.getCornerInWorldSpace(3), std::forward<TArgs>(args)...)) ||
+             tryInsert(std::make_shared<TQuadTreePoint>(bounds.getCornerInWorldSpace(2), std::forward<TArgs>(args)...));
     }
 
     bool tryRemove(std::shared_ptr<QuadTreePoint> point) noexcept {

--- a/include/NovelRT/Maths/QuadTreePoint.h
+++ b/include/NovelRT/Maths/QuadTreePoint.h
@@ -7,9 +7,20 @@
 
 namespace NovelRT::Maths {
   class QuadTreePoint {
+  private:
+    GeoVector<float> _position;
+
   public:
-    virtual ~QuadTreePoint();
-    virtual const GeoVector<float>& getPosition() const noexcept = 0;
+    QuadTreePoint(GeoVector<float> position) :
+      _position(position) {
+    }
+
+    QuadTreePoint(float x, float y) : QuadTreePoint(GeoVector<float>(x, y)) {
+    }
+
+    const GeoVector<float>& getPosition() const noexcept {
+      return _position;
+    }
   };
 }
 

--- a/include/NovelRT/SceneGraph/QuadTreeNode.h
+++ b/include/NovelRT/SceneGraph/QuadTreeNode.h
@@ -1,0 +1,43 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
+
+#ifndef NOVELRT_QUADTREENODE_H
+#define NOVELRT_QUADTREENODE_H
+
+#ifndef NOVELRT_H
+#error Please do not include this directly. Use the centralised header (NovelRT.h) instead!
+#endif
+
+namespace NovelRT::SceneGraph {
+  class QuadTreeNode : public SceneNode {
+  private:
+    static const int32_t TOP_LEFT = 0;
+    static const int32_t TOP_RIGHT = 1;
+    static const int32_t BOTTOM_LEFT = 2;
+    static const int32_t BOTTOM_RIGHT = 3;
+
+    std::array<std::shared_ptr<QuadTreeScenePoint>, 4> _quadTreePoints;
+
+  public:
+    QuadTreeNode(std::array<std::shared_ptr<QuadTreeScenePoint>, 4> quadTreePoints)
+      : _quadTreePoints(quadTreePoints) {
+    }
+
+    const std::shared_ptr<QuadTreeScenePoint>& getTopLeft() const noexcept {
+      return _quadTreePoints[TOP_LEFT];
+    }
+
+    const std::shared_ptr<QuadTreeScenePoint>& getTopRight() const noexcept {
+      return _quadTreePoints[TOP_RIGHT];
+    }
+
+    const std::shared_ptr<QuadTreeScenePoint>& getBottomLeft() const noexcept {
+      return _quadTreePoints[BOTTOM_LEFT];
+    }
+
+    const std::shared_ptr<QuadTreeScenePoint>& getBottomRight() const noexcept {
+      return _quadTreePoints[BOTTOM_RIGHT];
+    }
+  };
+}
+
+#endif

--- a/include/NovelRT/SceneGraph/QuadTreeScenePoint.h
+++ b/include/NovelRT/SceneGraph/QuadTreeScenePoint.h
@@ -1,0 +1,32 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
+
+#ifndef NOVELRT_QUADTREESCENEPOINT_H
+#define NOVELRT_QUADTREESCENEPOINT_H
+
+#ifndef NOVELRT_H
+#error Please do not include this directly. Use the centralised header (NovelRT.h) instead!
+#endif
+
+namespace NovelRT::SceneGraph {
+  class QuadTreeScenePoint : public Maths::QuadTreePoint {
+  private:
+    std::shared_ptr<SceneNode> _sceneNode;
+
+  public:
+    QuadTreeScenePoint(Maths::GeoVector<float> position, std::shared_ptr<SceneNode> sceneNode) :
+      Maths::QuadTreePoint(position),
+      _sceneNode(sceneNode) {
+    }
+
+    QuadTreeScenePoint(float x, float y, std::shared_ptr<SceneNode> sceneNode) :
+      Maths::QuadTreePoint(x, y),
+      _sceneNode(sceneNode) {
+    }
+
+    const std::shared_ptr<SceneNode>& getSceneNode() const {
+      return _sceneNode;
+    }
+  };
+}
+
+#endif

--- a/include/NovelRT/SceneGraph/RenderObjectNode.h
+++ b/include/NovelRT/SceneGraph/RenderObjectNode.h
@@ -1,0 +1,26 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
+
+#ifndef NOVELRT_RENDEROBJECTNODE_H
+#define NOVELRT_RENDEROBJECTNODE_H
+
+#ifndef NOVELRT_H
+#error Please do not include this directly. Use the centralised header (NovelRT.h) instead!
+#endif
+
+namespace NovelRT::SceneGraph {
+  class RenderObjectNode : public SceneNode {
+  private:
+    std::shared_ptr<Graphics::RenderObject> _renderObject;
+
+  public:
+    RenderObjectNode(std::shared_ptr<Graphics::RenderObject> renderObject) :
+      _renderObject(renderObject) {
+    }
+
+    const std::shared_ptr<Graphics::RenderObject>& getRenderObject() const {
+      return _renderObject;
+    }
+  };
+}
+
+#endif

--- a/include/NovelRT/SceneGraph/Scene.h
+++ b/include/NovelRT/SceneGraph/Scene.h
@@ -10,19 +10,19 @@
 namespace NovelRT::SceneGraph {
   class Scene {
   private:
-    std::set<std::shared_ptr<SceneNode>> _rootNodes;
+    std::set<std::shared_ptr<SceneNode>> _nodes;
 
   public:
-    const std::set<std::shared_ptr<SceneNode>>& getRootNodes() {
-      return _rootNodes;
+    const std::set<std::shared_ptr<SceneNode>>& getNodes() {
+      return _nodes;
     }
 
     bool insert(const std::shared_ptr<SceneNode>& node) {
-      return _rootNodes.insert(node).second;
+      return _nodes.insert(node).second;
     }
 
     bool remove(const std::shared_ptr<SceneNode>& node) {
-      auto numErased = _rootNodes.erase(node);
+      auto numErased = _nodes.erase(node);
       assert((numErased == 0) || (numErased == 1));
       return numErased != 0;
     }

--- a/include/NovelRT/Transform.h
+++ b/include/NovelRT/Transform.h
@@ -21,12 +21,12 @@ namespace NovelRT {
     Transform(const Maths::GeoVector<float>& position, float rotation, const Maths::GeoVector<float>& scale) noexcept;
     Transform() noexcept;
 
-    inline const Maths::GeoBounds& getAABB() const {
+    inline Maths::GeoBounds getAABB() const {
       auto scale = fmaxf(_scale.getX(), _scale.getY());
       return Maths::GeoBounds(_position, Maths::GeoVector(scale, scale), 0);
     }
 
-    inline const Maths::GeoBounds& getBounds() const {
+    inline Maths::GeoBounds getBounds() const {
       return Maths::GeoBounds(_position, _scale, _rotation);
     }
 

--- a/include/NovelRT/Transform.h
+++ b/include/NovelRT/Transform.h
@@ -20,6 +20,15 @@ namespace NovelRT {
   public:
     Transform(const Maths::GeoVector<float>& position, float rotation, const Maths::GeoVector<float>& scale);
 
+    inline const Maths::GeoBounds& getAABB() const {
+      auto scale = fmaxf(_scale.getX(), _scale.getY());
+      return Maths::GeoBounds(_position, Maths::GeoVector(scale, scale), 0);
+    }
+
+    inline const Maths::GeoBounds& getBounds() const {
+      return Maths::GeoBounds(_position, _scale, _rotation);
+    }
+
     inline const Maths::GeoVector<float>& getPosition() const {
       return _position;
     }

--- a/src/NovelRT/Maths/GeoBounds.cpp
+++ b/src/NovelRT/Maths/GeoBounds.cpp
@@ -6,8 +6,7 @@ namespace NovelRT::Maths {
   GeoBounds::GeoBounds(const GeoVector<float>& position, const GeoVector<float>& size, float rotation) :
     _position(position),
     _rotation(rotation),
-    _size(size),
-    _extents(_size / 2.0f){}
+    _size(size) { }
 
   bool GeoBounds::pointIsWithinBounds(const GeoVector<float>& point) const {
     auto corner0 = getCornerInWorldSpace(0);
@@ -80,6 +79,6 @@ namespace NovelRT::Maths {
     _rotation = value;
   }
   GeoVector<float> GeoBounds::getExtents() const {
-    return _extents;
+    return _size / 2;
   }
 }

--- a/src/NovelRT/Maths/QuadTree.cpp
+++ b/src/NovelRT/Maths/QuadTree.cpp
@@ -1,0 +1,67 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
+
+#include <NovelRT.h>
+
+namespace NovelRT::Maths {
+  void QuadTree::subdivideTree() noexcept {
+    assert(getPointCount() == POINT_CAPACITY);
+
+    const GeoVector<float> TOP_LEFT_SCALE = GeoVector<float>(-0.5, +0.5);
+    const GeoVector<float> TOP_RIGHT_SCALE = GeoVector<float>(+0.5, +0.5);
+    const GeoVector<float> BOTTOM_LEFT_SCALE = GeoVector<float>(-0.5, -0.5);
+    const GeoVector<float> BOTTOM_RIGHT_SCALE = GeoVector<float>(+0.5, -0.5);
+
+    GeoVector size = getBounds().getSize() / 2;
+    GeoVector position = getBounds().getPosition();
+
+    _children[TOP_LEFT] = std::make_unique<QuadTree>(GeoBounds(position + (size * TOP_LEFT_SCALE), size, 0), weak_from_this());
+    _children[TOP_RIGHT] = std::make_unique<QuadTree>(GeoBounds(position + (size * TOP_RIGHT_SCALE), size, 0), weak_from_this());
+    _children[BOTTOM_LEFT] = std::make_unique<QuadTree>(GeoBounds(position + (size * BOTTOM_LEFT_SCALE), size, 0), weak_from_this());
+    _children[BOTTOM_RIGHT] = std::make_unique<QuadTree>(GeoBounds(position + (size * BOTTOM_RIGHT_SCALE), size, 0), weak_from_this());
+
+    for (size_t i = 0; i < getPointCount(); i++) {
+      auto point = getPoint(i);
+
+      auto result = tryInsert(point);
+      assert(result); unused(result);
+
+      _points[i] = nullptr;
+    }
+
+    _pointCount = 0;
+  }
+
+  void QuadTree::tryMergeTree() noexcept {
+    auto parent = getParent().lock();
+
+    if (parent == nullptr) {
+      return;
+    }
+
+    size_t totalPointCount = 0;
+
+    for (auto child : parent->_children) {
+      if (child->getTopLeft() != nullptr) {
+        return;
+      }
+      totalPointCount += child->getPointCount();
+    }
+
+    if (totalPointCount <= POINT_CAPACITY) {
+      size_t d = 0;
+
+      for (size_t c = 0; c < 4; c++) {
+        auto child = parent->_children[c];
+
+        for (size_t s = 0; s < child->getPointCount(); s++) {
+          parent->_points[d++] = child->getPoint(s);
+        }
+
+        parent->_children[c] = nullptr;
+      }
+
+      assert(d == totalPointCount);
+      parent->_pointCount = totalPointCount;
+    }
+  }
+}

--- a/src/NovelRT/Maths/QuadTreePoint.cpp
+++ b/src/NovelRT/Maths/QuadTreePoint.cpp
@@ -1,7 +1,0 @@
-// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
-
-#include <NovelRT.h>
-
-namespace NovelRT::Maths {
-  QuadTreePoint::~QuadTreePoint() { }
-}

--- a/tests/NovelRT.Tests/Maths/QuadTreeTest.cpp
+++ b/tests/NovelRT.Tests/Maths/QuadTreeTest.cpp
@@ -259,3 +259,29 @@ TEST_F(QuadTreeTest, removeOneDoesNotCauseMergeWhenAdjacentPointCountMoreThan4) 
   EXPECT_EQ(_quadTree->getBottomRight()->getPoint(0), point3);
   EXPECT_EQ(_quadTree->getTopLeft()->getPoint(1), point4);
 }
+
+TEST_F(QuadTreeTest, getIntersectingPointsForQuadTreeBoundsReturnsAll) {
+  auto point0 = std::make_shared<QuadTreePoint>(-1.0f, 1.0f);
+  _quadTree->tryInsert(point0);
+
+  auto point1 = std::make_shared<QuadTreePoint>(1.0f, 1.0f);
+  _quadTree->tryInsert(point1);
+
+  auto point2 = std::make_shared<QuadTreePoint>(-1.0f, -1.0f);
+  _quadTree->tryInsert(point2);
+
+  auto point3 = std::make_shared<QuadTreePoint>(1.0f, -1.0f);
+  _quadTree->tryInsert(point3);
+
+  auto point4 = std::make_shared<QuadTreePoint>(0.0f, 0.0f);
+  _quadTree->tryInsert(point4);
+
+  auto intersectingPoints = _quadTree->getIntersectingPoints(_quadTree->getBounds());
+  EXPECT_EQ(intersectingPoints.size(), 5u);
+
+  EXPECT_EQ(intersectingPoints[0], point0);
+  EXPECT_EQ(intersectingPoints[1], point4);
+  EXPECT_EQ(intersectingPoints[2], point1);
+  EXPECT_EQ(intersectingPoints[3], point2);
+  EXPECT_EQ(intersectingPoints[4], point3);
+}


### PR DESCRIPTION
This cleans up the implementation of `QuadTree` and adds `SceneGraph` integration. It also adds a helper method which allows the corners of a bounding box to be trivially added to the quad tree to and to get the bounding box from a transform.