### PR TITLE
hotfix: fix dotnet service compilation by explicitly casting ints to bytes

### DIFF
--- a/src/NovelRT.DotNet/InkService.cs
+++ b/src/NovelRT.DotNet/InkService.cs
@@ -67,7 +67,7 @@ namespace NovelRT.DotNet
         private static byte Story_GetCanContinue(IntPtr storyHandle)
         {
             var story = RuntimeService.ResolveHandle<Story>(storyHandle);
-            return story.canContinue ? 1 : 0;
+            return story.canContinue ? (byte)1 : (byte)0;
         }
 
         [UnmanagedCallersOnly]


### PR DESCRIPTION
since https://github.com/dotnet/roslyn/pull/50755 got merged, the changed code now properly infers the resulting expression type to be of type int, so that the explicit conversion is required.