### PR TITLE
Fix FontSet not storing its own font size

### DIFF
--- a/src/NovelRT/Graphics/FontSet.cpp
+++ b/src/NovelRT/Graphics/FontSet.cpp
@@ -77,6 +77,7 @@ namespace NovelRT::Graphics {
     FT_Done_Face(face);
     FT_Done_FreeType(freeTypeLoader);
     _fontFile = file;
+    _fontSize = fontSize;
 
   }
 


### PR DESCRIPTION
This fixes an issue where FontSet->getFontSize() will always return 0, because loadFontAsTextureSet() doesn't assign the `_fontSize` instance member.