### PR TITLE
Build tools: Write infrastructure to copy outputs between dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,11 @@ option(NOVELRT_BUILD_SAMPLES "Build NovelRT samples" ON)
 option(NOVELRT_BUILD_DOCUMENTATION "Build NovelRT documentation" ON)
 option(NOVELRT_BUILD_TESTS "Build NovelRT tests" ON)
 
+include(OutputCopyLocal)
+
 add_subdirectory(src)
+
+add_subdirectory(resources)
 
 if(NOVELRT_BUILD_SAMPLES)
   add_subdirectory(samples)
@@ -39,5 +43,3 @@ if(NOVELRT_BUILD_TESTS)
 
   add_subdirectory(tests)
 endif()
-
-add_subdirectory(resources)

--- a/cmake/FindGMock.cmake
+++ b/cmake/FindGMock.cmake
@@ -16,18 +16,6 @@ find_package(PkgConfig)
 pkg_check_modules(pc_gmock QUIET gmock)
 pkg_check_modules(pc_gmock_main QUIET gmock_main)
 
-if(WIN32 AND NOT DEFINED gmock_USE_DEBUG_BUILD)
-  if(CMAKE_BUILD_TYPE MATCHES "(Debug|DEBUG|debug)")
-    set(GMock_BUILD_TYPE DEBUG)
-  else()
-    set(GMock_BUILD_TYPE RELEASE)
-  endif()
-elseif(gmock_USE_DEBUG_BUILD)
-  set(GMock_BUILD_TYPE DEBUG)
-else()
-  set(GMock_BUILD_TYPE RELEASE)
-endif()
-
 set(GMock_DEFINITIONS ${pc_gmock_CFLAGS_OTHER})
 set(GMock_Main_DEFINITIONS ${pc_gmock_main_CFLAGS_OTHER})
 set(gmock_search_dir ${gmock_ROOT_DIR} $ENV{gmock_INSTALL_DIR})
@@ -38,43 +26,25 @@ find_path(GMock_INCLUDE_DIR gmock/gmock.h
 )
 
 find_library(
-  GMock_LIBRARY_DEBUG NAMES gmockd
+  GMock_LIBRARY NAMES gmock
   HINTS ${gmock_search_dir} ${pc_gmock_LIBDIR} ${pc_gmock_LIBRARY_DIRS}
   PATH_SUFFIXES lib bin
   ENV LIBRARY_PATH
 )
 
 find_library(
-  GMock_Main_LIBRARY_DEBUG NAMES gmock_maind
+  GMock_Main_LIBRARY NAMES gmock_main
   HINTS ${gmock_search_dir} ${pc_gmock_LIBDIR} ${pc_gmock_main_LIBDIR} ${pc_gmock_LIBRARY_DIRS}
   PATH_SUFFIXES lib bin
   ENV LIBRARY_PATH
 )
 
-find_library(
-  GMock_LIBRARY_RELEASE NAMES gmock
-  HINTS ${gmock_search_dir} ${pc_gmock_LIBDIR} ${pc_gmock_LIBRARY_DIRS}
-  PATH_SUFFIXES lib bin
-  ENV LIBRARY_PATH
-)
-
-find_library(
-  GMock_Main_LIBRARY_RELEASE NAMES gmock_main
-  HINTS ${gmock_search_dir} ${pc_gmock_LIBDIR} ${pc_gmock_main_LIBDIR} ${pc_gmock_LIBRARY_DIRS}
-  PATH_SUFFIXES lib bin
-  ENV LIBRARY_PATH
-)
-
-if(GMock_Main_LIBRARY_DEBUG OR GMock_Main_LIBRARY_RELEASE)
+if(GMock_Main_LIBRARY)
   set(GMock_Main_FOUND TRUE)
 endif()
 
-set(GMock_LIBRARIES_DEBUG ${GMock_LIBRARY_DEBUG})
-set(GMock_Main_LIBRARIES_DEBUG ${GMock_Main_LIBRARY_DEBUG})
-set(GMock_LIBRARIES_RELEASE ${GMock_LIBRARY_RELEASE})
-set(GMock_Main_LIBRARIES_RELEASE ${GMock_Main_LIBRARY_RELEASE})
-set(GMock_LIBRARIES ${GMock_LIBRARIES_${GMock_BUILD_TYPE}})
-set(GMock_Main_LIBRARIES ${GMock_Main_LIBRARIES_${GMock_BUILD_TYPE}})
+set(GMock_LIBRARIES ${GMock_LIBRARY})
+set(GMock_Main_LIBRARIES ${GMock_Main_LIBRARY})
 set(GMock_INCLUDE_DIRS ${GMock_INCLUDE_DIR})
 seT(GMock_VERSION ${pc_gmock_VERSION})
 

