### PR TITLE
Transparency and Background Colour changing support

### DIFF
--- a/include/NovelRT/Graphics/RenderingService.h
+++ b/include/NovelRT/Graphics/RenderingService.h
@@ -22,14 +22,14 @@ namespace NovelRT::Graphics {
     ShaderProgram _basicFillRectProgram;
     ShaderProgram _texturedRectProgram;
     ShaderProgram _fontProgram;
-
-    RGBAConfig _framebufferColour;
     
     Utilities::Lazy<GLuint> _cameraObjectRenderUbo;
     std::shared_ptr<Camera> _camera;
 
     std::map<Atom, std::weak_ptr<Texture>> _textureCache;
     std::map<Atom, std::weak_ptr<FontSet>> _fontCache;
+
+    RGBAConfig _framebufferColour;
 
     void bindCameraUboForProgram(GLuint shaderProgramId);
 
@@ -39,7 +39,6 @@ namespace NovelRT::Graphics {
   public:
     RenderingService(NovelRunner* const runner);
     int initialiseRendering();
-    
     void tearDown() const;
 
     std::unique_ptr<ImageRect> createImageRect(const Transform& transform, int layer, const std::string& filePath, const RGBAConfig& colourTint = RGBAConfig(255, 255, 255, 255));
@@ -55,7 +54,7 @@ namespace NovelRT::Graphics {
     void beginFrame() const;
     void endFrame() const;
 
-    void setBackgroundColour(const RGBAConfig colour);
+    void setBackgroundColour(const RGBAConfig& colour);
 
     std::shared_ptr<Texture> getTexture(const std::string& fileTarget = "");
     std::shared_ptr<FontSet> getFontSet(const std::string& fileTarget, float fontSize);

--- a/include/NovelRT/Graphics/RenderingService.h
+++ b/include/NovelRT/Graphics/RenderingService.h
@@ -23,6 +23,8 @@ namespace NovelRT::Graphics {
     ShaderProgram _texturedRectProgram;
     ShaderProgram _fontProgram;
 
+    RGBAConfig _framebufferColour;
+    
     Utilities::Lazy<GLuint> _cameraObjectRenderUbo;
     std::shared_ptr<Camera> _camera;
 
@@ -37,7 +39,7 @@ namespace NovelRT::Graphics {
   public:
     RenderingService(NovelRunner* const runner);
     int initialiseRendering();
-
+    
     void tearDown() const;
 
     std::unique_ptr<ImageRect> createImageRect(const Transform& transform, int layer, const std::string& filePath, const RGBAConfig& colourTint = RGBAConfig(255, 255, 255, 255));
@@ -52,6 +54,8 @@ namespace NovelRT::Graphics {
 
     void beginFrame() const;
     void endFrame() const;
+
+    void setBackgroundColour(const RGBAConfig colour);
 
     std::shared_ptr<Texture> getTexture(const std::string& fileTarget = "");
     std::shared_ptr<FontSet> getFontSet(const std::string& fileTarget, float fontSize);

--- a/include/NovelRT/NovelRunner.h
+++ b/include/NovelRT/NovelRunner.h
@@ -23,7 +23,6 @@ namespace NovelRT {
      * Use this to define game behaviour that is required to be done per-frame.
      */
     Utilities::Event<Timing::Timestamp> Update;
-    
   private:
     int _exitCode;
     Utilities::Lazy<std::unique_ptr<Timing::StepTimer>> _stepTimer;

--- a/include/NovelRT/NovelRunner.h
+++ b/include/NovelRT/NovelRunner.h
@@ -23,7 +23,7 @@ namespace NovelRT {
      * Use this to define game behaviour that is required to be done per-frame.
      */
     Utilities::Event<Timing::Timestamp> Update;
-
+    
   private:
     int _exitCode;
     Utilities::Lazy<std::unique_ptr<Timing::StepTimer>> _stepTimer;
@@ -43,7 +43,7 @@ namespace NovelRT {
      * @param windowTitle The title of the window created for NovelRunner.
      * @param targetFrameRate The framerate that should be targeted and capped.
      */
-    explicit NovelRunner(int displayNumber, const std::string& windowTitle = "NovelRTTest", uint32_t targetFrameRate = 0);
+    explicit NovelRunner(int displayNumber, const std::string& windowTitle = "NovelRTTest", uint32_t targetFrameRate = 0, bool transparency = false);
     /**
      * Launches the NovelRT game loop. This method will block until the game terminates.
      * @returns Exit code.

--- a/include/NovelRT/Windowing/WindowingService.h
+++ b/include/NovelRT/Windowing/WindowingService.h
@@ -35,7 +35,7 @@ namespace NovelRT::Windowing {
   public:
     explicit WindowingService(NovelRunner* const runner);
 
-    void initialiseWindow(int displayNumber, const std::string& windowTitle);
+    void initialiseWindow(int displayNumber, const std::string& windowTitle, bool transparencyEnabled);
     void tearDown();
 
     inline GLFWwindow* getWindow() const {

--- a/src/NovelRT/Graphics/RenderingService.cpp
+++ b/src/NovelRT/Graphics/RenderingService.cpp
@@ -15,7 +15,8 @@ namespace NovelRT::Graphics {
       glBindBufferRange(GL_UNIFORM_BUFFER, 0, tempHandle, 0, sizeof(Maths::GeoMatrix4x4<float>));
       return tempHandle;
     })),
-    _camera(nullptr) {
+    _camera(nullptr),
+    _framebufferColour(RGBAConfig(0,0,0,0)) {
       auto ptr = _runner->getWindowingService();
       if(!ptr.expired()) ptr.lock()->WindowResized += ([this](auto input) {
         initialiseRenderPipeline(false, &input);
@@ -190,7 +191,7 @@ namespace NovelRT::Graphics {
 
   void RenderingService::beginFrame() const {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-    glClearColor(0.0f, 0.0f, 0.4f, 0.0f);
+    glClearColor(_framebufferColour.getRScalar(), _framebufferColour.getGScalar(), _framebufferColour.getBScalar(), _framebufferColour.getAScalar());
     _camera->initialiseCameraForFrame();
   }
 
@@ -278,5 +279,10 @@ namespace NovelRT::Graphics {
     _fontCache.emplace(returnValue->getId(), std::weak_ptr<FontSet>(returnValue));
     returnValue->loadFontAsTextureSet(fileTarget, fontSize);
     return returnValue;
+  }
+
+  void RenderingService::setBackgroundColour(const RGBAConfig colour)
+  {
+    _framebufferColour = colour;
   }
 }

--- a/src/NovelRT/Graphics/RenderingService.cpp
+++ b/src/NovelRT/Graphics/RenderingService.cpp
@@ -16,7 +16,7 @@ namespace NovelRT::Graphics {
       return tempHandle;
     })),
     _camera(nullptr),
-    _framebufferColour(RGBAConfig(0,0,0,0)) {
+    _framebufferColour(RGBAConfig(0,0,102,255)) {
       auto ptr = _runner->getWindowingService();
       if(!ptr.expired()) ptr.lock()->WindowResized += ([this](auto input) {
         initialiseRenderPipeline(false, &input);
@@ -281,8 +281,7 @@ namespace NovelRT::Graphics {
     return returnValue;
   }
 
-  void RenderingService::setBackgroundColour(const RGBAConfig colour)
-  {
+  void RenderingService::setBackgroundColour(const RGBAConfig& colour) {
     _framebufferColour = colour;
   }
 }

--- a/src/NovelRT/NovelRunner.cpp
+++ b/src/NovelRT/NovelRunner.cpp
@@ -3,7 +3,7 @@
 #include <NovelRT.h>
 
 namespace NovelRT {
-  NovelRunner::NovelRunner(int displayNumber, const std::string& windowTitle, uint32_t targetFrameRate) :
+  NovelRunner::NovelRunner(int displayNumber, const std::string& windowTitle, uint32_t targetFrameRate, bool transparency) :
     SceneConstructionRequested(Utilities::Event<>()),
     Update(Utilities::Event<Timing::Timestamp>()),
     _exitCode(1),
@@ -20,7 +20,7 @@ namespace NovelRT {
        _loggingService.logError("GLFW ERROR: ", err);
       throw std::runtime_error("Unable to continue! Cannot start without a glfw window.");
     }
-    _novelWindowingService->initialiseWindow(displayNumber, windowTitle);
+    _novelWindowingService->initialiseWindow(displayNumber, windowTitle, transparency);
     _novelRenderer->initialiseRendering();
     _novelInteractionService->setScreenSize(_novelWindowingService->getWindowSize());
     _novelWindowingService->WindowTornDown += [this] { _exitCode = 0; };

--- a/src/NovelRT/Windowing/WindowingService.cpp
+++ b/src/NovelRT/Windowing/WindowingService.cpp
@@ -19,7 +19,7 @@ namespace NovelRT::Windowing {
     _logger.logError("Could not initialize GLFW: ", error);
   }
 
-  void WindowingService::initialiseWindow(int /*displayNumber*/, const std::string& windowTitle) {
+  void WindowingService::initialiseWindow(int /*displayNumber*/, const std::string& windowTitle, bool transparencyEnabled) {
     GLFWmonitor* primaryMonitor = glfwGetPrimaryMonitor();
     const GLFWvidmode* displayData = glfwGetVideoMode(primaryMonitor);
 
@@ -36,6 +36,11 @@ namespace NovelRT::Windowing {
       checkForOptimus(OptimusLibraryName);
 #endif
 
+    //Set Framebuffer Transparency
+   if (transparencyEnabled)
+   {
+     glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);
+   }
     _logger.logInfoLine("Attempting to create OpenGL ES v3.0 context using EGL API");
 
     glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);

--- a/src/NovelRT/Windowing/WindowingService.cpp
+++ b/src/NovelRT/Windowing/WindowingService.cpp
@@ -37,8 +37,7 @@ namespace NovelRT::Windowing {
 #endif
 
     //Set Framebuffer Transparency
-   if (transparencyEnabled)
-   {
+   if (transparencyEnabled) {
      glfwWindowHint(GLFW_TRANSPARENT_FRAMEBUFFER, GLFW_TRUE);
    }
     _logger.logInfoLine("Attempting to create OpenGL ES v3.0 context using EGL API");


### PR DESCRIPTION
This PR should allow for users to:
1) Define a custom background colour - if not, it will use a default colour of Black (0,0,0,0) or no colour (see below for significance)

2) Pass a bool flag to `NovelRunner` which tells if Framebuffer Transparency is enabled.
- It is important to note that the framebuffer will respect Alpha values and treat an RGBA value of (0,0,0,0) as having _no colour_, hence the framebuffer will be completely transparent if enabled.