### PR TITLE
Add parentheses to suppress gcc warning, fixes #182

### DIFF
--- a/src/NovelRT/Maths/GeoBounds.cpp
+++ b/src/NovelRT/Maths/GeoBounds.cpp
@@ -28,7 +28,7 @@ namespace NovelRT::Maths {
     auto minB = otherBounds.position() - otherBounds.getExtents();
     auto maxB = otherBounds.position() + otherBounds.getExtents();
 
-    auto result = (minA > maxB) | (minB > maxA);
+    auto result = (minA > maxB) || (minB > maxA);
     return result;
   }
 

--- a/src/NovelRT/Maths/GeoBounds.cpp
+++ b/src/NovelRT/Maths/GeoBounds.cpp
@@ -28,7 +28,7 @@ namespace NovelRT::Maths {
     auto minB = otherBounds.position() - otherBounds.getExtents();
     auto maxB = otherBounds.position() + otherBounds.getExtents();
 
-    auto result = minA > maxB | minB > maxA;
+    auto result = (minA > maxB) | (minB > maxA);
     return result;
   }
 


### PR DESCRIPTION
This fixes #182 by adding parentheses to suppress the annoying gcc warning which resulted in a failed build.