### PR TITLE
Iterate events by creating a copy of the handlers prior to iteration

### DIFF
--- a/include/NovelRT/Utilities/Event.h
+++ b/include/NovelRT/Utilities/Event.h
@@ -75,8 +75,10 @@ namespace NovelRT::Utilities {
     }
 
     void operator()(TArgs... args) const {
-      for (size_t i = 0; i < _handlers.size(); i++) {
-        _handlers.at(i)(args...);
+      auto handlers = _handlers;
+
+      for (auto handler : handlers) {
+        handler(args...);
       }
     }
   };

--- a/tests/NovelRT.Tests/Utilities/EventTest.cpp
+++ b/tests/NovelRT.Tests/Utilities/EventTest.cpp
@@ -90,14 +90,24 @@ TEST(EventTest, unsubscribeRemovesMatchingVersion2)
 }
 
 TEST(EventTest, subscribeWithinSubscribeDoesNotCauseHardCrash) {
-  auto logger = NovelRT::LoggingService();
   auto event = Event<>();
-  event += [&] {event += [&] { event += [&] { logger.logInfo("Hello! this is a test"); }; }; };
+  int32_t counter = 0;
+
+  auto OnEvent1 = [&]() { counter++; };
+  auto OnEvent2 = [&]() { counter++; event += OnEvent1; };
+
+  event += OnEvent2;
+
   event();
+  EXPECT_EQ(1, counter);
+
   event();
+  EXPECT_EQ(3, counter);
+
   event();
+  EXPECT_EQ(6, counter);
+
   event();
-  event();
-  event();
+  EXPECT_EQ(10, counter);
 }
 


### PR DESCRIPTION
Slightly improved over the version introduced in #158. Namely, this doesn't run subscriptions on the same frame they were added and doesn't ignore subscriptions if they are removed the same frame.