### PR TITLE
Removed usage of std::byte.

### DIFF
--- a/include/NovelRT/Ecs/ComponentBufferMemoryContainer.h
+++ b/include/NovelRT/Ecs/ComponentBufferMemoryContainer.h
@@ -18,7 +18,7 @@ namespace NovelRT::Ecs
     private:
         SparseSetMemoryContainer _rootSet;
         std::vector<SparseSetMemoryContainer> _updateSets;
-        std::vector<std::byte> _deleteInstructionState;
+        std::vector<uint8_t> _deleteInstructionState;
         size_t _sizeOfDataTypeInBytes;
         std::function<
             void(SparseSetMemoryContainer::ByteIteratorView, SparseSetMemoryContainer::ByteIteratorView, size_t)>

--- a/include/NovelRT/Ecs/SparseSetMemoryContainer.h
+++ b/include/NovelRT/Ecs/SparseSetMemoryContainer.h
@@ -18,22 +18,22 @@ namespace NovelRT::Ecs
     private:
         std::vector<size_t> _dense;
         std::vector<size_t> _sparse;
-        std::vector<std::byte> _data;
+        std::vector<uint8_t> _data;
         size_t _sizeOfDataTypeInBytes;
 
         [[nodiscard]] size_t GetStartingByteIndexForDenseIndex(size_t denseIndex) const noexcept;
-        [[nodiscard]] std::byte* GetDataObjectStartAtIndex(size_t location) noexcept;
+        [[nodiscard]] uint8_t* GetDataObjectStartAtIndex(size_t location) noexcept;
         void InsertInternal(size_t key, const void* value);
 
     public:
         class ByteIteratorView
         {
         private:
-            std::vector<std::byte>::iterator _iteratorAtValue;
+            std::vector<uint8_t>::iterator _iteratorAtValue;
             size_t _sizeOfObject;
 
         public:
-            explicit ByteIteratorView(std::vector<std::byte>::iterator iteratorAtValue, size_t sizeOfObject) noexcept
+            explicit ByteIteratorView(std::vector<uint8_t>::iterator iteratorAtValue, size_t sizeOfObject) noexcept
                 : _iteratorAtValue(iteratorAtValue), _sizeOfObject(sizeOfObject)
             {
             }
@@ -43,7 +43,7 @@ namespace NovelRT::Ecs
                 return _sizeOfObject != 0;
             }
 
-            [[nodiscard]] inline std::vector<std::byte>::iterator GetUnderlyingIterator() const noexcept
+            [[nodiscard]] inline std::vector<uint8_t>::iterator GetUnderlyingIterator() const noexcept
             {
                 return _iteratorAtValue;
             }
@@ -72,11 +72,11 @@ namespace NovelRT::Ecs
         class ConstByteIteratorView
         {
         private:
-            std::vector<std::byte>::const_iterator _iteratorAtValue;
+            std::vector<uint8_t>::const_iterator _iteratorAtValue;
             size_t _sizeOfObject;
 
         public:
-            explicit ConstByteIteratorView(std::vector<std::byte>::const_iterator iteratorAtValue,
+            explicit ConstByteIteratorView(std::vector<uint8_t>::const_iterator iteratorAtValue,
                                            size_t sizeOfObject) noexcept
                 : _iteratorAtValue(iteratorAtValue), _sizeOfObject(sizeOfObject)
             {
@@ -87,7 +87,7 @@ namespace NovelRT::Ecs
                 return _sizeOfObject != 0;
             }
 
-            [[nodiscard]] inline std::vector<std::byte>::const_iterator GetUnderlyingIterator() const noexcept
+            [[nodiscard]] inline std::vector<uint8_t>::const_iterator GetUnderlyingIterator() const noexcept
             {
                 return _iteratorAtValue;
             }

--- a/src/NovelRT.Interop/Ecs/NrtComponentBufferMemoryContainer.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtComponentBufferMemoryContainer.cpp
@@ -12,7 +12,7 @@ using namespace NovelRT::Ecs;
 using namespace NovelRT::Exceptions;
 
 std::vector<size_t> dummySizeTCollection{};
-std::vector<std::byte> dummyByteCollection{};
+std::vector<uint8_t> dummyByteCollection{};
 
 extern "C"
 {

--- a/src/NovelRT.Interop/Ecs/NrtSparseSetMemoryContainer.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtSparseSetMemoryContainer.cpp
@@ -12,7 +12,7 @@
 using namespace NovelRT::Ecs;
 using namespace NovelRT::Exceptions;
 
-std::vector<std::byte> dummyByteVectorSparseSet{std::byte(0)};
+std::vector<uint8_t> dummyByteVectorSparseSet{uint8_t(0)};
 std::vector<size_t> dummySizeTVectorSparseSet{0};
 
 extern "C"

--- a/src/NovelRT.Interop/Ecs/NrtUnsafeComponentView.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtUnsafeComponentView.cpp
@@ -12,7 +12,7 @@ using namespace NovelRT::Ecs;
 using namespace NovelRT::Exceptions;
 
 std::vector<size_t> dummySizeTVectorComponentView;
-std::vector<std::byte> dummyByteVectorComponentView;
+std::vector<uint8_t> dummyByteVectorComponentView;
 
 extern "C"
 {

--- a/src/NovelRT/Ecs/ComponentBufferMemoryContainer.cpp
+++ b/src/NovelRT/Ecs/ComponentBufferMemoryContainer.cpp
@@ -15,7 +15,7 @@ namespace NovelRT::Ecs
                            size_t)> componentUpdateLogic) noexcept
         : _rootSet(SparseSetMemoryContainer(sizeOfDataTypeInBytes)),
           _updateSets(std::vector<SparseSetMemoryContainer>{}),
-          _deleteInstructionState(std::vector<std::byte>(sizeOfDataTypeInBytes)),
+          _deleteInstructionState(std::vector<uint8_t>(sizeOfDataTypeInBytes)),
           _sizeOfDataTypeInBytes(sizeOfDataTypeInBytes),
           _componentUpdateLogic(std::move(componentUpdateLogic))
     {

--- a/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
+++ b/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
@@ -10,7 +10,7 @@ namespace NovelRT::Ecs
     SparseSetMemoryContainer::SparseSetMemoryContainer(size_t sizeOfDataTypeInBytes) noexcept
         : _dense(std::vector<size_t>{}),
           _sparse(std::vector<size_t>{}),
-          _data(std::vector<std::byte>{}),
+          _data(std::vector<uint8_t>{}),
           _sizeOfDataTypeInBytes(sizeOfDataTypeInBytes)
     {
     }
@@ -20,7 +20,7 @@ namespace NovelRT::Ecs
         return _sizeOfDataTypeInBytes * denseIndex;
     }
 
-    std::byte* SparseSetMemoryContainer::GetDataObjectStartAtIndex(size_t location) noexcept
+    uint8_t* SparseSetMemoryContainer::GetDataObjectStartAtIndex(size_t location) noexcept
     {
         return _data.data() + (location * _sizeOfDataTypeInBytes);
     }


### PR DESCRIPTION
As per the title, this is a result of the discussion of the C++ specification and the precise behaviour of `std::byte` over `uint8_t`. This change is also being introduced to make the types across C and C++ a tad more consistent.