### PR TITLE
Updated error handling. Fixed memory leaks.

### DIFF
--- a/include/NovelRT.Interop/NrtInteropErrorHandlingInternal.h
+++ b/include/NovelRT.Interop/NrtInteropErrorHandlingInternal.h
@@ -18,6 +18,7 @@ void Nrt_setErrMsgIsNotInitialisedInternal();
 void Nrt_setErrMsgIsArgumentOutOfRangeInternal();
 void Nrt_setErrMsgIsInvalidOperationInternal();
 void Nrt_setErrMsgIsCharacterNotFoundInternal();
+void Nrt_setErrMsgIsOutOfMemoryInternal();
 void Nrt_setErrMsgCustomInternal(const char* message);
 
 #ifdef __cplusplus

--- a/src/NovelRT.Interop/NrtInteropErrorHandlingInternal.cpp
+++ b/src/NovelRT.Interop/NrtInteropErrorHandlingInternal.cpp
@@ -14,6 +14,7 @@ const char* const errMsgIsNotInitialised = "Unable to continue! The service is c
 const char* const errMsgIsArgumentOutOfRange = "Unable to continue! The argument is out of range.";
 const char* const errMsgIsInvalidOperation = "Unable to continue! The current operation is invalid.";
 const char* const errMsgIsCharacterNotFound = "Unable to continue! The character can't be found.";
+const char* const errMsgIsOutOfMemory = "Insufficient memory to continue the execution of the program.";
 const char* currentErrorMessage = nullptr;
 bool customMessageSet = false;
 
@@ -91,6 +92,11 @@ void Nrt_setErrMsgIsInvalidOperationInternal() {
 void Nrt_setErrMsgIsCharacterNotFoundInternal() {
   validateCustomMessageInternal();
   currentErrorMessage = errMsgIsCharacterNotFound;
+}
+
+void Nrt_setErrMsgIsOutOfMemoryInternal() {
+  validateCustomMessageInternal();
+  currentErrorMessage = errMsgIsOutOfMemory;
 }
 
 void Nrt_setErrMsgCustomInternal(const char* message) {

--- a/src/NovelRT.Interop/Utilities/NrtMisc.cpp
+++ b/src/NovelRT.Interop/Utilities/NrtMisc.cpp
@@ -70,7 +70,7 @@ const char* Nrt_appendFilePath(int32_t numberOfArgs, ...) {
 #if defined(WIN32)
   finalPath = static_cast<char*>(malloc(finalString.length() + 1));
 
-  if(strlen(finalPath) < (finalString.length() + 1)) {
+  if(finalPath == nullptr) {
     Nrt_setErrMsgIsOutOfMemoryInternal();
     return NULL;
   }
@@ -78,7 +78,7 @@ const char* Nrt_appendFilePath(int32_t numberOfArgs, ...) {
   strcpy_s(finalPath, finalString.length() + 1, finalString.c_str());
 #else
   finalPath = strdup(finalString.c_str());
-  if(strlen(finalPath) == nullptr) {
+  if(finalPath == nullptr) {
     Nrt_setErrMsgIsOutOfMemoryInternal();
     return NULL;
   }

--- a/src/NovelRT.Interop/Utilities/NrtMisc.cpp
+++ b/src/NovelRT.Interop/Utilities/NrtMisc.cpp
@@ -12,10 +12,10 @@ extern "C" {
 
 const char* Nrt_getExecutablePath() {
   std::string cppPath = std::string(NovelRT::Utilities::Misc::getExecutablePath().string());
-  size_t length = cppPath.length() + 1;
   char* returnPtr = nullptr;
 
   #ifdef WIN32
+  size_t length = cppPath.length() + 1;
   returnPtr = static_cast<char*>(malloc(length));
   strcpy_s(returnPtr, length, cppPath.c_str());
   #else
@@ -27,10 +27,10 @@ const char* Nrt_getExecutablePath() {
 
 const char* Nrt_getExecutableDirPath() {
   std::string cppPath = std::string(NovelRT::Utilities::Misc::getExecutableDirPath().string());
-  size_t length = cppPath.length() + 1;
   char* returnPtr = nullptr;
 
   #ifdef WIN32
+  size_t length = cppPath.length() + 1;
   returnPtr = static_cast<char*>(malloc(length));
   strcpy_s(returnPtr, length, cppPath.c_str());
   #else
@@ -64,7 +64,7 @@ const char* Nrt_appendFilePath(int32_t numberOfArgs, ...) {
     }
   }
   va_end(args);
-  
+
   char* finalPath = nullptr;
 //strcpy_s is not included by all compilers that don't have __STDC_LIB_EXT1__ available, including clang.
 #if defined(WIN32)

--- a/src/NovelRT.Interop/Utilities/NrtMisc.cpp
+++ b/src/NovelRT.Interop/Utilities/NrtMisc.cpp
@@ -64,10 +64,11 @@ const char* Nrt_appendFilePath(int32_t numberOfArgs, ...) {
     }
   }
   va_end(args);
-
+  
+  char* finalPath = nullptr;
 //strcpy_s is not included by all compilers that don't have __STDC_LIB_EXT1__ available, including clang.
 #if defined(WIN32)
-  char* finalPath = static_cast<char*>(malloc(finalString.length() + 1));
+  finalPath = static_cast<char*>(malloc(finalString.length() + 1));
 
   if(strlen(finalPath) < (finalString.length() + 1)) {
     Nrt_setErrMsgIsOutOfMemoryInternal();


### PR DESCRIPTION
This fixes some memory leaks I found in the C API today while also retaining their original behaviour of moving ownership to the calling code.

This should allow people to `free()` the strings as needed now.