--- a/cmake/FindGTest.cmake
+++ b/cmake/FindGTest.cmake
@@ -16,18 +16,6 @@ find_package(PkgConfig)
 pkg_check_modules(pc_gtest QUIET gtest)
 pkg_check_modules(pc_gtest_main QUIET gtest_main)
 
-if(WIN32 AND NOT DEFINED gtest_USE_DEBUG_BUILD)
-  if(CMAKE_BUILD_TYPE MATCHES "(Debug|DEBUG|debug)")
-    set(GTest_BUILD_TYPE DEBUG)
-  else()
-    set(GTest_BUILD_TYPE RELEASE)
-  endif()
-elseif(gtest_USE_DEBUG_BUILD)
-  set(GTest_BUILD_TYPE DEBUG)
-else()
-  set(GTest_BUILD_TYPE RELEASE)
-endif()
-
 set(GTest_DEFINITIONS ${pc_gtest_CFLAGS_OTHER})
 set(GTest_Main_DEFINITIONS ${pc_gtest_main_CFLAGS_OTHER})
 set(gtest_search_dir ${gtest_ROOT_DIR} $ENV{gtest_INSTALL_DIR})
@@ -38,45 +26,25 @@ find_path(GTest_INCLUDE_DIR gtest/gtest.h
 )
 
 find_library(
-  GTest_LIBRARY_DEBUG NAMES gtestd
+  GTest_LIBRARY NAMES gtest
   HINTS ${gtest_search_dir} ${pc_gtest_LIBDIR} ${pc_gtest_LIBRARY_DIRS}
   PATH_SUFFIXES lib bin
   ENV LIBRARY_PATH
 )
 
 find_library(
-  GTest_Main_LIBRARY_DEBUG NAMES gtest_maind
+  GTest_Main_LIBRARY NAMES gtest_main
   HINTS ${gtest_search_dir} ${pc_gtest_LIBDIR} ${pc_gtest_main_LIBDIR} ${pc_gtest_LIBRARY_DIRS}
   PATH_SUFFIXES lib bin
   ENV LIBRARY_PATH
 )
 
-find_library(
-  GTest_LIBRARY_RELEASE NAMES gtest
-  HINTS ${gtest_search_dir} ${pc_gtest_LIBDIR} ${pc_gtest_LIBRARY_DIRS}
-  PATH_SUFFIXES lib bin
-  ENV LIBRARY_PATH
-)
-
-find_library(
-  GTest_Main_LIBRARY_RELEASE NAMES gtest_main
-  HINTS ${gtest_search_dir} ${pc_gtest_LIBDIR} ${pc_gtest_main_LIBDIR} ${pc_gtest_LIBRARY_DIRS}
-  PATH_SUFFIXES lib bin
-  ENV LIBRARY_PATH
-)
-
-if(GTest_Main_LIBRARY_DEBUG OR GTest_Main_LIBRARY_RELEASE)
+if(GTest_Main_LIBRARY)
   set(GTest_Main_FOUND TRUE)
 endif()
 
-set(GTest_LIBRARIES_DEBUG ${GTest_LIBRARY_DEBUG})
-set(GTest_Main_LIBRARIES_DEBUG ${GTest_Main_LIBRARY_DEBUG})
-
-set(GTest_LIBRARIES_RELEASE ${GTest_LIBRARY_RELEASE})
-set(GTest_Main_LIBRARIES_RELEASE ${GTest_Main_LIBRARY_RELEASE})
-
-set(GTest_LIBRARIES ${GTest_LIBRARIES_${GTest_BUILD_TYPE}})
-set(GTest_Main_LIBRARIES ${GTest_Main_LIBRARIES_${GTest_BUILD_TYPE}})
+set(GTest_LIBRARIES ${GTest_LIBRARY})
+set(GTest_Main_LIBRARIES ${GTest_Main_LIBRARY})
 set(GTest_INCLUDE_DIRS ${GTest_INCLUDE_DIR})
 seT(GTest_VERSION ${pc_gtest_VERSION})
 

