### PR TITLE
Reworked sound sources for OpenAL

### DIFF
--- a/include/NovelRT/Audio/AudioService.h
+++ b/include/NovelRT/Audio/AudioService.h
@@ -28,10 +28,6 @@ namespace NovelRT::Audio {
     ALint _soundSourceState;
     SoundBank _soundStorage;
     SoundBank _bufferStorage;
-    
-
-
-
 
     ALuint readFile(std::string input);
     std::string getALError();
@@ -53,14 +49,10 @@ namespace NovelRT::Audio {
     void stopMusic();
     void setMusicVolume(float value);
     void checkSources();
-
-    //For touhou sample
-    //Returns source
     ALuint loadSound(std::string input);
     void unload(ALuint handle);
     void playSound(ALuint handle, int loops);
     void stopSound(ALuint handle);
-
 
   };
 }

--- a/include/NovelRT/Audio/AudioService.h
+++ b/include/NovelRT/Audio/AudioService.h
@@ -15,18 +15,19 @@ namespace NovelRT::Audio {
     const ALuint _noBuffer = 0;
     const ALfloat _pitch = 1.0f;
 
+    std::vector<ALuint> _soundStorage;
     Utilities::Lazy<std::unique_ptr<ALCdevice, void(*)(ALCdevice*)>> _device;
     Utilities::Lazy<std::unique_ptr<ALCcontext, void(*)(ALCcontext*)>> _context;
     LoggingService _logger;
     ALuint _musicSource;
     ALint _musicSourceState;
     ALint _musicLoopAmount;
-    ALuint _soundSource;
     ALint _soundSourceState;
     ALint _soundLoopAmount;
     SoundBank _sounds;
     MusicBank _music;
     std::string _deviceName;
+    bool _manualLoad;
 
     ALuint readFile(std::string input);
     std::string getALError();
@@ -38,18 +39,26 @@ namespace NovelRT::Audio {
     ~AudioService();
 
     bool initializeAudio();
-    std::vector<ALuint>::iterator load(std::string input, bool isMusic);
-    void unload(ALuint handle, bool isMusic);
-    void playSound(std::vector<ALuint>::iterator handle, int loops);
-    void stopSound();
-    void setSoundVolume(float val);
-    void setSoundPosition(float posX, float posY);
+    std::vector<ALuint>::iterator loadMusic(std::string input);
+    
+    void unloadMusic(ALuint handle);
+    void setSoundVolume(ALuint source, float val);
+    void setSoundPosition(ALuint source, float posX, float posY);
     void resumeMusic();
     void playMusic(std::vector<ALuint>::iterator handle, int loops);
     void pauseMusic();
     void stopMusic();
     void setMusicVolume(float value);
     void checkSources();
+
+    //For touhou sample
+    //Returns source
+    ALuint loadSound(std::string input);
+    void unloadSound(ALuint handle);
+    void playSound(ALuint handle, int loops);
+    void stopSound(ALuint handle);
+
+
   };
 }
 

