### PR TITLE
macOS Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ compile_commands.json
 CTestTestfile.cmake
 
 # End of https://www.gitignore.io/api/c++,cmake,clion
+
+# MacOS files
+*.DS_Store

--- a/include/NovelRT.h
+++ b/include/NovelRT.h
@@ -38,6 +38,10 @@
 #include <Windows.h>
 #endif
 
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
+
 //Freetype
 #include <ft2build.h>
 #include FT_FREETYPE_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,9 +19,14 @@ set(NOVELRT_LIB_LINK_LIBRARIES
   glfw
   glm
   OpenAL::OpenAL
-  png
   spdlog::spdlog_header_only
 )
+
+if (APPLE)
+  set(NOVELRT_LIB_LINK_LIBRARIES ${NOVELRT_LIB_LINK_LIBRARIES} png_static)
+else()
+  set(NOVELRT_LIB_LINK_LIBRARIES ${NOVELRT_LIB_LINK_LIBRARIES} png)
+endif()
 
 if (WIN32)
   set(NOVELRT_LIB_LINK_LIBRARIES ${NOVELRT_LIB_LINK_LIBRARIES} sndfile-shared)
@@ -47,9 +52,11 @@ link_libraries(${NETHOST_LIBRARY})
 
 if (WIN32)
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-else()
+elseif(UNIX AND NOT APPLE)
   link_libraries(m)
   link_libraries(stdc++fs)
+else()
+  link_libraries(m)
 endif()
 
 add_library(NovelRT SHARED ${NOVELRT_LIB_HEADERS} ${NOVELRT_LIB_SOURCES})

