### PR TITLE
Add conan install task for Visual studio and update readme for steps

### DIFF
--- a/.vs/tasks.vs.json
+++ b/.vs/tasks.vs.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.1",
+  "tasks": [
+    {
+      "taskLabel": "conan install windows-vs2019-amd64",
+      "appliesTo": "conanfile.txt",
+      "type": "launch",
+      "command": "${env.COMSPEC}",
+      "args": [
+        "cd build & conan install .. --build=missing --profile windows-vs2019-amd64"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ cmake ..
 cmake --build . -j
 ```
 
+#### Visual studio 2019 specific instructions
+
+When you open the NovelRT folder in VS2019 for the first time the CMakeSettings.json file will contain incorrect values.
+Change the buildRoot value to `${projectDir}\\build` and the installRoot to `${projectDir}\\install` and restart Visual Studio this will make sure that it uses the same build path as the CLI commands.
+You can delete the `out` folder in the NovelRT root as well as we won't use it anymore.
+Afterwards right click on the `conanfile.txt` file in the root and click the `Run conan install windows-vs2019-amd64` option.
+This runs the conan install command from the section above to regenerate the files we need to build with cmake as Visual Studio wiped the output from earlier.
+Then regenerate the cmake by clicking regenerate on the yellow warning ribbon on the top of Visual Studio.
+
 ## Example
 Examples will be placed here when we have created some. In the meantime, we advise asking us directly on our discord (invite URL above and below).
 


### PR DESCRIPTION
This PR adds a file in the .vs folder called tasks.vs.json
The addition of this file makes it easier for new people that use Visual Studio as they will already have the changes in place to run `conan install` from VS as VS automatically wipes the build folder.

The readme also has a subheader added to it specifically for Visual Studio 2019 that explains the steps needed for VS.

The original Windows CLI steps should still be followed initially otherwise either the build directory won't exists or we don't know for sure if the conan install command can be executed properly.

The addition of this file is technically an antipattern since it is an IDE specific file, so that is something to be aware of before merging the file. The benefit however is that it makes it much simpler for new people that don't know much about the Visual Studio pipeline to set up their development environment.