### PR TITLE
Improved Event and EventHandler

### DIFF
--- a/include/NovelRT/Utilities/Event.h
+++ b/include/NovelRT/Utilities/Event.h
@@ -58,19 +58,19 @@ namespace NovelRT::Utilities {
       return _handlers.size();
     }
 
-    const EventHandler<TArgs...>& operator+=(const EventHandler<TArgs...>& handler) {
+    Atom operator+=(const EventHandler<TArgs...>& handler) {
       if (handler.getId() != Atom()) {
-        return _handlers.emplace_back(handler);
+        _handlers.emplace_back(handler);
       }
-      return handler;
+      return handler.getId();
     }
 
-    const EventHandler<TArgs...>& operator+=(const std::function<void(TArgs...)>& function) {
+    Atom operator+=(const std::function<void(TArgs...)>& function) {
       auto handler = EventHandler<TArgs...>(function);
       return *this += handler;
     }
 
-    const EventHandler<TArgs...>& operator+=(std::function<void(TArgs...)>&& function) {
+    Atom operator+=(std::function<void(TArgs...)>&& function) {
       auto handler = EventHandler<TArgs...>(function);
       return *this += handler;
     }

--- a/include/NovelRT/Utilities/Event.h
+++ b/include/NovelRT/Utilities/Event.h
@@ -19,13 +19,13 @@ namespace NovelRT::Utilities {
     }
 
     explicit EventHandler(std::function<void(TArgs...)>&& function) :
-    _id((function != nullptr) ? Atom::getNextEventHandlerId() : Atom()),
-    _function(std::move(function)) {
+      _id((function != nullptr) ? Atom::getNextEventHandlerId() : Atom()),
+      _function(std::move(function)) {
     }
 
     explicit EventHandler(const std::function<void(TArgs...)>& function) :
-    _id((function != nullptr) ? Atom::getNextEventHandlerId() : Atom()),
-    _function(function) {
+      _id((function != nullptr) ? Atom::getNextEventHandlerId() : Atom()),
+      _function(function) {
     }
 
     void operator()(TArgs... args) const {


### PR DESCRIPTION
Introduced move semantics and a `remove` method to remove `EventHandler` by their ids.
The API is a bit dirty (i think) so this will be a draft for now.

* All `operator+=` of `Event` make use of perfect forwarding.
* `EventHandler` has also been modified to support perfect forwarding.
* A `remove(Atom)` method has been added to remove event handlers by their Atom, so you don't need to hold a reference to them.