--- a/include/NovelRT/Audio/AudioService.h
+++ b/include/NovelRT/Audio/AudioService.h
@@ -15,19 +15,23 @@ namespace NovelRT::Audio {
     const ALuint _noBuffer = 0;
     const ALfloat _pitch = 1.0f;
 
-    std::vector<ALuint> _soundStorage;
     Utilities::Lazy<std::unique_ptr<ALCdevice, void(*)(ALCdevice*)>> _device;
     Utilities::Lazy<std::unique_ptr<ALCcontext, void(*)(ALCcontext*)>> _context;
+    std::string _deviceName;
     LoggingService _logger;
+    bool _manualLoad;
+    MusicBank _music;
     ALuint _musicSource;
     ALint _musicSourceState;
     ALint _musicLoopAmount;
-    ALint _soundSourceState;
     ALint _soundLoopAmount;
-    SoundBank _sounds;
-    MusicBank _music;
-    std::string _deviceName;
-    bool _manualLoad;
+    ALint _soundSourceState;
+    SoundBank _soundStorage;
+    SoundBank _bufferStorage;
+    
+
+
+
 
     ALuint readFile(std::string input);
     std::string getALError();
@@ -41,7 +45,6 @@ namespace NovelRT::Audio {
     bool initializeAudio();
     std::vector<ALuint>::iterator loadMusic(std::string input);
     
-    void unloadMusic(ALuint handle);
     void setSoundVolume(ALuint source, float val);
     void setSoundPosition(ALuint source, float posX, float posY);
     void resumeMusic();
@@ -54,7 +57,7 @@ namespace NovelRT::Audio {
     //For touhou sample
     //Returns source
     ALuint loadSound(std::string input);
-    void unloadSound(ALuint handle);
+    void unload(ALuint handle);
     void playSound(ALuint handle, int loops);
     void stopSound(ALuint handle);
 

--- a/samples/main.cpp
+++ b/samples/main.cpp
@@ -69,8 +69,11 @@ int main(int /*argc*/, char* /*argv*/[])
   auto console = NovelRT::LoggingService(NovelRT::Utilities::Misc::CONSOLE_LOG_APP);
   auto audio = runner.getAudioService();
   audio.lock()->initializeAudio();
-  //auto bgm = audio->load((soundsDirPath / "running.ogg").string(), true);
-  //auto jojo = audio->load((soundsDirPath / "jojo.ogg").string(), false);
+  auto bgm = audio.lock()->loadMusic((soundsDirPath / "marisa.ogg").string());
+  auto jojo = audio.lock()->loadSound((soundsDirPath / "caution.wav").string());
+  auto jojo2 = audio.lock()->loadSound((soundsDirPath / "master_spark.wav").string());
+  auto jojo3 = audio.lock()->loadSound((soundsDirPath / "ATTACK3.wav").string());
+  auto jojo4 = audio.lock()->loadSound((soundsDirPath / "SPELLCARD.wav").string());
 
 #ifdef TEST_ANIM
   auto movingState = std::make_shared<NovelRT::Animation::SpriteAnimatorState>();
@@ -181,14 +184,18 @@ int main(int /*argc*/, char* /*argv*/[])
 
   auto loggingLevel = NovelRT::LogLevel::Debug;
 
-  memeInteractionRect->Interacted += [&console] {
+  memeInteractionRect->Interacted += [&] {
     console.logDebug("WAHEYYY");
+    audio.lock()->playSound(jojo, 0);
+    audio.lock()->playSound(jojo2, 0);
+    audio.lock()->playSound(jojo3, 0);
+    audio.lock()->playSound(jojo4, 0);
   };
 
   //If uncommenting the call, pass &jojo to the subscription next to &audio.
   interactionRect->Interacted += [&] {
     console.log("Test button!", loggingLevel);
-    //audio->playSound(jojo, 0);
+    
 
 #ifdef TEST_ANIM
     switch (testAnim->getCurrentPlayState()) {
@@ -229,7 +236,7 @@ int main(int /*argc*/, char* /*argv*/[])
   };
 
   runner.getDotNetRuntimeService().lock()->initialize();
-  //audio->playMusic(bgm, -1);
+  audio.lock()->playMusic(bgm, -1);
 
   runner.runNovel();
 

--- a/samples/main.cpp
+++ b/samples/main.cpp
@@ -71,9 +71,6 @@ int main(int /*argc*/, char* /*argv*/[])
   audio.lock()->initializeAudio();
   auto bgm = audio.lock()->loadMusic((soundsDirPath / "marisa.ogg").string());
   auto jojo = audio.lock()->loadSound((soundsDirPath / "caution.wav").string());
-  auto jojo2 = audio.lock()->loadSound((soundsDirPath / "master_spark.wav").string());
-  auto jojo3 = audio.lock()->loadSound((soundsDirPath / "ATTACK3.wav").string());
-  auto jojo4 = audio.lock()->loadSound((soundsDirPath / "SPELLCARD.wav").string());
 
 #ifdef TEST_ANIM
   auto movingState = std::make_shared<NovelRT::Animation::SpriteAnimatorState>();
@@ -187,12 +184,8 @@ int main(int /*argc*/, char* /*argv*/[])
   memeInteractionRect->Interacted += [&] {
     console.logDebug("WAHEYYY");
     audio.lock()->playSound(jojo, 0);
-    audio.lock()->playSound(jojo2, 0);
-    audio.lock()->playSound(jojo3, 0);
-    audio.lock()->playSound(jojo4, 0);
   };
 
-  //If uncommenting the call, pass &jojo to the subscription next to &audio.
   interactionRect->Interacted += [&] {
     console.log("Test button!", loggingLevel);
     

--- a/src/NovelRT/Audio/AudioService.cpp
+++ b/src/NovelRT/Audio/AudioService.cpp
@@ -29,9 +29,9 @@ AudioService::AudioService() :
   _musicLoopAmount(0),
   _soundSourceState(0),
   _soundLoopAmount(0),
-  isInitialised(false),
+  _soundStorage(),
   _manualLoad(false),
-  _soundStorage() {
+  isInitialised(false) {
   }
 
 bool AudioService::initializeAudio() {

--- a/src/NovelRT/Audio/AudioService.cpp
+++ b/src/NovelRT/Audio/AudioService.cpp
@@ -286,7 +286,7 @@ ALuint AudioService::loadSound(std::string input) {
 }
 
 void AudioService::unload(ALuint source) {
-  alSourcei(source, AL_BUFFER, _noBuffer);
+  alSourcei(source, AL_BUFFER, 0);
 }
 
 void AudioService::playSound(ALuint handle, int loops) {

--- a/src/NovelRT/Audio/AudioService.cpp
+++ b/src/NovelRT/Audio/AudioService.cpp
@@ -51,7 +51,8 @@ ALuint AudioService::readFile(std::string input) {
   SNDFILE* file = sf_open(input.c_str(), SFM_READ, &info);
 
   if (file == nullptr) {
-    _logger.logErrorLine(std::string(sf_strerror(nullptr)));
+    _logger.logWarningLine(std::string(sf_strerror(nullptr)));
+    return _noBuffer;
   }
 
   std::vector<uint16_t> data;
@@ -84,7 +85,7 @@ std::vector<ALuint>::iterator AudioService::loadMusic(std::string input) {
 
   //Sorry Matt, nullptr types are incompatible to ALuint according to VS.
   if (newBuffer == _noBuffer) {
-    _logger.logError("Could not load audio file: ", getALError());
+    _logger.logWarning("Could not load audio file: " + input);
     return _music.end();
   }
 
@@ -143,8 +144,8 @@ void AudioService::playMusic(std::vector<ALuint>::iterator handle, int loops) {
     throw std::runtime_error("Unable to continue! Dangerous call being made to AudioService::playMusic. You cannot play a sound when the AudioService is not initialised.");
   }
 
-  if (*handle == _noBuffer) {
-    _logger.logErrorLine("Cannot play the requested sound - it may have been deleted or not loaded properly.");
+  if (handle == _music.end()) {
+    _logger.logWarningLine("Cannot play the requested sound - it may have been deleted or not loaded properly.");
     return;
   }
 
@@ -260,7 +261,6 @@ std::string AudioService::getALError() {
   }
 }
 
-//for touhou project
 ALuint AudioService::loadSound(std::string input) {
   if (!isInitialised) {
     _logger.logError("Cannot load new audio into memory while the service is uninitialised! Aborting...");
@@ -269,7 +269,8 @@ ALuint AudioService::loadSound(std::string input) {
   auto newBuffer = readFile(input);
 
   if (newBuffer == _noBuffer) {
-    _logger.logError("Could not load audio file: ", getALError());
+    _logger.logWarning("Could not load audio file: " + input);
+    return _noBuffer;
   }
 
   _manualLoad = true;


### PR DESCRIPTION
Can now create up to 256 sources theoretically (OpenAL's limit) - must be managed manually as sources are handled, not buffers.