### PR TITLE
Porting the CAPI sample to the C# bindings side

### DIFF
--- a/include/NovelRT.Interop/Utilities/NrtMisc.h
+++ b/include/NovelRT.Interop/Utilities/NrtMisc.h
@@ -13,8 +13,8 @@ extern "C"
 
     const char* Nrt_getExecutablePath();
     const char* Nrt_getExecutableDirPath();
-    const char* Nrt_appendFilePath(int32_t numberOfArgs, ...);
-    const char* Nrt_appendText(int32_t numberOfArgs, ...);
+    const char* Nrt_appendFilePath(int32_t numberOfArgs, const char* const* args);
+    const char* Nrt_appendText(int32_t numberOfArgs, const char* const* args);
 
 #ifdef __cplusplus
 }

--- a/samples/CAPI/main.c
+++ b/samples/CAPI/main.c
@@ -152,13 +152,16 @@ int main()
         Nrt_LoggingService_logErrorLine(console, error);
         return -1;
     }
-    const char* path = Nrt_appendFilePath(2, execPath, "Resources");
+
+    const char* const pathParts[2] = {execPath, "Resources"};
+    const char* path = Nrt_appendFilePath(2, pathParts);
 
     // Getting & Initialising AudioService
     res = Nrt_NovelRunner_getAudioService(runner, &audio);
     if (res != NRT_SUCCESS)
     {
-        const char* errMsg = Nrt_appendText(2, "Error getting AudioService: ", Nrt_getLastError());
+        const char* const textParts[2] = {"Error getting AudioService: ", Nrt_getLastError()};
+        const char* errMsg = Nrt_appendText(2, textParts);
         Nrt_LoggingService_logErrorLine(console, errMsg);
         return -1;
     }
@@ -167,7 +170,8 @@ int main()
         booleanResult = Nrt_AudioService_initialiseAudio(audio);
         if (booleanResult != NRT_TRUE)
         {
-            const char* errMsg = Nrt_appendText(2, "Error initialising AudioService: ", Nrt_getLastError());
+            const char* const textParts[2] = {"Error initialising AudioService: ", Nrt_getLastError()};
+            const char* errMsg = Nrt_appendText(2, textParts);
             Nrt_LoggingService_logErrorLine(console, errMsg);
             return -1;
         }
@@ -181,7 +185,8 @@ int main()
     }
     else
     {
-        const char* errMsg = Nrt_appendText(2, "Error getting InteractionService: ", Nrt_getLastError());
+        const char* const textParts[2] = {"Error getting InteractionService: ", Nrt_getLastError()};
+        const char* errMsg = Nrt_appendText(2, textParts);
         Nrt_LoggingService_logErrorLine(console, errMsg);
         return -1;
     }
@@ -190,7 +195,8 @@ int main()
     res = Nrt_NovelRunner_getRuntimeService(runner, &dotnet);
     if (res != NRT_SUCCESS)
     {
-        const char* errMsg = Nrt_appendText(2, "Error getting RuntimeService: ", Nrt_getLastError());
+        const char* const textParts[2] = {"Error getting RuntimeService: ", Nrt_getLastError()};
+        const char* errMsg = Nrt_appendText(2, textParts);
         Nrt_LoggingService_logErrorLine(console, errMsg);
         return -1;
     }
@@ -217,7 +223,8 @@ int main()
     res = Nrt_NovelRunner_getRenderer(runner, &renderer);
     if (res != NRT_SUCCESS)
     {
-        const char* errMsg = Nrt_appendText(2, "Error getting RenderingService: ", Nrt_getLastError());
+        const char* const textParts[2] = {"Error getting RenderingService: ", Nrt_getLastError()};
+        const char* errMsg = Nrt_appendText(2, textParts);
         Nrt_LoggingService_logErrorLine(console, errMsg);
         return -1;
     }
@@ -232,9 +239,12 @@ int main()
     NrtTransform nChanTransform = {nChanPosition, nChanSize, 0};
     NrtRGBAConfigHandle nChanColours = Nrt_RGBAConfig_Create(255, 255, 255, 255);
 
-    const char* nChanFileLocation = Nrt_appendFilePath(3, path, "Images", "novel-chan.png");
-    res = Nrt_RenderingService_createImageRectWithFile(renderer, &nChanRect, nChanTransform, 3, nChanFileLocation,
-                                                       nChanColours);
+    {
+        const char* const pathParts[3] = {path, "Images", "novel-chan.png"};
+        const char* nChanFileLocation = Nrt_appendFilePath(3, pathParts);
+        res = Nrt_RenderingService_createImageRectWithFile(renderer, &nChanRect, nChanTransform, 3, nChanFileLocation,
+                                                           nChanColours);
+    }
 
     // Creating InteractionRect
     NrtTransform interactTransform = {nChanPosition, nChanSize, 0};