--- a/cmake/OutputCopyLocal.cmake
+++ b/cmake/OutputCopyLocal.cmake
@@ -1,0 +1,234 @@
+define_property(TARGET
+  PROPERTY INTERFACE_COPY_LOCAL
+  BRIEF_DOCS "Copy the outputs of this target to any dependents of this target."
+  FULL_DOCS "Copy the outputs of this target to any dependents of this target."
+)
+
+define_property(TARGET
+  PROPERTY COPY_LOCAL
+  BRIEF_DOCS "Copy the outputs of this target to any dependents of this target."
+  FULL_DOCS "Copy the outputs of this target to any dependents of this target."
+)
+
+define_property(TARGET
+  PROPERTY ADDITIONAL_COPY_LOCAL_FILES
+  BRIEF_DOCS "Additional files to copy to dependents of this target."
+  FULL_DOCS "Additional files to copy to dependents of this target."
+)
+
+define_property(TARGET
+  PROPERTY ADDITIONAL_COPY_LOCAL_FILES_DESTINATION
+  BRIEF_DOCS "Location to copy ADDITIONAL_COPY_LOCAL_FILES to."
+  FULL_DOCS "Location to copy ADDITIONAL_COPY_LOCAL_FILES to."
+)
+
+function(add_copy_local_targets target dependency)
+  get_target_property(copy_local ${dependency} COPY_LOCAL)
+  get_target_property(interface_copy_local ${dependency} INTERFACE_COPY_LOCAL)
+  get_target_property(copy_local_files ${dependency} ADDITIONAL_COPY_LOCAL_FILES)
+  get_target_property(copy_local_files_destination ${dependency} ADDITIONAL_COPY_LOCAL_FILES_DESTINATION)
+  get_target_property(copy_local_libs ${dependency} _COPY_LOCAL_LIBS)
+  get_target_property(source_location ${dependency} BINARY_DIR)
+  get_target_property(target_location ${target} BINARY_DIR)
+
+  if(NOT copy_local)
+    set(copy_local ${interface_copy_local})
+  endif()
+
+  if(copy_local AND ${copy_local})
+    # Maintain a list of targets to copy local after the build is completed
+
+    get_target_property(imported ${dependency} IMPORTED)
+
+    if(imported)
+      get_target_property(configurations ${dependency} IMPORTED_CONFIGURATIONS)
+
+      if(configurations)
+        foreach(configuration ${configurations})
+          get_target_property(location ${dependency} IMPORTED_LOCATION_${configuration})
+
+          if(location)
+            if(target_file)
+              set(target_file "$<IF:$<CONFIG:${configuration}>,${location},${target_file}>")
+            else()
+              # Use this configuration as a fallback.
+              set(target_file "${location}")
+            endif()
+          endif()
+        endforeach()
+      endif()
+
+      if(NOT target_file)
+        get_target_property(target_file ${dependency} IMPORTED_LOCATION)
+      endif()
+    endif()
+
+    if(NOT target_file)
+      set(target_file "$<TARGET_FILE:${dependency}>")
+    endif()
+
+    if(copy_local_libs)
+      set_property(
+        TARGET ${target} APPEND
+        PROPERTY _COPY_LOCAL_LIBS ${target_file} ${copy_local_libs}
+      )
+    else()
+      set_property(
+        TARGET ${target} APPEND
+        PROPERTY _COPY_LOCAL_LIBS ${target_file}
+      )
+    endif()
+  endif()
+
+  if(copy_local_files)
+    # Identify directories to create
+    set(directories_to_create)
+    foreach(file ${copy_local_files})
+      file(RELATIVE_PATH relpath "${source_location}" "${file}")
+      get_filename_component(directory "${relpath}" DIRECTORY)
+
+      if(directory)
+        if(copy_local_files_destination)
+          set(directory "${copy_local_files_destination}/${directory}/")
+        endif()
+      elseif(copy_local_files_destination)
+        set(directory "${copy_local_files_destination}/")
+      endif()
+
+      list(APPEND directories_to_create "${target_location}/${directory}")
+    endforeach()
+
+    # Ensure we're only creating unique directories
+    list(REMOVE_DUPLICATES directories_to_create)
+
+    # Create those directories.
+    add_custom_command(
+      TARGET ${target} POST_BUILD
+      DEPENDS "${copy_local_file}"
+      COMMAND ${CMAKE_COMMAND} -E make_directory
+        ${directories_to_create}
+      VERBATIM
+    )
+
+    foreach(directory ${directories_to_create})
+      # Group files to copy by directory
+      if(copy_local_files_destination)
+        file(RELATIVE_PATH relpath "${target_location}/${copy_local_files_destination}" "${directory}")
+      else()
+        file(RELATIVE_PATH relpath "${target_location}/${copy_local_files_destination}" "${directory}")
+      endif()
+
+      set(files_to_copy)
+      foreach(file ${copy_local_files})
+        get_filename_component(dirname "${file}" DIRECTORY)
+        file(RELATIVE_PATH relpath2 "${source_location}" "${dirname}")
+        if("${relpath}" STREQUAL "${relpath2}")
+          list(APPEND files_to_copy "${file}")
+        endif()
+      endforeach()
+
+      # Copy the files for this directory.
+      add_custom_command(
+        TARGET ${target} POST_BUILD
+        DEPENDS "${copy_local_file}"
+        COMMAND ${CMAKE_COMMAND} -E copy
+          ${files_to_copy}
+          ${directory}
+        VERBATIM
+      )
+    endforeach()
+  endif()
+endfunction()
+
+macro(add_library name)
+  _add_library(${name} ${ARGN})
+
+  get_target_property(interface ${name} TYPE)
+  get_target_property(aliased ${name} ALIASED_TARGET)
+
+  if(NOT "${interface}" STREQUAL "INTERFACE_LIBRARY")
+    unset(interface)
+  endif()
+
+  # Libraries should likely be copied locally by default.
+
+  # ALIAS libraries can't have set_target_properties called
+  if(NOT aliased)
+    # Interface libraries have a whitelist on the property names which can be set.
+    if(interface)
+      set_target_properties(${name}
+        PROPERTIES
+          INTERFACE_COPY_LOCAL TRUE
+      )
+    else()
+      set_target_properties(${name}
+        PROPERTIES
+          COPY_LOCAL TRUE
+      )
+    endif()
+  endif()
+
+  unset(interface)
+  unset(aliased)
+endmacro()
+
+macro(add_executable name)
+  _add_executable(${name} ${ARGN})
+
+  get_target_property(imported ${name} IMPORTED)
+  get_target_property(aliased ${name} ALIASED_TARGET)
+
+  # executables likely shouldn't be copied locally by default.
+  if(NOT aliased)
+    set_target_properties(${name}
+      PROPERTIES
+        COPY_LOCAL FALSE
+    )
+
+    # Imported targets cannot have custom commands added to them.
+    if(NOT imported)
+      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/CopyDependencies.cmake [[
+foreach(copy_file ${COPY_LOCAL_FILES})
+  get_filename_component(name "${copy_file}" NAME)
+  while(IS_SYMLINK "${copy_file}")
+    file(READ_SYMLINK "${copy_file}" link_dest)
+    if(NOT IS_ABSOLUTE "${link_dest}")
+      get_filename_component(dir "${copy_file}" DIRECTORY)
+      set(link_dest "${dir}/${link_dest}")
+    endif()
+    set(copy_file "${link_dest}")
+  endwhile()
+  configure_file(${copy_file} ${DESTINATION}/${name} COPYONLY)
+endforeach()]])
+      add_custom_command(
+        TARGET ${name} POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+          -DCOPY_LOCAL_FILES=$<REMOVE_DUPLICATES:$<GENEX_EVAL:$<TARGET_PROPERTY:${name},_COPY_LOCAL_LIBS>>>
+          -DDESTINATION=$<TARGET_FILE_DIR:${name}>
+          -P ${CMAKE_CURRENT_BINARY_DIR}/CopyDependencies.cmake
+        VERBATIM
+      )
+    endif()
+  endif()
+
+  unset(imported)
+  unset(aliased)
+endmacro()
+
+macro(add_dependencies target)
+  foreach(dependency ${ARGN})
+    add_copy_local_targets(${target} ${dependency})
+  endforeach()
+
+  _add_dependencies(${target} ${ARGN})
+endmacro()
+
+macro(target_link_libraries target)
+  foreach(dependency ${ARGN})
+    if(TARGET ${dependency})
+      add_copy_local_targets(${target} ${dependency})
+    endif()
+  endforeach()
+
+  _target_link_libraries(${target} ${ARGN})
+endmacro()

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -14,13 +14,26 @@ set(RESOURCES_FILES
   Shaders/TexturedVertexShader.glsl
 )
 
