### PR TITLE
SpriteAnimator delta time update.

### DIFF
--- a/include/NovelRT/Animation/SpriteAnimator.h
+++ b/include/NovelRT/Animation/SpriteAnimator.h
@@ -11,7 +11,7 @@ namespace NovelRT::Animation {
 
   class SpriteAnimator {
   private:
-    float _accumulatedDelta;
+    Timing::Timestamp _accumulatedDelta;
     uint32_t _currentFrameIndex;
     NovelRunner* _runner; //I'm a bit worried about this, but whatever, just want it working for now
     Graphics::ImageRect* _rect;

--- a/include/NovelRT/Animation/SpriteAnimatorFrame.h
+++ b/include/NovelRT/Animation/SpriteAnimatorFrame.h
@@ -15,9 +15,10 @@ namespace NovelRT::Animation {
 
   private:
     std::shared_ptr<Graphics::Texture> _texture;
-    float _duration;
+    Timing::Timestamp _duration;
 
   public:
+    SpriteAnimatorFrame() : _duration(Timing::Timestamp::zero()) {}
 
     inline const std::shared_ptr<Graphics::Texture>& texture() const noexcept {
       return _texture;
@@ -27,11 +28,11 @@ namespace NovelRT::Animation {
       return _texture;
     }
 
-    inline const float& duration() const noexcept {
+    inline const Timing::Timestamp& duration() const noexcept {
       return _duration;
     }
 
-    inline float& duration() noexcept {
+    inline Timing::Timestamp& duration() noexcept {
       return _duration;
     }
   };

--- a/include/NovelRT/Timing/Timestamp.h
+++ b/include/NovelRT/Timing/Timestamp.h
@@ -13,8 +13,7 @@ namespace NovelRT::Timing {
     uint64_t _ticks;
 
   public:
-    Timestamp(uint64_t ticks) : _ticks(ticks) {}
-    explicit Timestamp(double seconds) : _ticks(static_cast<uint64_t>(seconds * TicksPerSecond)) {}
+    explicit Timestamp(uint64_t ticks) noexcept : _ticks(ticks) {}
 
     inline uint64_t getTicks() const {
       return _ticks;
@@ -34,6 +33,10 @@ namespace NovelRT::Timing {
 
     inline static const Timestamp zero() {
       return Timestamp(0ULL);
+    }
+
+    inline static const Timestamp fromSeconds(double seconds) {
+      return Timestamp(static_cast<uint64_t>(seconds * TicksPerSecond));
     }
 
     inline Timestamp operator+(const Timestamp& other) const {

--- a/include/NovelRT/Timing/Timestamp.h
+++ b/include/NovelRT/Timing/Timestamp.h
@@ -14,7 +14,7 @@ namespace NovelRT::Timing {
 
   public:
     Timestamp(uint64_t ticks) : _ticks(ticks) {}
-    Timestamp(double seconds) : _ticks(static_cast<uint64_t>(seconds * TicksPerSecond)) {}
+    explicit Timestamp(double seconds) : _ticks(static_cast<uint64_t>(seconds * TicksPerSecond)) {}
 
     inline uint64_t getTicks() const {
       return _ticks;
@@ -32,6 +32,69 @@ namespace NovelRT::Timing {
       return returnVal;
     }
 
+    inline static const Timestamp zero() {
+      return Timestamp(0ULL);
+    }
+
+    inline Timestamp operator+(const Timestamp& other) const {
+      return Timestamp(_ticks + other.getTicks());
+    }
+
+    inline Timestamp operator-(const Timestamp& other) const {
+      return Timestamp(_ticks - other.getTicks());
+    }
+
+    inline Timestamp operator*(const Timestamp& other) const {
+      return Timestamp(_ticks * other.getTicks());
+    }
+
+    inline Timestamp operator/(const Timestamp& other) const {
+      return Timestamp(_ticks / other.getTicks());
+    }
+
+    inline Timestamp& operator+=(const Timestamp& other) {
+      _ticks += other.getTicks();
+      return *this;
+    }
+
+    inline Timestamp operator-=(const Timestamp& other) {
+      _ticks -= other.getTicks();
+      return *this;
+    }
+
+    inline Timestamp operator*=(const Timestamp& other) {
+      _ticks *= other.getTicks();
+      return *this;
+    }
+
+    inline Timestamp operator/=(const Timestamp& other) {
+      _ticks /= other.getTicks();
+      return *this;
+    }
+
+    inline bool operator<(const Timestamp& other) const {
+      return _ticks < other.getTicks();
+    }
+
+    inline bool operator>(const Timestamp& other) const {
+      return _ticks > other.getTicks();
+    }
+
+    inline bool operator<=(const Timestamp& other) const {
+      return _ticks <= other.getTicks();
+    }
+
+    inline bool operator>=(const Timestamp& other) const {
+      return _ticks >= other.getTicks();
+    }
+
+    inline bool operator==(const Timestamp& other) const {
+      return _ticks == other.getTicks();
+    }
+
+    inline bool operator!=(const Timestamp& other) const {
+      return _ticks != other.getTicks();
+    }
   };
 }
 

--- a/samples/main.cpp
+++ b/samples/main.cpp
@@ -80,7 +80,7 @@ int main(int /*argc*/, char* /*argv*/[])
 
   for (int32_t i = 0; i < 10; i++) {
     auto frame = NovelRT::Animation::SpriteAnimatorFrame();
-    frame.duration() = NovelRT::Timing::Timestamp(0.1f);
+    frame.duration() = NovelRT::Timing::Timestamp::fromSeconds(0.1f);
     frame.texture() = runner.getRenderer().lock()->getTexture((imagesDirPath / "idle" / ("0-" + std::to_string(i) + ".png")).string());
     idleFrames.push_back(frame);
   }
@@ -99,7 +99,7 @@ int main(int /*argc*/, char* /*argv*/[])
 
   for (int32_t i = 0; i < 5; i++) {
     auto frame = NovelRT::Animation::SpriteAnimatorFrame();
-    frame.duration() = NovelRT::Timing::Timestamp(0.1f);
+    frame.duration() = NovelRT::Timing::Timestamp::fromSeconds(0.1f);
     frame.texture() = runner.getRenderer().lock()->getTexture((imagesDirPath / "right" / ("100-" + std::to_string(i) + ".png")).string());
     movingFrames.push_back(frame);
   }

--- a/samples/main.cpp
+++ b/samples/main.cpp
@@ -75,38 +75,38 @@ int main(int /*argc*/, char* /*argv*/[])
 #ifdef TEST_ANIM
   auto movingState = std::make_shared<NovelRT::Animation::SpriteAnimatorState>();
   auto idleState = std::make_shared<NovelRT::Animation::SpriteAnimatorState>();
-  idleState->setShouldLoop(true);
+  idleState->shouldLoop() = true;
   auto idleFrames = std::vector<NovelRT::Animation::SpriteAnimatorFrame>();
 
   for (int32_t i = 0; i < 10; i++) {
     auto frame = NovelRT::Animation::SpriteAnimatorFrame();
-    frame.setDuration(0.1f);
-    frame.setTexture(runner.getRenderer().lock()->getTexture((imagesDirPath / "idle" / ("0-" + std::to_string(i) + ".png")).string()));
+    frame.duration() = NovelRT::Timing::Timestamp(0.1f);
+    frame.texture() = runner.getRenderer().lock()->getTexture((imagesDirPath / "idle" / ("0-" + std::to_string(i) + ".png")).string());
     idleFrames.push_back(frame);
   }
 
-  idleFrames.back().FrameExit += [] { shouldBeInIdle = false; };
+  idleFrames.back().FrameExit += [&shouldBeInIdle] { shouldBeInIdle = false; };
 
-  idleState->insertNewState(movingState, std::vector<std::function<bool()>> {[] { return !shouldBeInIdle;  }});
+  idleState->insertNewState(movingState, std::vector<std::function<bool()>> {[&shouldBeInIdle] { return !shouldBeInIdle;  }});
 
-  idleState->setFrames(idleFrames);
+  idleState->frames() = idleFrames;
 
 
-  movingState->setShouldLoop(true);
-  movingState->insertNewState(idleState, std::vector<std::function<bool()>> {[] {return shouldBeInIdle;  }});
+  movingState->shouldLoop() = true;
+  movingState->insertNewState(idleState, std::vector<std::function<bool()>> {[&shouldBeInIdle] {return shouldBeInIdle;  }});
 
   auto movingFrames = std::vector<NovelRT::Animation::SpriteAnimatorFrame>();
 
   for (int32_t i = 0; i < 5; i++) {
     auto frame = NovelRT::Animation::SpriteAnimatorFrame();
-    frame.setDuration(0.1f);
-    frame.setTexture(runner.getRenderer().lock()->getTexture((imagesDirPath / "right" / ("100-" + std::to_string(i) + ".png")).string()));
+    frame.duration() = NovelRT::Timing::Timestamp(0.1f);
+    frame.texture() = runner.getRenderer().lock()->getTexture((imagesDirPath / "right" / ("100-" + std::to_string(i) + ".png")).string());
     movingFrames.push_back(frame);
   }
 
-  movingFrames.back().FrameExit += [] { shouldBeInIdle = true; };
+  movingFrames.back().FrameExit += [&shouldBeInIdle] { shouldBeInIdle = true; };
 
-  movingState->setFrames(movingFrames);
+  movingState->frames() = movingFrames;
 
 
 

--- a/src/NovelRT/Animation/SpriteAnimator.cpp
+++ b/src/NovelRT/Animation/SpriteAnimator.cpp
@@ -28,7 +28,7 @@ namespace NovelRT::Animation {
 
         if (transitionPtr != nullptr) {
           _currentState = transitionPtr;
-          _accumulatedDelta = 0.0f;
+          _accumulatedDelta = Timing::Timestamp::zero();
           _currentFrameIndex = 0;
           _currentState->frames().at(_currentFrameIndex).FrameEnter();
         }
@@ -48,8 +48,7 @@ namespace NovelRT::Animation {
           newFrame.FrameEnter();
         }
 
-
-        _accumulatedDelta += delta.getSecondsFloat();
+        _accumulatedDelta += delta;
         break;
       }
 

--- a/src/NovelRT/Animation/SpriteAnimator.cpp
+++ b/src/NovelRT/Animation/SpriteAnimator.cpp
@@ -4,7 +4,7 @@
 
 namespace NovelRT::Animation {
   SpriteAnimator::SpriteAnimator(NovelRunner* runner, Graphics::ImageRect* rect) noexcept :
-    _accumulatedDelta(0.0f),
+    _accumulatedDelta(0),
     _currentFrameIndex(0),
     _runner(runner),
     _rect(rect),
@@ -34,7 +34,7 @@ namespace NovelRT::Animation {
         }
 
         if (_currentState->frames().size() > _currentFrameIndex && _currentState->frames().at(_currentFrameIndex).duration() <= _accumulatedDelta) {
-          _accumulatedDelta = 0;
+          _accumulatedDelta = Timing::Timestamp(0);
           _currentState->frames().at(_currentFrameIndex++).FrameExit();
 
           if (_currentState->shouldLoop() && _currentFrameIndex >= _currentState->frames().size()) {
@@ -70,7 +70,7 @@ namespace NovelRT::Animation {
   void SpriteAnimator::stop() {
     _runner->Update -= _animationUpdateHandle;
     _animatorState = AnimatorPlayState::Stopped;
-    _accumulatedDelta = 0;
+    _accumulatedDelta = Timing::Timestamp(0);
     _currentFrameIndex = 0;
   }
 }

--- a/tests/NovelRT.Tests/Timing/TimestampTest.cpp
+++ b/tests/NovelRT.Tests/Timing/TimestampTest.cpp
@@ -14,7 +14,7 @@ protected:
     _timestamp = Timestamp(TicksPerSecond);
   }
 public:
-  TimestampTest() : _timestamp(Timestamp(0ULL)) {}
+  TimestampTest() : _timestamp(Timestamp(0)) {}
 };
 
 TEST_F(TimestampTest, GetTicksShouldReturnCorrectValue) {
@@ -30,47 +30,47 @@ TEST_F(TimestampTest, GetSecondsFloatShouldReturnCorrectValue) {
 }
 
 TEST_F(TimestampTest, AddOperatorAddsCorrectly) {
-  auto result = Timestamp(0ULL) + Timestamp(1ULL);
-  ASSERT_EQ(result.getTicks(), 1ULL);
+  auto result = Timestamp(0) + Timestamp(1);
+  ASSERT_EQ(result.getTicks(), 1);
 }
 
 TEST_F(TimestampTest, SubtractOperatorSubtractsCorrectly) {
-  auto result = Timestamp(1ULL) - Timestamp(1ULL);
-  ASSERT_EQ(result.getTicks(), 0ULL);
+  auto result = Timestamp(1) - Timestamp(1);
+  ASSERT_EQ(result.getTicks(), 0);
 }
 
 TEST_F(TimestampTest, MultiplyOperatorMultipliesCorrectly) {
-  auto result = Timestamp(2ULL) * Timestamp(2ULL);
-  ASSERT_EQ(result.getTicks(), 4ULL);
+  auto result = Timestamp(2) * Timestamp(2);
+  ASSERT_EQ(result.getTicks(), 4);
 }
 
 TEST_F(TimestampTest, DivideOperatorDividesCorrectly) {
-  auto result = Timestamp(2ULL) / Timestamp(2ULL);
-  ASSERT_EQ(result.getTicks(), 1ULL);
+  auto result = Timestamp(2) / Timestamp(2);
+  ASSERT_EQ(result.getTicks(), 1);
 }
 
 TEST_F(TimestampTest, AddAssignOperatorAddsAndAssignsCorrectly) {
-  auto result = Timestamp(0ULL);
-  result += Timestamp(1ULL);
-  ASSERT_EQ(result.getTicks(), 1ULL);
+  auto result = Timestamp(0);
+  result += Timestamp(1);
+  ASSERT_EQ(result.getTicks(), 1);
 }
 
 TEST_F(TimestampTest, SubtractAssignOperatorSubtractsAndAssignsCorrectly) {
-  auto result = Timestamp(1ULL);
-  result -= Timestamp(1ULL);
-  ASSERT_EQ(result.getTicks(), 0ULL);
+  auto result = Timestamp(1);
+  result -= Timestamp(1);
+  ASSERT_EQ(result.getTicks(), 0);
 }
 
 TEST_F(TimestampTest, MultiplyAssignOperatorMultipliesAndAssignsCorrectly) {
-  auto result = Timestamp(2ULL);
-  result *= Timestamp(2ULL);
-  ASSERT_EQ(result.getTicks(), 4ULL);
+  auto result = Timestamp(2);
+  result *= Timestamp(2);
+  ASSERT_EQ(result.getTicks(), 4);
 }
 
 TEST_F(TimestampTest, DivideAssignOperatorDividesAndAssignsCorrectly) {
-  auto result = Timestamp(2ULL);
-  result /= Timestamp(2ULL);
-  ASSERT_EQ(result.getTicks(), 1ULL);
+  auto result = Timestamp(2);
+  result /= Timestamp(2);
+  ASSERT_EQ(result.getTicks(), 1);
 }
 
 TEST_F(TimestampTest, EqualityOperatorEvaluatesCorrectly) {
@@ -78,5 +78,5 @@ TEST_F(TimestampTest, EqualityOperatorEvaluatesCorrectly) {
 }
 
 TEST_F(TimestampTest, InequalityOperatorEvaluatesCorrectly) {
-  ASSERT_NE(_timestamp, Timestamp(0ULL));
+  ASSERT_NE(_timestamp, Timestamp(0));
 }

--- a/tests/NovelRT.Tests/Timing/TimestampTest.cpp
+++ b/tests/NovelRT.Tests/Timing/TimestampTest.cpp
@@ -14,7 +14,7 @@ protected:
     _timeStamp = Timestamp(TicksPerSecond);
   }
 public:
-  TimestampTest() : _timeStamp(Timestamp(uint64_t(0))) {}
+  TimestampTest() : _timeStamp(Timestamp(0ULL)) {}
 };
 
 TEST_F(TimestampTest, GetTicksShouldReturnCorrectValue) {
@@ -27,4 +27,48 @@ TEST_F(TimestampTest, GetSecondsDoubleShouldReturnCorrectValue) {
 
 TEST_F(TimestampTest, GetSecondsFloatShouldReturnCorrectValue) {
   ASSERT_FLOAT_EQ(_timeStamp.getSecondsFloat(), 1.0f);
+}
+
+TEST_F(TimestampTest, AddOperatorAddsCorrectly) {
+  auto result = Timestamp(0ULL) + Timestamp(1ULL);
+  ASSERT_EQ(result.getTicks(), 1ULL);
+}
+
+TEST_F(TimestampTest, SubtractOperatorSubtractsCorrectly) {
+  auto result = Timestamp(1ULL) - Timestamp(1ULL);
+  ASSERT_EQ(result.getTicks(), 0ULL);
+}
+
+TEST_F(TimestampTest, MultiplyOperatorMultipliesCorrectly) {
+  auto result = Timestamp(2ULL) * Timestamp(2ULL);
+  ASSERT_EQ(result.getTicks(), 4ULL);
+}
+
+TEST_F(TimestampTest, DivideOperatorDividesCorrectly) {
+  auto result = Timestamp(2ULL) / Timestamp(2ULL);
+  ASSERT_EQ(result.getTicks(), 1ULL);
+}
+
+TEST_F(TimestampTest, AddAssignOperatorAddsAndAssignsCorrectly) {
+  auto result = Timestamp(0ULL);
+  result += Timestamp(1ULL);
+  ASSERT_EQ(result.getTicks(), 1ULL);
+}
+
+TEST_F(TimestampTest, SubtractAssignOperatorSubtractsAndAssignsCorrectly) {
+  auto result = Timestamp(1ULL);
+  result -= Timestamp(1ULL);
+  ASSERT_EQ(result.getTicks(), 0ULL);
+}
+
+TEST_F(TimestampTest, MultiplyAssignOperatorMultipliesAndAssignsCorrectly) {
+  auto result = Timestamp(2ULL);
+  result *= Timestamp(2ULL);
+  ASSERT_EQ(result.getTicks(), 4ULL);
+}
+
+TEST_F(TimestampTest, DivideAssignOperatorDividesAndAssignsCorrectly) {
+  auto result = Timestamp(2ULL);
+  result /= Timestamp(2ULL);
+  ASSERT_EQ(result.getTicks(), 1ULL);
 }

--- a/tests/NovelRT.Tests/Timing/TimestampTest.cpp
+++ b/tests/NovelRT.Tests/Timing/TimestampTest.cpp
@@ -8,25 +8,25 @@ using namespace NovelRT::Timing;
 
 class TimestampTest : public testing::Test {
 protected:
-  Timestamp _timeStamp;
+  Timestamp _timestamp;
 
   void SetUp() override {
-    _timeStamp = Timestamp(TicksPerSecond);
+    _timestamp = Timestamp(TicksPerSecond);
   }
 public:
-  TimestampTest() : _timeStamp(Timestamp(0ULL)) {}
+  TimestampTest() : _timestamp(Timestamp(0ULL)) {}
 };
 
 TEST_F(TimestampTest, GetTicksShouldReturnCorrectValue) {
-  ASSERT_EQ(_timeStamp.getTicks(), TicksPerSecond);
+  ASSERT_EQ(_timestamp.getTicks(), TicksPerSecond);
 }
 
 TEST_F(TimestampTest, GetSecondsDoubleShouldReturnCorrectValue) {
-  ASSERT_DOUBLE_EQ(_timeStamp.getSecondsDouble(), 1.0);
+  ASSERT_DOUBLE_EQ(_timestamp.getSecondsDouble(), 1.0);
 }
 
 TEST_F(TimestampTest, GetSecondsFloatShouldReturnCorrectValue) {
-  ASSERT_FLOAT_EQ(_timeStamp.getSecondsFloat(), 1.0f);
+  ASSERT_FLOAT_EQ(_timestamp.getSecondsFloat(), 1.0f);
 }
 
 TEST_F(TimestampTest, AddOperatorAddsCorrectly) {
@@ -71,4 +71,12 @@ TEST_F(TimestampTest, DivideAssignOperatorDividesAndAssignsCorrectly) {
   auto result = Timestamp(2ULL);
   result /= Timestamp(2ULL);
   ASSERT_EQ(result.getTicks(), 1ULL);
+}
+
+TEST_F(TimestampTest, EqualityOperatorEvaluatesCorrectly) {
+  ASSERT_EQ(_timestamp, Timestamp(TicksPerSecond));
+}
+
+TEST_F(TimestampTest, InequalityOperatorEvaluatesCorrectly) {
+  ASSERT_NE(_timestamp, Timestamp(0ULL));
 }


### PR DESCRIPTION
This PR contains updates for the `SpriteAnimator` to use `Timing::Timestamp` instead of `float`.

Also adds support for common operators in `Timing::Timestamp`.