@@ -243,7 +253,8 @@ int main()
     // Creating Ink Story
     if (inkServiceProvided == NRT_TRUE)
     {
-        const char* storyLocation = Nrt_appendFilePath(3, path, "Scripts", "story.json");
+        const char* const pathParts[3] = {path, "Scripts", "story.json"};
+        const char* storyLocation = Nrt_appendFilePath(3, pathParts);
         Nrt_LoggingService_logInfoLine(console, storyLocation);
 
         FILE* json = fopen(storyLocation, "rb");

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Simple)
 add_subdirectory(CAPI)
+add_subdirectory(NovelRT.DotNet.Sample)

--- a/samples/NovelRT.DotNet.Sample/CMakeLists.txt
+++ b/samples/NovelRT.DotNet.Sample/CMakeLists.txt
@@ -1,0 +1,86 @@
+find_package(Dotnet ${NOVELRT_DOTNET_VERSION} REQUIRED)
+
+set(DOTNET_SAMPLE_CSPROJ ${CMAKE_CURRENT_LIST_DIR}/NovelRT.DotNet.Sample.csproj)
+
+set(DOTNET_SAMPLE_SOURCES
+  NovelRT.DotNet.Sample.runtimeconfig.json
+  Program.cs
+)
+
+set(DOTNET_SAMPLE_OPTIONS
+  /nologo
+  /p:IntermediateOutputPath=${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dotnet_Sample_Build.dir/
+  /p:MSBuildProjectExtensionsPath=${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dotnet_Sample_Build.dir/
+  /p:OutDir=${CMAKE_CURRENT_BINARY_DIR}/
+  /p:PublishDir=${CMAKE_CURRENT_BINARY_DIR}/publish/
+)
+
+execute_process(
+  COMMAND ${Dotnet_PROGRAM} msbuild ${DOTNET_SAMPLE_CSPROJ} ${DOTNET_SAMPLE_OPTIONS}
+  /t:Restore
+)
+
+execute_process(
+  COMMAND ${Dotnet_PROGRAM} msbuild ${DOTNET_SAMPLE_CSPROJ} ${DOTNET_SAMPLE_OPTIONS}
+  /t:GetCMakeOutputAssembly
+  OUTPUT_VARIABLE DOTNET_SAMPLE_OUTPUT_ASSEMBLY
+)
+string(STRIP "${DOTNET_SAMPLE_OUTPUT_ASSEMBLY}" DOTNET_SAMPLE_OUTPUT_ASSEMBLY)
+
+execute_process(
+  COMMAND ${Dotnet_PROGRAM} msbuild ${DOTNET_SAMPLE_CSPROJ} ${DOTNET_SAMPLE_OPTIONS}
+  /t:GetCMakeOutputByproducts
+  OUTPUT_VARIABLE DOTNET_SAMPLE_OUTPUT_BYPRODUCTS
+)
+string(STRIP "${DOTNET_SAMPLE_OUTPUT_BYPRODUCTS}" DOTNET_SAMPLE_OUTPUT_BYPRODUCTS)
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/publish)
+
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${DOTNET_SAMPLE_OUTPUT_ASSEMBLY}
+  DEPENDS ${DOTNET_SAMPLE_SOURCES} ${DOTNET_SAMPLE_CSPROJ}
+  BYPRODUCTS ${DOTNET_SAMPLE_OUTPUT_BYPRODUCTS}
+  COMMAND ${Dotnet_PROGRAM} msbuild ${DOTNET_SAMPLE_CSPROJ} ${DOTNET_SAMPLE_OPTIONS}
+  /t:Build,Publish
+  COMMENT "Building ${DOTNET_SAMPLE_CSPROJ}"
+)
+
+add_custom_target(Dotnet_Sample_Build ALL
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${DOTNET_SAMPLE_OUTPUT_ASSEMBLY}
+)
+
+add_executable(Dotnet_Sample IMPORTED GLOBAL)
+add_dependencies(Dotnet_Sample Dotnet_Build Dotnet_Sample_Build)
+
+set_target_properties(Dotnet_Sample
+  PROPERTIES
+  IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/publish/IF_YOU_SEE_THIS_YOU_TRIED_TO_RUN_THE_DOTNET_TARGET
+)
+
+add_custom_command(
+  TARGET Dotnet_Sample_Build POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+    $<TARGET_FILE_DIR:Engine>
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+add_custom_command(
+  TARGET Dotnet_Sample_Build POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+    $<TARGET_FILE_DIR:Engine>
+    ${CMAKE_CURRENT_BINARY_DIR}/publish
+)
+
+add_custom_command(
+  TARGET Dotnet_Sample_Build POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+    $<TARGET_FILE_DIR:Interop>
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+add_custom_command(
+  TARGET Dotnet_Sample_Build POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+    $<TARGET_FILE_DIR:Interop>
+    ${CMAKE_CURRENT_BINARY_DIR}/publish
+)

--- a/samples/NovelRT.DotNet.Sample/NovelRT.DotNet.Sample.csproj
+++ b/samples/NovelRT.DotNet.Sample/NovelRT.DotNet.Sample.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/NovelRT.DotNet/NovelRT.DotNet.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../../resources/**/*.ttf" Link="Resources/%(RecursiveDir)/%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../resources/**/*.png" Link="Resources/%(RecursiveDir)/%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../resources/**/*.lua" Link="Resources/%(RecursiveDir)/%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../resources/**/*.ink" Link="Resources/%(RecursiveDir)/%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../resources/**/*.json" Link="Resources/%(RecursiveDir)/%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../resources/**/*.glsl" Link="Resources/%(RecursiveDir)/%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <!-- DO NOT REMOVE: Used by CMakeLists to identify project outputs -->
+  <Target Name="GetCMakeOutputAssembly">
+    <Message Importance="High" Text="$(TargetFileName)" />
+  </Target>
+
+  <!-- DO NOT REMOVE: Used by CMakeLists to identify project outputs -->
+  <Target Name="GetCMakeOutputByproducts" DependsOnTargets="ComputeFilesToPublish">
+    <Message Importance="High" Text="@(ResolvedFileToPublish->'$(PublishDir)%(RelativePath)')" />
+  </Target>
+
+</Project>

--- a/samples/NovelRT.DotNet.Sample/NovelRT.DotNet.Sample.runtimeconfig.json
+++ b/samples/NovelRT.DotNet.Sample/NovelRT.DotNet.Sample.runtimeconfig.json
@@ -1,0 +1,10 @@
+{
+  "runtimeOptions": {
+    "tfm": "net5.0",
+    "rollForward": "LatestMinor",
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "5.0.0"
+    }
+  }
+}

--- a/samples/NovelRT.DotNet.Sample/Program.cs
+++ b/samples/NovelRT.DotNet.Sample/Program.cs
@@ -1,11 +1,391 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
 
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using NovelRT.Interop;
+using static System.Net.Mime.MediaTypeNames;
+using static NovelRT.Interop.NovelRT;
+using static NovelRT.Interop.NrtBool;
+using static NovelRT.Interop.NrtResult;
+
 namespace NovelRT.DotNet.Sample
 {
-    public static class Program
+    public static unsafe class Program
     {
-        public static void Main(string[] args)
+        private static NrtResult res = NRT_SUCCESS;
+        private static NrtBool booleanResult = NRT_TRUE;
+        private static NrtBool inkServiceProvided = NRT_FALSE;
+
+        private static int hMove = 1; // 1 == move right, 0 == move left
+        private static int vMove = 1; // 1 == move up, 0 == move down
+
+        // Services
+        private static IntPtr audio = IntPtr.Zero;
+        private static IntPtr input = IntPtr.Zero;
+        private static IntPtr console = IntPtr.Zero;
+        private static IntPtr dotnet = IntPtr.Zero;
+        private static IntPtr ink = IntPtr.Zero;
+        private static IntPtr timer = IntPtr.Zero;
+        private static IntPtr renderer = IntPtr.Zero;
+        private static IntPtr updateEvent = IntPtr.Zero;
+        private static IntPtr colourChange = IntPtr.Zero;
+
+        // Objects
+        private static IntPtr nChanRect = IntPtr.Zero;
+        private static IntPtr interactRect = IntPtr.Zero;
+        private static IntPtr story = IntPtr.Zero;
+
+        private static Random rand = null;
+
+        public static int Main(string[] args)
         {
+            res = NRT_SUCCESS;
+            rand = new Random();
+
+            // Creating NovelRunner
+            IntPtr runner = Nrt_NovelRunner_create(0);
+
+            // Starting LoggingService
+            fixed (byte* customTitle = Encoding.UTF8.GetBytes("Interop"))
+            {
+                console = Nrt_LoggingService_createCustomTitle((sbyte*)customTitle);
+            }
+
+            // Getting a constant to the Resources folder
+            sbyte* execPath = Nrt_getExecutableDirPath();
+            sbyte* error = Nrt_getLastError();
+
+            if (error != null)
+            {
+                Nrt_LoggingService_logErrorLine(console, error);
+                return -1;
+            }
+
+            sbyte* path;
+
+            fixed (byte* pathPart = Encoding.UTF8.GetBytes("Resources"))
+            {
+                var pathParts = stackalloc sbyte*[2] { execPath, (sbyte*)pathPart };
+                path = Nrt_appendFilePath(2, pathParts);
+            }
+
+            // Getting & Initialising AudioService
+            fixed (IntPtr* pAudio = &audio)
+            {
+                res = (NrtResult)Nrt_NovelRunner_getAudioService(runner, pAudio);
+            }
+
+            if (res != NRT_SUCCESS)
+            {
+                fixed (byte* text = Encoding.UTF8.GetBytes("Error getting AudioService: "))
+                {
+                    var textParts = stackalloc sbyte*[2] { (sbyte*)text, Nrt_getLastError() };
+                    sbyte* errMsg = Nrt_appendText(2, textParts);
+                    Nrt_LoggingService_logErrorLine(console, errMsg);
+                }
+                return -1;
+            }
+            else
+            {
+                booleanResult = (NrtBool)Nrt_AudioService_initialiseAudio(audio);
+
+                if (booleanResult != NRT_TRUE)
+                {
+                    fixed (byte* text = Encoding.UTF8.GetBytes("Error initialising AudioService: "))
+                    {
+                        var textParts = stackalloc sbyte*[2] { (sbyte*)text, Nrt_getLastError() };
+                        sbyte* errMsg = Nrt_appendText(2, textParts);
+                        Nrt_LoggingService_logErrorLine(console, errMsg);
+                    }
+                    return -1;
+                }
+            }
+
+            // Getting InteractionService
+            fixed (IntPtr* pInput = &input)
+            {
+                res = (NrtResult)Nrt_NovelRunner_getInteractionService(runner, pInput);
+            }
+
+            if (res == NRT_SUCCESS)
+            {
+                fixed (byte* info = Encoding.UTF8.GetBytes("Received InteractionService from C via C#!"))
+                {
+                    Nrt_LoggingService_logInfoLine(console, (sbyte*)info);
+                }
+            }
+            else
+            {
+                fixed (byte* text = Encoding.UTF8.GetBytes("Error getting InteractionService: "))
+                {
+                    var textParts = stackalloc sbyte*[2] { (sbyte*)text, Nrt_getLastError() };
+                    sbyte* errMsg = Nrt_appendText(2, textParts);
+                    Nrt_LoggingService_logErrorLine(console, errMsg);
+                }
+                return -1;
+            }
+
+            // Getting & Initialising RuntimeService / InkService
+            fixed (IntPtr* pDotnet = &dotnet)
+            {
+                res = (NrtResult)Nrt_NovelRunner_getRuntimeService(runner, pDotnet);
+            }
+
+            if (res != NRT_SUCCESS)
+            {
+                fixed (byte* text = Encoding.UTF8.GetBytes("Error getting RuntimeService: "))
+                {
+                    var textParts = stackalloc sbyte*[2] { (sbyte*)text, Nrt_getLastError() };
+                    sbyte* errMsg = Nrt_appendText(2, textParts);
+                    Nrt_LoggingService_logErrorLine(console, errMsg);
+                }
+                return -1;
+            }
+            else
+            {
+                fixed (byte* info = Encoding.UTF8.GetBytes("Received .NET RuntimeService from C API via C#!"))
+                {
+                    Nrt_LoggingService_logInfoLine(console, (sbyte*)info);
+                }
+                res = (NrtResult)Nrt_RuntimeService_initialise(dotnet);
+
+                if (res == NRT_SUCCESS)
+                {
+                    fixed (IntPtr* pInk = &ink)
+                    {
+                        res = (NrtResult)Nrt_RuntimeService_getInkService(dotnet, pInk);
+                    }
+
+                    if (res == NRT_SUCCESS)
+                    {
+                        fixed (byte* info = Encoding.UTF8.GetBytes("Received Ink Service from C API via C#!"))
+                        {
+                            Nrt_LoggingService_logInfoLine(console, (sbyte*)info);
+                        }
+                        inkServiceProvided = NRT_TRUE;
+                        Nrt_InkService_initialise(ink);
+                    }
+                    else
+                    {
+                        fixed (byte* info = Encoding.UTF8.GetBytes("Failed to receive Ink Service!"))
+                        {
+                            Nrt_LoggingService_logErrorLine(console, (sbyte*)info);
+                        }
+                    }
+                }
+            }
+
+            // Changing Background Colour
+            fixed (IntPtr* pRenderer = &renderer)
+            {
+                res = (NrtResult)Nrt_NovelRunner_getRenderer(runner, pRenderer);
+            }
+
+            if (res != NRT_SUCCESS)
+            {
+                fixed (byte* text = Encoding.UTF8.GetBytes("Error getting RenderingService: "))
+                {
+                    var textParts = stackalloc sbyte*[2] { (sbyte*)text, Nrt_getLastError() };
+                    sbyte* errMsg = Nrt_appendText(2, textParts);
+                    Nrt_LoggingService_logErrorLine(console, errMsg);
+                }
+                return -1;
+            }
+
+            colourChange = Nrt_RGBAConfig_Create(0, 0, 0, 255);
+
+            IntPtr background = Nrt_RGBAConfig_Create(0, 0, 0, 0);
+            Nrt_RenderingService_setBackgroundColour(renderer, background);
+
+            // Creating ImageRect
+            NrtGeoVector2F nChanPosition = new NrtGeoVector2F { x = 1920 / 2, y = 1080 / 2 };
+            NrtGeoVector2F nChanSize = new NrtGeoVector2F { x = 762, y = 881 };
+            NrtTransform nChanTransform = new NrtTransform { position = nChanPosition, scale = nChanSize, rotation = 0 };
+            IntPtr nChanColours = Nrt_RGBAConfig_Create(255, 255, 255, 255);
+
+            sbyte* nChanFileLocation;
+
+            fixed (byte* filePathPart1 = Encoding.UTF8.GetBytes("Images"))
+            fixed (byte* filePathPart2 = Encoding.UTF8.GetBytes("novel-chan.png"))
+{
+                var pathParts = stackalloc sbyte*[3] { path, (sbyte*)filePathPart1, (sbyte*)filePathPart2 };
+                nChanFileLocation = Nrt_appendFilePath(3, pathParts);
+            }
+
+            fixed (IntPtr* pNChanRect = &nChanRect)
+            {
+                res = (NrtResult)Nrt_RenderingService_createImageRectWithFile(renderer, pNChanRect, nChanTransform, 3, nChanFileLocation, nChanColours);
+            }
+
+            // Creating InteractionRect
+            NrtTransform interactTransform = new NrtTransform { position = nChanPosition, scale = nChanSize, rotation = 0 };
+
+            fixed (IntPtr* pInteractRect = &interactRect)
+            {
+                res = (NrtResult)Nrt_InteractionService_createBasicInteractionRect(input, interactTransform, 3, pInteractRect);
+            }
+
+            // Creating Ink Story
+            if (inkServiceProvided == NRT_TRUE)
+            {
+                sbyte* storyLocation;
+
+                fixed (byte* filePathPart1 = Encoding.UTF8.GetBytes("Scripts"))
+                fixed (byte* filePathPart2 = Encoding.UTF8.GetBytes("story.json"))
+                {
+                    var pathParts = stackalloc sbyte*[3] { path, (sbyte*)filePathPart1, (sbyte*)filePathPart2 };
+                    storyLocation = Nrt_appendFilePath(3, pathParts);
+                }
+
+                Nrt_LoggingService_logInfoLine(console, storyLocation);
+                string buffer = File.ReadAllText(Marshal.PtrToStringAnsi((IntPtr)storyLocation));
+
+                fixed (IntPtr* pStory = &story)
+                fixed (byte* pBuffer = Encoding.UTF8.GetBytes(buffer))
+                {
+                    res = (NrtResult)Nrt_InkService_createStory(ink, (sbyte*)pBuffer, pStory);
+                }
+
+                if (res == NRT_SUCCESS)
+                {
+                    Nrt_Story_resetState(story);
+                }
+                Nrt_Input_BasicInteractionRect_addInteraction(interactRect, &interactWithNovelChan);
+            }
+
+            // Setting up Scene Construction
+            Nrt_NovelRunner_addSceneConstructionRequested(runner, &renderNovelChan);
+
+            // Setting up Update methods
+            Nrt_NovelRunner_addUpdate(runner, &moveNovelChan);
+
+            // Run the novel!
+            Nrt_NovelRunner_runNovel(runner);
+
+            return 0;
+        }
+
+        // Function to render NovelChan
+        [UnmanagedCallersOnly]
+        private static void renderNovelChan()
+        {
+            Nrt_ImageRect_executeObjectBehaviour(nChanRect);
+            Nrt_Input_BasicInteractionRect_executeObjectBehaviour(interactRect);
+        }
+
+        // Function to move NovelChan DVD screensaver style
+        [UnmanagedCallersOnly]
+        private static void moveNovelChan(ulong delta)
+        {
+            if (nChanRect == IntPtr.Zero)
+                return;
+
+            int bounced = 0;
+            float trueDelta = 0.0f;
+            float moveAmount = 100.0f;
+
+            trueDelta = Nrt_Timestamp_getSecondsFloat(delta);
+            NrtTransform transform = Nrt_ImageRect_getTransform(nChanRect);
+
+            float xOrigin = transform.position.x;
+            float yOrigin = transform.position.y;
+
+            float rectXSize = transform.scale.x;
+            float rectQuarterSizeX = rectXSize / 4.0f;
+            float rectYSize = transform.scale.y;
+            float rectQuarterSizeY = rectYSize / 4.0f;
+
+            float xMax = 1920.0f;
+            float xMin = 0.0f;
+            float yMax = 1080.0f;
+            float yMin = 0.0f;
+
+            if (hMove == 1)
+            {
+                transform.position.x += (moveAmount * trueDelta);
+                if (transform.position.x >= (xMax - rectQuarterSizeX))
+                {
+                    hMove = 0;
+                    bounced = 1;
+
+                    fixed (byte* info = Encoding.UTF8.GetBytes("Flipped X axis movement."))
+                    {
+                        Nrt_LoggingService_logInfoLine(console, (sbyte*)info);
+                    }
+                }
+            }
+            else
+            {
+                transform.position.x -= (moveAmount * trueDelta);
+                if (transform.position.x <= (xMin + rectQuarterSizeX))
+                {
+                    hMove = 1;
+                    bounced = 1;
+
+                    fixed (byte* info = Encoding.UTF8.GetBytes("Flipped X axis movement."))
+                    {
+                        Nrt_LoggingService_logInfoLine(console, (sbyte*)info);
+                    }
+                }
+            }
+
+            if (vMove == 1)
+            {
+                transform.position.y += (moveAmount * trueDelta);
+                if (transform.position.y >= (yMax - rectQuarterSizeY))
+                {
+                    vMove = 0;
+                    bounced = 1;
+
+                    fixed (byte* info = Encoding.UTF8.GetBytes("Flipped Y axis movement."))
+                    {
+                        Nrt_LoggingService_logInfoLine(console, (sbyte*)info);
+                    }
+                }
+            }
+            else
+            {
+                transform.position.y -= (moveAmount * trueDelta);
+                if (transform.position.y <= (yMin + rectQuarterSizeY))
+                {
+                    vMove = 1;
+                    bounced = 1;
+
+                    fixed (byte* info = Encoding.UTF8.GetBytes("Flipped Y axis movement."))
+                    {
+                        Nrt_LoggingService_logInfoLine(console, (sbyte*)info);
+                    }
+                }
+            }
+
+            if (bounced == 1)
+            {
+                bounced = 0;
+                Nrt_RGBAConfig_setR(colourChange, (rand.Next() % 256));
+                Nrt_RGBAConfig_setG(colourChange, (rand.Next() % 256));
+                Nrt_RGBAConfig_setB(colourChange, (rand.Next() % 256));
+                Nrt_ImageRect_setColourTint(nChanRect, colourChange);
+            }
+
+            Nrt_ImageRect_setTransform(nChanRect, transform);
+            Nrt_Input_BasicInteractionRect_setTransform(interactRect, transform);
+        }
+
+        // Function to interact with Ink
+        [UnmanagedCallersOnly]
+        private static void interactWithNovelChan()
+        {
+            if ((NrtBool)Nrt_Story_canContinue(story) == NRT_FALSE)
+            {
+                Nrt_Story_resetState(story);
+            }
+
+            sbyte* cSharpResult = Nrt_Story_continue(story);
+            Nrt_LoggingService_logDebugLine(console, cSharpResult);
+            Nrt_RuntimeService_freeString(dotnet, cSharpResult);
         }
     }
 }

--- a/samples/NovelRT.DotNet.Sample/Program.cs
+++ b/samples/NovelRT.DotNet.Sample/Program.cs
@@ -1,0 +1,11 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root for more information.
+
+namespace NovelRT.DotNet.Sample
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/src/NovelRT.DotNet/CMakeLists.txt
+++ b/src/NovelRT.DotNet/CMakeLists.txt
@@ -1,8 +1,59 @@
-find_package(Dotnet 5.0.100 REQUIRED)
+find_package(Dotnet ${NOVELRT_DOTNET_VERSION} REQUIRED)
 
-set(CSPROJ ${CMAKE_CURRENT_LIST_DIR}/NovelRT.DotNet.csproj)
+set(DOTNET_CSPROJ ${CMAKE_CURRENT_LIST_DIR}/NovelRT.DotNet.csproj)
 
-set(OPTIONS
+set(DOTNET_SOURCES
+  NovelRT.DotNet.runtimeconfig.json
+
+  InkService.cs
+  InkService.Exports.cs
+  RuntimeService.cs
+  RuntimeService.Exports.cs
+
+  Interop/NativeTypeName.cs
+
+  Interop/Animation/NovelRT.cs
+  Interop/Animation/NrtAnimatorPlayState.cs
+
+  Interop/Audio/NovelRT.cs
+
+  Interop/Core/NovelRT.cs
+  Interop/Core/NrtBool.cs
+  Interop/Core/NrtLogLevel.cs
+  Interop/Core/NrtResult.cs
+
+  Interop/DotNet/NovelRT.cs
+
+  Interop/Ecs/NovelRT.cs
+
+  Interop/Graphics/NovelRT.cs
+  Interop/Graphics/NrtCameraFrameState.cs
+
+  Interop/Ink/NovelRT.cs
+
+  Interop/Input/NovelRT.cs
+  Interop/Input/NrtKeyCode.cs
+  Interop/Input/NrtKeyState.cs
+
+  Interop/Maths/NovelRT.cs
+  Interop/Maths/NrtGeoBounds.cs
+  Interop/Maths/NrtGeoMatrix4x4F.cs
+  Interop/Maths/NrtGeoVector2F.cs
+  Interop/Maths/NrtGeoVector3F.cs
+  Interop/Maths/NrtGeoVector4F.cs
+  Interop/Maths/NrtTransform.cs
+
+  Interop/SceneGraph/NovelRT.cs
+
+  Interop/Timing/NovelRT.cs
+
+  Interop/Utilities/NovelRT.cs
+
+  Interop/Windowing/NovelRT.cs
+  Interop/Windowing/NrtWindowMode.cs
+)
+
+set(DOTNET_OPTIONS
   /nologo
   /p:IntermediateOutputPath=${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dotnet_Build.dir/
   /p:MSBuildProjectExtensionsPath=${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/Dotnet_Build.dir/
@@ -11,44 +62,45 @@ set(OPTIONS
   )
 
 execute_process(
-  COMMAND ${Dotnet_PROGRAM} msbuild ${CSPROJ} ${OPTIONS}
+  COMMAND ${Dotnet_PROGRAM} msbuild ${DOTNET_CSPROJ} ${DOTNET_OPTIONS}
   /t:Restore
 )
 
 execute_process(
-  COMMAND ${Dotnet_PROGRAM} msbuild ${CSPROJ} ${OPTIONS}
+  COMMAND ${Dotnet_PROGRAM} msbuild ${DOTNET_CSPROJ} ${DOTNET_OPTIONS}
   /t:GetCMakeOutputAssembly
-  OUTPUT_VARIABLE OUTPUT_ASSEMBLY
+  OUTPUT_VARIABLE DOTNET_OUTPUT_ASSEMBLY
 )
-string(STRIP "${OUTPUT_ASSEMBLY}" OUTPUT_ASSEMBLY)
+string(STRIP "${DOTNET_OUTPUT_ASSEMBLY}" DOTNET_OUTPUT_ASSEMBLY)
 
 execute_process(
-  COMMAND ${Dotnet_PROGRAM} msbuild ${CSPROJ} ${OPTIONS}
+  COMMAND ${Dotnet_PROGRAM} msbuild ${DOTNET_CSPROJ} ${DOTNET_OPTIONS}
   /t:GetCMakeOutputByproducts
-  OUTPUT_VARIABLE OUTPUT_BYPRODUCTS
+  OUTPUT_VARIABLE DOTNET_OUTPUT_BYPRODUCTS
 )
-string(STRIP "${OUTPUT_BYPRODUCTS}" OUTPUT_BYPRODUCTS)
+string(STRIP "${DOTNET_OUTPUT_BYPRODUCTS}" DOTNET_OUTPUT_BYPRODUCTS)
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/publish)
 
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_ASSEMBLY}
-  BYPRODUCTS ${OUTPUT_BYPRODUCTS}
-  COMMAND ${Dotnet_PROGRAM} msbuild ${CSPROJ} ${OPTIONS}
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${DOTNET_OUTPUT_ASSEMBLY}
+  DEPENDS ${DOTNET_SOURCES} ${DOTNET_CSPROJ}
+  BYPRODUCTS ${DOTNET_OUTPUT_BYPRODUCTS}
+  COMMAND ${Dotnet_PROGRAM} msbuild ${DOTNET_CSPROJ} ${DOTNET_OPTIONS}
   /t:Build,Publish
-  COMMENT "Building .NET subproject"
+  COMMENT "Building ${DOTNET_CSPROJ}"
 )
 
-add_custom_target(Dotnet_Build
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_ASSEMBLY}
-  )
+add_custom_target(Dotnet_Build ALL
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${DOTNET_OUTPUT_ASSEMBLY}
+)
 
 add_executable(Dotnet IMPORTED GLOBAL)
 add_dependencies(Dotnet Dotnet_Build)
 set_target_properties(Dotnet
   PROPERTIES
   IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/publish/IF_YOU_SEE_THIS_YOU_TRIED_TO_RUN_THE_DOTNET_TARGET
-  )
+)
 
 if(WIN32)
   set(nethost_lib "nethost.dll")