+set(RESOURCES_OUTPUTS)
 foreach(resource ${RESOURCES_FILES})
-  configure_file(${resource} Resources/${resource} COPYONLY)
+  add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${resource}"
+    DEPENDS "${CMAKE_CURRENT_LIST_DIR}/${resource}"
+    COMMAND ${CMAKE_COMMAND} -E copy
+      "${CMAKE_CURRENT_LIST_DIR}/${resource}"
+      "${CMAKE_CURRENT_BINARY_DIR}/${resource}"
+    VERBATIM
+  )
+  list(APPEND RESOURCES_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/${resource}")
 endforeach()
 
-add_executable(Resources IMPORTED GLOBAL)
+add_custom_target(Resources
+  DEPENDS ${RESOURCES_OUTPUTS}
+)
+
 set_target_properties(Resources
   PROPERTIES
-    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/Resources/IF_YOU_SEE_THIS_YOU_TRIED_TO_RUN_THE_RESOURCES_TARGET
+    ADDITIONAL_COPY_LOCAL_FILES "${RESOURCES_OUTPUTS}"
+    ADDITIONAL_COPY_LOCAL_FILES_DESTINATION Resources
 )
 

--- a/samples/Simple/CMakeLists.txt
+++ b/samples/Simple/CMakeLists.txt
@@ -19,34 +19,3 @@ target_link_libraries(Simple
     Engine
     Lua::Lua
 )
-
-add_custom_command(
-  TARGET Simple POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_directory
-    $<TARGET_FILE_DIR:Dotnet>
-    $<TARGET_FILE_DIR:Simple>/dotnet
-)
-
-#this is pure hacky hotfix goodness. We need to figure out a better way to do this in the future.
-if(WIN32)
-  add_custom_command(
-    TARGET Simple POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-      $<TARGET_FILE_DIR:Simple>/dotnet/nethost.dll
-      $<TARGET_FILE_DIR:Simple>
-  )
-endif()
-
-add_custom_command(
-  TARGET Simple POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_directory
-    $<TARGET_FILE_DIR:Resources>
-    $<TARGET_FILE_DIR:Simple>/Resources
-)
-
-add_custom_command(
-  TARGET Simple POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_directory
-    $<TARGET_FILE_DIR:Engine>
-    $<TARGET_FILE_DIR:Simple>
-)

--- a/src/NovelRT.DotNet/CMakeLists.txt
+++ b/src/NovelRT.DotNet/CMakeLists.txt
@@ -6,8 +6,8 @@ set(OPTIONS
   /nologo
   /p:IntermediateOutputPath=${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dotnet_Build.dir/
   /p:MSBuildProjectExtensionsPath=${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dotnet_Build.dir/
-  /p:OutDir=${CMAKE_CURRENT_BINARY_DIR}/
-  /p:PublishDir=${CMAKE_CURRENT_BINARY_DIR}/publish/
+  /p:OutDir=${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/Dotnet_Build.dir/
+  /p:PublishDir=${CMAKE_CURRENT_BINARY_DIR}/
 )
 
 execute_process(
@@ -17,38 +17,22 @@ execute_process(
 
 execute_process(
   COMMAND ${Dotnet_PROGRAM} msbuild ${CSPROJ} ${OPTIONS}
-    /t:GetCMakeOutputAssembly
-  OUTPUT_VARIABLE OUTPUT_ASSEMBLY
-)
-string(STRIP "${OUTPUT_ASSEMBLY}" OUTPUT_ASSEMBLY)
-
-execute_process(
-  COMMAND ${Dotnet_PROGRAM} msbuild ${CSPROJ} ${OPTIONS}
     /t:GetCMakeOutputByproducts
   OUTPUT_VARIABLE OUTPUT_BYPRODUCTS
 )
 string(STRIP "${OUTPUT_BYPRODUCTS}" OUTPUT_BYPRODUCTS)
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/publish)
-
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_ASSEMBLY}
-  BYPRODUCTS ${OUTPUT_BYPRODUCTS}
+  OUTPUT ${OUTPUT_BYPRODUCTS}
+  DEPENDS ${CSPROJ}
   COMMAND ${Dotnet_PROGRAM} msbuild ${CSPROJ} ${OPTIONS}
     /t:Build,Publish
+  VERBATIM
   COMMENT "Building .NET subproject"
 )
 
 add_custom_target(Dotnet_Build
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_ASSEMBLY}
-)
-
-add_executable(Dotnet IMPORTED GLOBAL)
-add_dependencies(Dotnet Dotnet_Build)
-set_target_properties(Dotnet
-  PROPERTIES
-    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/publish/IF_YOU_SEE_THIS_YOU_TRIED_TO_RUN_THE_DOTNET_TARGET
-)
+  DEPENDS ${OUTPUT_BYPRODUCTS})
 
 if(WIN32)
   set(nethost_lib "nethost.dll")
@@ -58,21 +42,24 @@ elseif(UNIX)
   set(nethost_lib "libnethost.so")
 endif()
 
-add_library(CoreCLR::nethost SHARED IMPORTED GLOBAL)
-set_target_properties(CoreCLR::nethost
+add_library(Dotnet SHARED IMPORTED GLOBAL)
+add_dependencies(Dotnet Dotnet_Build)
+set_target_properties(Dotnet
   PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}/publish"
-    IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/publish/${nethost_lib}"
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}"
+    IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/${nethost_lib}"
+    IMPORTED_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/nethost.h"
+    ADDITIONAL_COPY_LOCAL_FILES "${OUTPUT_BYPRODUCTS}"
+    ADDITIONAL_COPY_LOCAL_FILES_DESTINATION Dotnet
 )
 
 if(WIN32)