--- a/src/NovelRT/Graphics/RenderingService.cpp
+++ b/src/NovelRT/Graphics/RenderingService.cpp
@@ -57,10 +57,15 @@ namespace NovelRT::Graphics {
 
       glEnable(GL_BLEND);
       glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
+#if defined(__APPLE__)
+        _basicFillRectProgram = loadShaders("BasicVertexShader_Apple.glsl", "BasicFragmentShader_Apple.glsl");
+        _texturedRectProgram = loadShaders("TexturedVertexShader_Apple.glsl", "TexturedFragmentShader_Apple.glsl");
+        _fontProgram = loadShaders("FontVertexShader_Apple.glsl", "FontFragmentShader_Apple.glsl");
+#else
       _basicFillRectProgram = loadShaders("BasicVertexShader.glsl", "BasicFragmentShader.glsl");
       _texturedRectProgram = loadShaders("TexturedVertexShader.glsl", "TexturedFragmentShader.glsl");
       _fontProgram = loadShaders("FontVertexShader.glsl", "FontFragmentShader.glsl");
+#endif
     }
     else {
       _camera->forceResize(windowSize);

--- a/src/NovelRT/Utilities/Misc.cpp
+++ b/src/NovelRT/Utilities/Misc.cpp
@@ -26,6 +26,25 @@ namespace NovelRT::Utilities {
 
       path[pathLength] = L'\0';
       return path;
+#elif defined(__APPLE__)
+      char *path;
+      uint32_t pathLength = 0;
+      _NSGetExecutablePath(nullptr, &pathLength);
+      path = new char[pathLength];
+      if ((pathLength <= 0) || (pathLength >= PATH_MAX))
+      {
+          return std::filesystem::current_path();
+      }
+      
+      if (_NSGetExecutablePath(path, &pathLength) < 0)
+      {
+          return std::filesystem::current_path();
+      }
+      
+      char *actualPath = realpath(path, nullptr);
+      free(path);
+      
+      return std::string(actualPath).c_str();
 #else
       char path[PATH_MAX + 1];
       auto pathLength = readlink("/proc/self/exe", path, PATH_MAX);

--- a/src/NovelRT/Windowing/WindowingService.cpp
+++ b/src/NovelRT/Windowing/WindowingService.cpp
@@ -36,12 +36,27 @@ namespace NovelRT::Windowing {
       checkForOptimus(OptimusLibraryName);
 #endif
 
+      
+#if defined(__APPLE__)
+      _logger.logInfoLine("Attempting to create OpenGL 4.1 context");
+      glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+      glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+      glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
+      glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+      
+      auto window = glfwCreateWindow(wData, hData, windowTitle.c_str(), nullptr, nullptr);
+      if (window == nullptr)
+      {
+          _logger.throwIfNullPtr(window, "Failed to create OpenGL v4.1 context");
+      }
+#else
     _logger.logInfoLine("Attempting to create OpenGL ES v3.0 context using EGL API");
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_EGL_CONTEXT_API);
+
 
     auto window = glfwCreateWindow(wData, hData, windowTitle.c_str(), nullptr, nullptr);
 
@@ -66,9 +81,7 @@ namespace NovelRT::Windowing {
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
         glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GLFW_TRUE);
-        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-        glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
-
+        
 #ifndef NDEBUG
         glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
 #endif
@@ -77,7 +90,7 @@ namespace NovelRT::Windowing {
         _logger.throwIfNullPtr(window, "Failed to create OpenGL v4.3 context using native API");
       }
     }
-
+#endif
     _windowTitle = windowTitle;
     _logger.logInfo("Window succesfully created.");
 

--- a/src/Resources/Shaders/BasicFragmentShader_Apple.glsl
+++ b/src/Resources/Shaders/BasicFragmentShader_Apple.glsl
@@ -1,0 +1,8 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
+#version 330
+precision mediump float;
+in vec4 fragmentColour;
+out vec4 colour;
+void main(){
+    colour = fragmentColour;
+}

--- a/src/Resources/Shaders/BasicVertexShader_Apple.glsl
+++ b/src/Resources/Shaders/BasicVertexShader_Apple.glsl
@@ -1,0 +1,16 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
+#version 330
+
+layout(location = 0) in vec3 vertexPosition;
+layout(location = 1) in vec4 vertexColour;
+
+layout (std140) uniform finalViewMatrixBuffer {
+  mat4 modelViewProjection;
+};
+
+out vec4 fragmentColour;
+
+void main(){
+    gl_Position = vec4(vertexPosition, 1.0f) * modelViewProjection;
+    fragmentColour = vertexColour;
+}

--- a/src/Resources/Shaders/FontFragmentShader_Apple.glsl
+++ b/src/Resources/Shaders/FontFragmentShader_Apple.glsl
@@ -1,0 +1,16 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
+#version 330
+precision mediump float;
+out vec4 fragColor;
+
+in vec2 texCoord;
+in vec4 colourTint;
+
+uniform sampler2D ourTexture;
+
+void main()
+{
+    vec3 glyphColour = texture(ourTexture, texCoord).rgb;
+    float alpha = glyphColour.r;
+    fragColor = vec4(1, 1, 1, alpha)  * colourTint;
+}

--- a/src/Resources/Shaders/FontVertexShader_Apple.glsl
+++ b/src/Resources/Shaders/FontVertexShader_Apple.glsl
@@ -1,0 +1,20 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
+#version 330
+
+layout (location = 0) in vec3 vertexPosition;
+layout (location = 1) in vec2 aTexCoord;
+layout (location = 2) in vec4 aColourTint;
+
+layout (std140) uniform finalViewMatrixBuffer {
+  mat4 modelViewProjection;
+};
+
+out vec2 texCoord;
+out vec4 colourTint;
+
+void main()
+{
+    gl_Position = vec4(vertexPosition, 1.0) * modelViewProjection;
+    texCoord = aTexCoord;
+    colourTint = aColourTint;
+}

--- a/src/Resources/Shaders/TexturedFragmentShader_Apple.glsl
+++ b/src/Resources/Shaders/TexturedFragmentShader_Apple.glsl
@@ -1,0 +1,14 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
+#version 330
+precision mediump float;
+out vec4 fragColour;
+
+in vec2 texCoord;
+in vec4 colourTint;
+
+uniform sampler2D ourTexture;
+
+void main()
+{
+    fragColour = texture(ourTexture, texCoord) * colourTint;
+}

--- a/src/Resources/Shaders/TexturedVertexShader_Apple.glsl
+++ b/src/Resources/Shaders/TexturedVertexShader_Apple.glsl
@@ -1,0 +1,20 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
+#version 330
+
+layout (location = 0) in vec3 vertexPosition;
+layout (location = 1) in vec2 aTexCoord;
+layout (location = 2) in vec4 aColourTint;
+
+layout (std140) uniform finalViewMatrixBuffer {
+  mat4 modelViewProjection;
+};
+
+out vec2 texCoord;
+out vec4 colourTint;
+
+void main()
+{
+    gl_Position = vec4(vertexPosition, 1.0) * modelViewProjection;
+    texCoord = aTexCoord;
+    colourTint = aColourTint;
+}


### PR DESCRIPTION
Merging this PR would introduce basic support for building NovelRT, its tests and samples for macOS 10.15 (Catalina).

- Based on OpenGL 4.1 Core
- Earlier macOS compatibility may/may not be feasible due to our inclusion of `std::filesystem` - this is only supported on 10.15 due to it being the first release that macOS includes `std::filesystem` in `libc++` (There are Mac-specific alternatives though that would allow earlier ones to work)
- Requires separate shaders due to version compatibility (more details in comments)