--- a/src/NovelRT.DotNet/Interop/Utilities/NovelRT.cs
+++ b/src/NovelRT.DotNet/Interop/Utilities/NovelRT.cs
@@ -16,10 +16,10 @@ namespace NovelRT.Interop
 
         [DllImport("Interop", ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
-        public static extern sbyte* Nrt_appendFilePath([NativeTypeName("int32_t")] int numberOfArgs);
+        public static extern sbyte* Nrt_appendFilePath([NativeTypeName("int32_t")] int numberOfArgs, [NativeTypeName("const char * const *")] sbyte** args);
 
         [DllImport("Interop", ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
-        public static extern sbyte* Nrt_appendText([NativeTypeName("int32_t")] int numberOfArgs);
+        public static extern sbyte* Nrt_appendText([NativeTypeName("int32_t")] int numberOfArgs, [NativeTypeName("const char * const *")] sbyte** args);
     }
 }

--- a/src/NovelRT.Interop/Utilities/NrtMisc.cpp
+++ b/src/NovelRT.Interop/Utilities/NrtMisc.cpp
@@ -5,7 +5,6 @@
 #include <NovelRT.Interop/Utilities/NrtMisc.h>
 #include <NovelRT.h>
 
-#include <stdarg.h>
 #include <string.h>
 
 #ifdef __cplusplus
@@ -45,7 +44,7 @@ extern "C"
         return returnPtr;
     }
 
-    const char* Nrt_appendFilePath(int32_t numberOfArgs, ...)
+    const char* Nrt_appendFilePath(int32_t numberOfArgs, const char* const* args)
     {
         if (numberOfArgs <= 1)
         {
@@ -59,12 +58,10 @@ extern "C"
 #endif
 
         std::string finalString = "";
-        va_list args;
-        va_start(args, numberOfArgs);
 
         for (int i = 0; i < numberOfArgs; i++)
         {
-            const char* arg = va_arg(args, const char*);
+            const char* arg = args[i];
             std::cout << arg << std::endl;
             finalString.append(arg);
             if (i < numberOfArgs - 1)
@@ -72,7 +69,6 @@ extern "C"
                 finalString.append(dirMarker);
             }
         }
-        va_end(args);
 
         char* finalPath = nullptr;
 // strcpy_s is not included by all compilers that don't have __STDC_LIB_EXT1__ available, including clang.
@@ -97,7 +93,7 @@ extern "C"
         return finalPath;
     }
 
-    const char* Nrt_appendText(int32_t numberOfArgs, ...)
+    const char* Nrt_appendText(int32_t numberOfArgs, const char* const* args)
     {
         if (numberOfArgs <= 1)
         {
@@ -106,14 +102,11 @@ extern "C"
         }
 
         std::string finalString = "";
-        va_list args;
-        va_start(args, numberOfArgs);
 
         for (int i = 0; i < numberOfArgs; i++)
         {
-            finalString.append(va_arg(args, const char*));
+            finalString.append(args[i]);
         }
-        va_end(args);
 
         char* finalText = new char[finalString.length() + 1];
         if (strlen(finalText) < (finalString.length() + 1))


### PR DESCRIPTION
This adds the CAPI sample for the C# bindings and adjusts the `Nrt_append*` APIs to not use varargs, as that is not compatible with .NET.

This also cleans up the .NET cmakelist files to build and perform their up to date checks based on the correct set of inputs.