-  set_target_properties(CoreCLR::nethost
+  set_target_properties(Dotnet
     PROPERTIES
-      IMPORTED_IMPLIB "${CMAKE_CURRENT_BINARY_DIR}/publish/nethost.lib"
+      IMPORTED_IMPLIB "${CMAKE_CURRENT_BINARY_DIR}/nethost.lib"
   )
-# TODO: check if this is necessary on OS X too
 elseif(UNIX AND NOT APPLE)
-  set_target_properties(CoreCLR::nethost
+  set_target_properties(Dotnet
     PROPERTIES
       INTERFACE_LINK_LIBRARIES "dl"
   )

--- a/src/NovelRT/CMakeLists.txt
+++ b/src/NovelRT/CMakeLists.txt
@@ -69,6 +69,11 @@ target_include_directories(Engine
     $<INSTALL_INTERFACE:include>
 )
 
+set_target_properties(Engine
+  PROPERTIES
+    COPY_LOCAL TRUE
+)
+
 if(MSVC)
   target_compile_options(Engine
     PRIVATE
@@ -106,7 +111,7 @@ endif()
 
 target_link_libraries(Engine
   PUBLIC
-    CoreCLR::nethost
+    Dotnet
     Freetype::Freetype
     Glad::GLAD
     GLFW::GLFW3

--- a/tests/NovelRT.Tests/CMakeLists.txt
+++ b/tests/NovelRT.Tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy_directory
     $<TARGET_FILE_DIR:Dotnet>
     $<TARGET_FILE_DIR:Engine_Tests>/dotnet
+  VERBATIM
 )
 
 #this is pure hacky hotfix goodness. We need to figure out a better way to do this in the future.
@@ -52,6 +53,7 @@ if(WIN32)
     COMMAND ${CMAKE_COMMAND} -E copy
       $<TARGET_FILE_DIR:Engine_Tests>/dotnet/nethost.dll
       $<TARGET_FILE_DIR:Engine_Tests>
+    VERBATIM
   )
 endif()
 
@@ -60,6 +62,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy_directory
     $<TARGET_FILE_DIR:Engine>
     $<TARGET_FILE_DIR:Engine_Tests>
+  VERBATIM
 )
 
 


### PR DESCRIPTION
AKA: the missing piece

This should replace the weird vcpkg dependency script that's built in, and fix #209. In addition, this should also fix #208 as that was part of the same issue.

Not tested on Windows yet. As such, I'm expecting CI to fail.