### PR TITLE
[WIP] Add additional diagnostics

### DIFF
--- a/include/NovelRT/DebugService.h
+++ b/include/NovelRT/DebugService.h
@@ -16,6 +16,7 @@ namespace NovelRT
     private:
         std::shared_ptr<Graphics::RenderingService> _renderingService;
         std::unique_ptr<Graphics::TextRect> _fpsCounter;
+        std::unique_ptr<Graphics::TextRect> _shaderCounter;
         LoggingService _logging;
         uint32_t _framesPerSecond;
         uint32_t _minFramesPerSecond = 1000;
@@ -24,9 +25,14 @@ namespace NovelRT
         uint32_t _totalSeconds = 0;
         uint32_t _totalFrames = 0;
 
+        int32_t _vertexShadersLoaded = 0;
+        int32_t _fragmentShadersLoaded = 0;
+
         void updateFpsCounter();
 
         void onSceneConstruction();
+
+        void updateShaderCounter();
 
     public:
         DebugService(Utilities::Event<>& sceneConstructionEvent,
@@ -42,6 +48,11 @@ namespace NovelRT
         }
 
         void setFramesPerSecond(uint32_t framesPerSecond);
+
+        bool getIsShaderCounterVisible() const;
+        void setIsShaderCounterVisible(bool value);
+
+        void increaseLoadedShaderCount(bool isVertexShader);
     };
 } // namespace NovelRT
 #endif // NOVELRT_NOVELDEBUGSERVICE_H

--- a/include/NovelRT/DebugService.h
+++ b/include/NovelRT/DebugService.h
@@ -20,6 +20,7 @@ namespace NovelRT
         uint32_t _framesPerSecond;
         uint32_t _minFramesPerSecond = 1000;
         uint32_t _maxFramesPerSecond = 0;
+        uint32_t _lastTimeFpsDiagnosticsLogged = 0;
         uint32_t _totalSeconds = 0;
         uint32_t _totalFrames = 0;
 

--- a/include/NovelRT/Graphics/RenderingService.h
+++ b/include/NovelRT/Graphics/RenderingService.h
@@ -46,6 +46,8 @@ namespace NovelRT::Graphics
         int32_t initialiseRendering();
         void tearDown() const;
 
+        DebugService* debugService;
+
         std::unique_ptr<ImageRect> createImageRect(Transform transform,
                                                    int32_t layer,
                                                    const std::string& filePath,

--- a/samples/Simple/main.cpp
+++ b/samples/Simple/main.cpp
@@ -195,7 +195,10 @@ int main(int /*argc*/, char* /*argv*/[])
     inkInteractionRect = runner.getInteractionService()->createBasicInteractionRect(inkButtonTransform, -1);
     inkInteractionRect->subscribedKey() = NovelRT::Input::KeyCode::LeftMouseButton;
 
-    runner.getDebugService()->setIsFpsCounterVisible(true);
+
+    auto debugService = runner.getDebugService();
+    debugService->setIsFpsCounterVisible(true);
+    debugService->setIsShaderCounterVisible(true);
 
     runner.Update += [&](NovelRT::Timing::Timestamp delta) {
         const float rotationAmount = 45.0f;

--- a/src/NovelRT/DebugService.cpp
+++ b/src/NovelRT/DebugService.cpp
@@ -67,6 +67,7 @@ namespace NovelRT
             _fpsCounter->setActive(value);
         }
     }
+
     void DebugService::setFramesPerSecond(uint32_t framesPerSecond)
     {
         if (_framesPerSecond != framesPerSecond)
@@ -99,9 +100,15 @@ namespace NovelRT
             snprintf(fpsText, 64, "%u fps %u avg %u min %u max %u total", _framesPerSecond,
                      _totalFrames / _totalSeconds, _minFramesPerSecond, _maxFramesPerSecond, _totalFrames);
             _fpsCounter->setText(fpsText);
-            _logging.logInfo(fpsText);
+
+            if (_totalSeconds - _lastTimeFpsDiagnosticsLogged > 1)
+            {
+                _lastTimeFpsDiagnosticsLogged = _totalSeconds;
+                _logging.logInfo(fpsText);
+            }
         }
     }
+
     void DebugService::onSceneConstruction()
     {
         if (_fpsCounter == nullptr)

--- a/src/NovelRT/Graphics/RenderingService.cpp
+++ b/src/NovelRT/Graphics/RenderingService.cpp
@@ -145,6 +145,10 @@ namespace NovelRT::Graphics
             _logger.logError(std::string(&vertexShaderErrorMessage[0]));
             throw Exceptions::CompilationErrorException(vertexFileName, std::string(&vertexShaderErrorMessage[0]));
         }
+        else if (debugService != nullptr)
+        {
+            debugService->increaseLoadedShaderCount(true);
+        }
 
         // Compile Fragment Shader
         _logger.logInfo("Compiling shader: {}...", fragmentFileName);
@@ -161,6 +165,10 @@ namespace NovelRT::Graphics
             glGetShaderInfoLog(fragmentShaderId, infoLogLength, nullptr, &fragmentShaderErrorMessage[0]);
             _logger.logError(std::string(&fragmentShaderErrorMessage[0]));
             throw Exceptions::CompilationErrorException(fragmentFileName, std::string(&fragmentShaderErrorMessage[0]));
+        }
+        else if (debugService != nullptr)
+        {
+            debugService->increaseLoadedShaderCount(false);
         }
 
         // Link the program


### PR DESCRIPTION
This PR is to solve issue #30

Things to do for this PR:
- [x] Fix the current frame diagnostics not updating properly.
- [x] Add basic count of loaded shaders to diagnostics.
- [ ]  Add basic count of loaded objects in the scene.

Previously the fps counter wasn't updating if the FPS doesn't change, so if you permanently hit the vsync cap it would never update the total frames rendered/avg
The first commit in this PR takes care of this problem by changing the location of the updateFpsCounter call.

The second commit adds a way to trace the amount of shaders loaded into the system.
It is implemented in a push from the RenderingService to the DebugService to make sure that if we load a shader halfway through the runtime it will still be reflected and updated and not force us to update the shaderload text every frame.
This should save some if not a minor amount of processing power but make it responsive and update on the frame the new shader is loaded.