### PR TITLE
Expose opaque context parameters for interop APIs

### DIFF
--- a/include/NovelRT.Interop/Animation/NrtSpriteAnimatorFrame.h
+++ b/include/NovelRT.Interop/Animation/NrtSpriteAnimatorFrame.h
@@ -18,8 +18,12 @@ extern "C"
     NrtTimestamp Nrt_SpriteAnimatorFrame_getDuration(NrtSpriteAnimatorFrameHandle frame);
     NrtResult Nrt_SpriteAnimatorFrame_setDuration(NrtSpriteAnimatorFrameHandle frame, NrtTimestamp timestamp);
 
-    NrtResult Nrt_SpriteAnimatorFrame_addFrameEnter(NrtSpriteAnimatorFrameHandle frame, void (*func)(void*), void* context);
-    NrtResult Nrt_SpriteAnimatorFrame_addFrameExit(NrtSpriteAnimatorFrameHandle frame, void (*func)(void*), void* context);
+    NrtResult Nrt_SpriteAnimatorFrame_addFrameEnter(NrtSpriteAnimatorFrameHandle frame,
+                                                    void (*func)(void*),
+                                                    void* context);
+    NrtResult Nrt_SpriteAnimatorFrame_addFrameExit(NrtSpriteAnimatorFrameHandle frame,
+                                                   void (*func)(void*),
+                                                   void* context);
 
 #ifdef __cplusplus
 }

--- a/include/NovelRT.Interop/Animation/NrtSpriteAnimatorFrame.h
+++ b/include/NovelRT.Interop/Animation/NrtSpriteAnimatorFrame.h
@@ -18,8 +18,8 @@ extern "C"
     NrtTimestamp Nrt_SpriteAnimatorFrame_getDuration(NrtSpriteAnimatorFrameHandle frame);
     NrtResult Nrt_SpriteAnimatorFrame_setDuration(NrtSpriteAnimatorFrameHandle frame, NrtTimestamp timestamp);
 
-    NrtResult Nrt_SpriteAnimatorFrame_addFrameEnter(NrtSpriteAnimatorFrameHandle frame, void (*func)());
-    NrtResult Nrt_SpriteAnimatorFrame_addFrameExit(NrtSpriteAnimatorFrameHandle frame, void (*func)());
+    NrtResult Nrt_SpriteAnimatorFrame_addFrameEnter(NrtSpriteAnimatorFrameHandle frame, void (*func)(void*), void* context);
+    NrtResult Nrt_SpriteAnimatorFrame_addFrameExit(NrtSpriteAnimatorFrameHandle frame, void (*func)(void*), void* context);
 
 #ifdef __cplusplus
 }

--- a/include/NovelRT.Interop/Ecs/NrtComponentBufferMemoryContainer.h
+++ b/include/NovelRT.Interop/Ecs/NrtComponentBufferMemoryContainer.h
@@ -14,7 +14,8 @@ extern "C"
     NrtComponentBufferMemoryContainerHandle Nrt_ComponentBufferMemoryContainer_Create(size_t poolSize,
                                                                                       void* deleteInstructionState,
                                                                                       size_t sizeOfDataTypeInBytes,
-                                                                                      NrtComponentUpdateFnPtr fnPtr);
+                                                                                      NrtComponentUpdateFnPtr fnPtr,
+                                                                                      void* context);
 
     void Nrt_ComponentBufferMemoryContainer_PrepContainerForFrame(NrtComponentBufferMemoryContainerHandle container,
                                                                   NrtEntityIdVectorHandle entitiesToDelete);

--- a/include/NovelRT.Interop/Ecs/NrtComponentCache.h
+++ b/include/NovelRT.Interop/Ecs/NrtComponentCache.h
@@ -17,6 +17,7 @@ extern "C"
                                                              size_t sizeOfDataType,
                                                              const void* deleteInstructionState,
                                                              NrtComponentUpdateFnPtr updateFnPtr,
+                                                             void* context,
                                                              NrtComponentTypeId* outputResult);
 
     NrtResult Nrt_ComponentCache_GetComponentBufferById(NrtComponentCacheHandle componentCache,

--- a/include/NovelRT.Interop/Ecs/NrtEcsTypedefs.h
+++ b/include/NovelRT.Interop/Ecs/NrtEcsTypedefs.h
@@ -27,9 +27,10 @@ extern "C"
 
     typedef void (*NrtComponentUpdateFnPtr)(NrtSparseSetMemoryContainer_ByteIteratorViewHandle,
                                             NrtSparseSetMemoryContainer_ByteIteratorViewHandle,
-                                            size_t);
+                                            size_t,
+                                            void*);
 
-    typedef void (*NrtSystemUpdateFnPtr)(NrtTimestamp, NrtCatalogueHandle);
+    typedef void (*NrtSystemUpdateFnPtr)(NrtTimestamp, NrtCatalogueHandle, void*);
 
     typedef NrtAtom NrtEntityId;
     typedef NrtAtom NrtComponentTypeId;

--- a/include/NovelRT.Interop/Ecs/NrtSystemScheduler.h
+++ b/include/NovelRT.Interop/Ecs/NrtSystemScheduler.h
@@ -15,7 +15,9 @@ extern "C"
 
     NrtSystemSchedulerHandle Nrt_SystemScheduler_Create(uint32_t maximumThreadCount);
 
-    void Nrt_SystemScheduler_RegisterSystem(NrtSystemSchedulerHandle scheduler, NrtSystemUpdateFnPtr systemUpdatePtr, void* context);
+    void Nrt_SystemScheduler_RegisterSystem(NrtSystemSchedulerHandle scheduler,
+                                            NrtSystemUpdateFnPtr systemUpdatePtr,
+                                            void* context);
 
     uint32_t Nrt_SystemScheduler_GetWorkerThreadCount(NrtSystemSchedulerHandle systemScheduler);
 

--- a/include/NovelRT.Interop/Ecs/NrtSystemScheduler.h
+++ b/include/NovelRT.Interop/Ecs/NrtSystemScheduler.h
@@ -15,7 +15,7 @@ extern "C"
 
     NrtSystemSchedulerHandle Nrt_SystemScheduler_Create(uint32_t maximumThreadCount);
 
-    void Nrt_SystemScheduler_RegisterSystem(NrtSystemSchedulerHandle scheduler, NrtSystemUpdateFnPtr systemUpdatePtr);
+    void Nrt_SystemScheduler_RegisterSystem(NrtSystemSchedulerHandle scheduler, NrtSystemUpdateFnPtr systemUpdatePtr, void* context);
 
     uint32_t Nrt_SystemScheduler_GetWorkerThreadCount(NrtSystemSchedulerHandle systemScheduler);
 

--- a/include/NovelRT.Interop/Graphics/NrtCamera.h
+++ b/include/NovelRT.Interop/Graphics/NrtCamera.h
@@ -20,7 +20,8 @@ extern "C"
     NrtGeoMatrix4x4F Nrt_Camera_getCameraUboMatrix(NrtCameraHandle camera);
     NrtCameraFrameState Nrt_Camera_getFrameState(NrtCameraHandle camera);
     NrtResult Nrt_Camera_setForceResizeCallback(NrtCameraHandle camera,
-                                                void (*callback)(NrtCameraHandle, NrtGeoVector2F, void*), void* context);
+                                                void (*callback)(NrtCameraHandle, NrtGeoVector2F, void*),
+                                                void* context);
     NrtCameraHandle Nrt_Camera_createDefaultOrthographicProjection(NrtGeoVector2F windowSize);
     NrtCameraHandle Nrt_Camera_createDefaultPerspectiveProjection(NrtGeoVector2F windowSize);
     NrtResult Nrt_Camera_destroy(NrtCameraHandle camera);

--- a/include/NovelRT.Interop/Graphics/NrtCamera.h
+++ b/include/NovelRT.Interop/Graphics/NrtCamera.h
@@ -20,7 +20,7 @@ extern "C"
     NrtGeoMatrix4x4F Nrt_Camera_getCameraUboMatrix(NrtCameraHandle camera);
     NrtCameraFrameState Nrt_Camera_getFrameState(NrtCameraHandle camera);
     NrtResult Nrt_Camera_setForceResizeCallback(NrtCameraHandle camera,
-                                                void (*callback)(NrtCameraHandle, NrtGeoVector2F));
+                                                void (*callback)(NrtCameraHandle, NrtGeoVector2F, void*), void* context);
     NrtCameraHandle Nrt_Camera_createDefaultOrthographicProjection(NrtGeoVector2F windowSize);
     NrtCameraHandle Nrt_Camera_createDefaultPerspectiveProjection(NrtGeoVector2F windowSize);
     NrtResult Nrt_Camera_destroy(NrtCameraHandle camera);

--- a/include/NovelRT.Interop/Input/NrtBasicInteractionRect.h
+++ b/include/NovelRT.Interop/Input/NrtBasicInteractionRect.h
@@ -23,7 +23,7 @@ extern "C"
                                                                          const NrtGeoVector2F mousePosition);
     NrtKeyCode Nrt_Input_BasicInteractionRect_getSubscribedKey(NrtBasicInteractionRectHandle object);
     NrtResult Nrt_Input_BasicInteractionRect_setSubscribedKey(NrtBasicInteractionRectHandle object, NrtKeyCode value);
-    NrtResult Nrt_Input_BasicInteractionRect_addInteraction(NrtBasicInteractionRectHandle object, void (*ptr)());
+    NrtResult Nrt_Input_BasicInteractionRect_addInteraction(NrtBasicInteractionRectHandle object, void (*ptr)(void*), void* context);
 
 #ifdef __cplusplus
 }

--- a/include/NovelRT.Interop/Input/NrtBasicInteractionRect.h
+++ b/include/NovelRT.Interop/Input/NrtBasicInteractionRect.h
@@ -23,7 +23,9 @@ extern "C"
                                                                          const NrtGeoVector2F mousePosition);
     NrtKeyCode Nrt_Input_BasicInteractionRect_getSubscribedKey(NrtBasicInteractionRectHandle object);
     NrtResult Nrt_Input_BasicInteractionRect_setSubscribedKey(NrtBasicInteractionRectHandle object, NrtKeyCode value);
-    NrtResult Nrt_Input_BasicInteractionRect_addInteraction(NrtBasicInteractionRectHandle object, void (*ptr)(void*), void* context);
+    NrtResult Nrt_Input_BasicInteractionRect_addInteraction(NrtBasicInteractionRectHandle object,
+                                                            void (*ptr)(void*),
+                                                            void* context);
 
 #ifdef __cplusplus
 }

--- a/include/NovelRT.Interop/NrtNovelRunner.h
+++ b/include/NovelRT.Interop/NrtNovelRunner.h
@@ -28,8 +28,8 @@ extern "C"
     NrtResult Nrt_NovelRunner_getRenderer(NrtNovelRunnerHandle runner, NrtRenderingServiceHandle* outputService);
     NrtResult Nrt_NovelRunner_getDebugService(NrtNovelRunnerHandle runner, NrtDebugServiceHandle* outputService);
 
-    NrtResult Nrt_NovelRunner_addUpdate(NrtNovelRunnerHandle runner, void (*func)(NrtTimestamp));
-    NrtResult Nrt_NovelRunner_addSceneConstructionRequested(NrtNovelRunnerHandle runner, void (*func)());
+    NrtResult Nrt_NovelRunner_addUpdate(NrtNovelRunnerHandle runner, void (*func)(NrtTimestamp, void*), void* context);
+    NrtResult Nrt_NovelRunner_addSceneConstructionRequested(NrtNovelRunnerHandle runner, void (*func)(void*), void* context);
     NrtResult Nrt_NovelRunner_getUpdateEvent(NrtNovelRunnerHandle runner,
                                              NrtUtilitiesEventWithTimestampHandle* outputEvent);
     NrtResult Nrt_NovelRunner_getSceneConstructionEvent(NrtNovelRunnerHandle runner,

--- a/include/NovelRT.Interop/NrtNovelRunner.h
+++ b/include/NovelRT.Interop/NrtNovelRunner.h
@@ -29,7 +29,9 @@ extern "C"
     NrtResult Nrt_NovelRunner_getDebugService(NrtNovelRunnerHandle runner, NrtDebugServiceHandle* outputService);
 
     NrtResult Nrt_NovelRunner_addUpdate(NrtNovelRunnerHandle runner, void (*func)(NrtTimestamp, void*), void* context);
-    NrtResult Nrt_NovelRunner_addSceneConstructionRequested(NrtNovelRunnerHandle runner, void (*func)(void*), void* context);
+    NrtResult Nrt_NovelRunner_addSceneConstructionRequested(NrtNovelRunnerHandle runner,
+                                                            void (*func)(void*),
+                                                            void* context);
     NrtResult Nrt_NovelRunner_getUpdateEvent(NrtNovelRunnerHandle runner,
                                              NrtUtilitiesEventWithTimestampHandle* outputEvent);
     NrtResult Nrt_NovelRunner_getSceneConstructionEvent(NrtNovelRunnerHandle runner,

--- a/include/NovelRT.Interop/SceneGraph/NrtSceneNode.h
+++ b/include/NovelRT.Interop/SceneGraph/NrtSceneNode.h
@@ -17,12 +17,16 @@ extern "C"
     NrtBool Nrt_SceneNode_insert(NrtSceneNodeHandle node, NrtSceneNodeHandle nodeToInsert);
     NrtBool Nrt_SceneNode_remove(NrtSceneNodeHandle node, NrtSceneNodeHandle nodeToRemove);
     NrtBool Nrt_SceneNode_isAdjacent(NrtSceneNodeHandle firstNode, NrtSceneNodeHandle secondNode);
-    NrtResult Nrt_SceneNode_traverseBreadthFirst(NrtSceneNodeHandle node, void (*action)(NrtSceneNodeHandle, void*), void* context);
+    NrtResult Nrt_SceneNode_traverseBreadthFirst(NrtSceneNodeHandle node,
+                                                 void (*action)(NrtSceneNodeHandle, void*),
+                                                 void* context);
     NrtResult Nrt_SceneNode_traverseBreadthFirstWithIterator(NrtSceneNodeHandle node,
                                                              int32_t (*action)(NrtSceneNodeHandle, void*),
                                                              void* context,
                                                              NrtSceneNodeBreadthFirstIteratorHandle* outputIterator);
-    NrtResult Nrt_SceneNode_traverseDepthFirst(NrtSceneNodeHandle node, void (*action)(NrtSceneNodeHandle, void*), void* context);
+    NrtResult Nrt_SceneNode_traverseDepthFirst(NrtSceneNodeHandle node,
+                                               void (*action)(NrtSceneNodeHandle, void*),
+                                               void* context);
     NrtResult Nrt_SceneNode_traverseDepthFirstWithIterator(NrtSceneNodeHandle node,
                                                            int32_t (*action)(NrtSceneNodeHandle, void*),
                                                            void* context,

--- a/include/NovelRT.Interop/SceneGraph/NrtSceneNode.h
+++ b/include/NovelRT.Interop/SceneGraph/NrtSceneNode.h
@@ -17,13 +17,15 @@ extern "C"
     NrtBool Nrt_SceneNode_insert(NrtSceneNodeHandle node, NrtSceneNodeHandle nodeToInsert);
     NrtBool Nrt_SceneNode_remove(NrtSceneNodeHandle node, NrtSceneNodeHandle nodeToRemove);
     NrtBool Nrt_SceneNode_isAdjacent(NrtSceneNodeHandle firstNode, NrtSceneNodeHandle secondNode);
-    NrtResult Nrt_SceneNode_traverseBreadthFirst(NrtSceneNodeHandle node, void (*action)(NrtSceneNodeHandle));
+    NrtResult Nrt_SceneNode_traverseBreadthFirst(NrtSceneNodeHandle node, void (*action)(NrtSceneNodeHandle, void*), void* context);
     NrtResult Nrt_SceneNode_traverseBreadthFirstWithIterator(NrtSceneNodeHandle node,
-                                                             int32_t (*action)(NrtSceneNodeHandle),
+                                                             int32_t (*action)(NrtSceneNodeHandle, void*),
+                                                             void* context,
                                                              NrtSceneNodeBreadthFirstIteratorHandle* outputIterator);
-    NrtResult Nrt_SceneNode_traverseDepthFirst(NrtSceneNodeHandle node, void (*action)(NrtSceneNodeHandle));
+    NrtResult Nrt_SceneNode_traverseDepthFirst(NrtSceneNodeHandle node, void (*action)(NrtSceneNodeHandle, void*), void* context);
     NrtResult Nrt_SceneNode_traverseDepthFirstWithIterator(NrtSceneNodeHandle node,
-                                                           int32_t (*action)(NrtSceneNodeHandle),
+                                                           int32_t (*action)(NrtSceneNodeHandle, void*),
+                                                           void* context,
                                                            NrtSceneNodeDepthFirstIteratorHandle* outputIterator);
     NrtBool Nrt_SceneNode_canReach(NrtSceneNodeHandle firstNode, NrtSceneNodeHandle secondNode);
     NrtResult Nrt_SceneNode_delete(NrtSceneNodeHandle node);

--- a/include/NovelRT.Interop/SceneGraph/NrtSceneNodeBreadthFirstIterator.h
+++ b/include/NovelRT.Interop/SceneGraph/NrtSceneNodeBreadthFirstIterator.h
@@ -12,7 +12,8 @@ extern "C"
 #endif
 
     NrtResult Nrt_SceneNodeBreadthFirstIterator_create(NrtSceneNodeHandle node,
-                                                       int32_t (*func)(NrtSceneNodeHandle),
+                                                       int32_t (*func)(NrtSceneNodeHandle, void*),
+                                                       void* context,
                                                        NrtSceneNodeBreadthFirstIteratorHandle* outputIterator);
     NrtResult Nrt_SceneNodeBreadthFirstIterator_increment(NrtSceneNodeBreadthFirstIteratorHandle iterator);
     NrtResult Nrt_SceneNodeBreadthFirstIterator_postFixIncrement(NrtSceneNodeBreadthFirstIteratorHandle iterator);

--- a/include/NovelRT.Interop/SceneGraph/NrtSceneNodeDepthFirstIterator.h
+++ b/include/NovelRT.Interop/SceneGraph/NrtSceneNodeDepthFirstIterator.h
@@ -12,7 +12,8 @@ extern "C"
 #endif
 
     NrtResult Nrt_SceneNodeDepthFirstIterator_create(NrtSceneNodeHandle node,
-                                                     int32_t (*func)(NrtSceneNodeHandle),
+                                                     int32_t (*func)(NrtSceneNodeHandle, void*),
+                                                     void* context,
                                                      NrtSceneNodeDepthFirstIteratorHandle* outputIterator);
     NrtResult Nrt_SceneNodeDepthFirstIterator_increment(NrtSceneNodeDepthFirstIteratorHandle iterator);
     NrtResult Nrt_SceneNodeDepthFirstIterator_postFixIncrement(NrtSceneNodeDepthFirstIteratorHandle iterator);

--- a/samples/CAPI/main.c
+++ b/samples/CAPI/main.c
@@ -83,7 +83,7 @@ void moveNovelChan(NrtTimestamp delta, void* context)
 
             int size = snprintf(NULL, 0, "Flipped X axis movement. Count: %i", bounces);
             char* buf = alloca(size + 1);
-            snprintf(buf, sizeof(buf), "Flipped X axis movement. Count: %i", bounces);
+            snprintf(buf, size + 1, "Flipped X axis movement. Count: %i", bounces);
             Nrt_LoggingService_logInfoLine(console, buf);
         }
     }
@@ -98,7 +98,7 @@ void moveNovelChan(NrtTimestamp delta, void* context)
 
             int size = snprintf(NULL, 0, "Flipped X axis movement. Count: %i", bounces);
             char* buf = alloca(size + 1);
-            snprintf(buf, sizeof(buf), "Flipped X axis movement. Count: %i", bounces);
+            snprintf(buf, size + 1, "Flipped X axis movement. Count: %i", bounces);
             Nrt_LoggingService_logInfoLine(console, buf);
         }
     }
@@ -114,7 +114,7 @@ void moveNovelChan(NrtTimestamp delta, void* context)
 
             int size = snprintf(NULL, 0, "Flipped Y axis movement. Count: %i", bounces);
             char* buf = alloca(size + 1);
-            snprintf(buf, sizeof(buf), "Flipped Y axis movement. Count: %i", bounces);
+            snprintf(buf, size + 1, "Flipped Y axis movement. Count: %i", bounces);
             Nrt_LoggingService_logInfoLine(console, buf);
         }
     }
@@ -129,7 +129,7 @@ void moveNovelChan(NrtTimestamp delta, void* context)
 
             int size = snprintf(NULL, 0, "Flipped Y axis movement. Count: %i", bounces);
             char* buf = alloca(size + 1);
-            snprintf(buf, sizeof(buf), "Flipped Y axis movement. Count: %i", bounces);
+            snprintf(buf, size + 1, "Flipped Y axis movement. Count: %i", bounces);
             Nrt_LoggingService_logInfoLine(console, buf);
         }
     }

--- a/samples/CAPI/main.c
+++ b/samples/CAPI/main.c
@@ -33,14 +33,19 @@ NrtBasicInteractionRectHandle interactRect = NULL;
 NrtStoryHandle story = NULL;
 
 // Function to render NovelChan
-void renderNovelChan()
+void renderNovelChan(void* context)
 {
     Nrt_ImageRect_executeObjectBehaviour(nChanRect);
     Nrt_Input_BasicInteractionRect_executeObjectBehaviour(interactRect);
 }
 
+struct moveContext {
+  int xBounces;
+  int yBounces;
+};
+
 // Function to move NovelChan DVD screensaver style
-void moveNovelChan(NrtTimestamp delta)
+void moveNovelChan(NrtTimestamp delta, void* context)
 {
     if (nChanRect == NULL)
         return;
@@ -48,6 +53,7 @@ void moveNovelChan(NrtTimestamp delta)
     int32_t bounced = 0;
     float trueDelta = 0.0f;
     float moveAmount = 100.0f;
+    struct moveContext* moveContext = (struct moveContext*)context;
 
     trueDelta = Nrt_Timestamp_getSecondsFloat(delta);
     NrtTransform transform = Nrt_ImageRect_getTransform(nChanRect);
@@ -72,7 +78,12 @@ void moveNovelChan(NrtTimestamp delta)
         {
             hMove = 0;
             bounced = 1;
-            Nrt_LoggingService_logInfoLine(console, "Flipped X axis movement.");
+            int bounces = ++moveContext->xBounces;
+
+            int size = snprintf(NULL, 0, "Flipped X axis movement. Count: %i", bounces);
+            char buf[size + 1];
+            snprintf(buf, sizeof(buf), "Flipped X axis movement. Count: %i", bounces);
+            Nrt_LoggingService_logInfoLine(console, buf);
         }
     }
     else
@@ -82,7 +93,12 @@ void moveNovelChan(NrtTimestamp delta)
         {
             hMove = 1;
             bounced = 1;
-            Nrt_LoggingService_logInfoLine(console, "Flipped X axis movement.");
+            int bounces = ++moveContext->xBounces;
+
+            int size = snprintf(NULL, 0, "Flipped X axis movement. Count: %i", bounces);
+            char buf[size + 1];
+            snprintf(buf, sizeof(buf), "Flipped X axis movement. Count: %i", bounces);
+            Nrt_LoggingService_logInfoLine(console, buf);
         }
     }
 
@@ -93,7 +109,12 @@ void moveNovelChan(NrtTimestamp delta)
         {
             vMove = 0;
             bounced = 1;
-            Nrt_LoggingService_logInfoLine(console, "Flipped Y axis movement.");
+            int bounces = ++moveContext->yBounces;
+
+            int size = snprintf(NULL, 0, "Flipped Y axis movement. Count: %i", bounces);
+            char buf[size + 1];
+            snprintf(buf, sizeof(buf), "Flipped Y axis movement. Count: %i", bounces);
+            Nrt_LoggingService_logInfoLine(console, buf);
         }
     }
     else
@@ -103,7 +124,12 @@ void moveNovelChan(NrtTimestamp delta)
         {
             vMove = 1;
             bounced = 1;
-            Nrt_LoggingService_logInfoLine(console, "Flipped Y axis movement.");
+            int bounces = ++moveContext->yBounces;
+
+            int size = snprintf(NULL, 0, "Flipped Y axis movement. Count: %i", bounces);
+            char buf[size + 1];
+            snprintf(buf, sizeof(buf), "Flipped Y axis movement. Count: %i", bounces);
+            Nrt_LoggingService_logInfoLine(console, buf);
         }
     }
 
@@ -121,7 +147,7 @@ void moveNovelChan(NrtTimestamp delta)
 }
 
 // Function to interact with Ink
-void interactWithNovelChan()
+void interactWithNovelChan(void* context)
 {
     if (Nrt_Story_canContinue(story) == NRT_FALSE)
     {
@@ -278,14 +304,15 @@ int main()
         {
             Nrt_Story_resetState(story);
         }
-        Nrt_Input_BasicInteractionRect_addInteraction(interactRect, &interactWithNovelChan);
+        Nrt_Input_BasicInteractionRect_addInteraction(interactRect, &interactWithNovelChan, NULL);
     }
 
     // Setting up Scene Construction
-    Nrt_NovelRunner_addSceneConstructionRequested(runner, &renderNovelChan);
+    Nrt_NovelRunner_addSceneConstructionRequested(runner, &renderNovelChan, NULL);
 
     // Setting up Update methods
-    Nrt_NovelRunner_addUpdate(runner, moveNovelChan);
+    struct moveContext moveContext;
+    Nrt_NovelRunner_addUpdate(runner, moveNovelChan, &moveContext);
 
     // Run the novel!
     Nrt_NovelRunner_runNovel(runner);

--- a/samples/CAPI/main.c
+++ b/samples/CAPI/main.c
@@ -39,9 +39,10 @@ void renderNovelChan(void* context)
     Nrt_Input_BasicInteractionRect_executeObjectBehaviour(interactRect);
 }
 
-struct moveContext {
-  int xBounces;
-  int yBounces;
+struct moveContext
+{
+    int xBounces;
+    int yBounces;
 };
 
 // Function to move NovelChan DVD screensaver style

--- a/samples/CAPI/main.c
+++ b/samples/CAPI/main.c
@@ -82,7 +82,7 @@ void moveNovelChan(NrtTimestamp delta, void* context)
             int bounces = ++moveContext->xBounces;
 
             int size = snprintf(NULL, 0, "Flipped X axis movement. Count: %i", bounces);
-            char buf[size + 1];
+            char* buf = alloca(size + 1);
             snprintf(buf, sizeof(buf), "Flipped X axis movement. Count: %i", bounces);
             Nrt_LoggingService_logInfoLine(console, buf);
         }
@@ -97,7 +97,7 @@ void moveNovelChan(NrtTimestamp delta, void* context)
             int bounces = ++moveContext->xBounces;
 
             int size = snprintf(NULL, 0, "Flipped X axis movement. Count: %i", bounces);
-            char buf[size + 1];
+            char* buf = alloca(size + 1);
             snprintf(buf, sizeof(buf), "Flipped X axis movement. Count: %i", bounces);
             Nrt_LoggingService_logInfoLine(console, buf);
         }
@@ -113,7 +113,7 @@ void moveNovelChan(NrtTimestamp delta, void* context)
             int bounces = ++moveContext->yBounces;
 
             int size = snprintf(NULL, 0, "Flipped Y axis movement. Count: %i", bounces);
-            char buf[size + 1];
+            char* buf = alloca(size + 1);
             snprintf(buf, sizeof(buf), "Flipped Y axis movement. Count: %i", bounces);
             Nrt_LoggingService_logInfoLine(console, buf);
         }
@@ -128,7 +128,7 @@ void moveNovelChan(NrtTimestamp delta, void* context)
             int bounces = ++moveContext->yBounces;
 
             int size = snprintf(NULL, 0, "Flipped Y axis movement. Count: %i", bounces);
-            char buf[size + 1];
+            char* buf = alloca(size + 1);
             snprintf(buf, sizeof(buf), "Flipped Y axis movement. Count: %i", bounces);
             Nrt_LoggingService_logInfoLine(console, buf);
         }

--- a/samples/CAPI/main.c
+++ b/samples/CAPI/main.c
@@ -16,6 +16,8 @@ int32_t inkServiceProvided = NRT_FALSE;
 int32_t hMove = 1; // 1 == move right, 0 == move left
 int32_t vMove = 1; // 1 == move up, 0 == move down
 
+char flippedAxisTempBuffer[1024];
+
 // Services
 NrtAudioServiceHandle audio = NULL;
 NrtInteractionServiceHandle input = NULL;
@@ -33,20 +35,20 @@ NrtBasicInteractionRectHandle interactRect = NULL;
 NrtStoryHandle story = NULL;
 
 // Function to render NovelChan
-void renderNovelChan(void* context)
+void RenderNovelChan(void* context)
 {
     Nrt_ImageRect_executeObjectBehaviour(nChanRect);
     Nrt_Input_BasicInteractionRect_executeObjectBehaviour(interactRect);
 }
 
-struct moveContext
+struct MoveContext
 {
     int xBounces;
     int yBounces;
 };
 
 // Function to move NovelChan DVD screensaver style
-void moveNovelChan(NrtTimestamp delta, void* context)
+void MoveNovelChan(NrtTimestamp delta, void* context)
 {
     if (nChanRect == NULL)
         return;
@@ -54,7 +56,7 @@ void moveNovelChan(NrtTimestamp delta, void* context)
     int32_t bounced = 0;
     float trueDelta = 0.0f;
     float moveAmount = 100.0f;
-    struct moveContext* moveContext = (struct moveContext*)context;
+    struct MoveContext* moveContext = (struct MoveContext*)context;
 
     trueDelta = Nrt_Timestamp_getSecondsFloat(delta);
     NrtTransform transform = Nrt_ImageRect_getTransform(nChanRect);
@@ -82,9 +84,8 @@ void moveNovelChan(NrtTimestamp delta, void* context)
             int bounces = ++moveContext->xBounces;
 
             int size = snprintf(NULL, 0, "Flipped X axis movement. Count: %i", bounces);
-            char* buf = alloca(size + 1);
-            snprintf(buf, size + 1, "Flipped X axis movement. Count: %i", bounces);
-            Nrt_LoggingService_logInfoLine(console, buf);
+            snprintf(flippedAxisTempBuffer, size + 1, "Flipped X axis movement. Count: %i", bounces);
+            Nrt_LoggingService_logInfoLine(console, flippedAxisTempBuffer);
         }
     }
     else
@@ -97,9 +98,8 @@ void moveNovelChan(NrtTimestamp delta, void* context)
             int bounces = ++moveContext->xBounces;
 
             int size = snprintf(NULL, 0, "Flipped X axis movement. Count: %i", bounces);
-            char* buf = alloca(size + 1);
-            snprintf(buf, size + 1, "Flipped X axis movement. Count: %i", bounces);
-            Nrt_LoggingService_logInfoLine(console, buf);
+            snprintf(flippedAxisTempBuffer, size + 1, "Flipped X axis movement. Count: %i", bounces);
+            Nrt_LoggingService_logInfoLine(console, flippedAxisTempBuffer);
         }
     }
 
@@ -113,9 +113,8 @@ void moveNovelChan(NrtTimestamp delta, void* context)
             int bounces = ++moveContext->yBounces;
 
             int size = snprintf(NULL, 0, "Flipped Y axis movement. Count: %i", bounces);
-            char* buf = alloca(size + 1);
-            snprintf(buf, size + 1, "Flipped Y axis movement. Count: %i", bounces);
-            Nrt_LoggingService_logInfoLine(console, buf);
+            snprintf(flippedAxisTempBuffer, size + 1, "Flipped Y axis movement. Count: %i", bounces);
+            Nrt_LoggingService_logInfoLine(console, flippedAxisTempBuffer);
         }
     }
     else
@@ -128,9 +127,8 @@ void moveNovelChan(NrtTimestamp delta, void* context)
             int bounces = ++moveContext->yBounces;
 
             int size = snprintf(NULL, 0, "Flipped Y axis movement. Count: %i", bounces);
-            char* buf = alloca(size + 1);
-            snprintf(buf, size + 1, "Flipped Y axis movement. Count: %i", bounces);
-            Nrt_LoggingService_logInfoLine(console, buf);
+            snprintf(flippedAxisTempBuffer, size + 1, "Flipped Y axis movement. Count: %i", bounces);
+            Nrt_LoggingService_logInfoLine(console, flippedAxisTempBuffer);
         }
     }
 
@@ -148,7 +146,7 @@ void moveNovelChan(NrtTimestamp delta, void* context)
 }
 
 // Function to interact with Ink
-void interactWithNovelChan(void* context)
+void InteractWithNovelChan(void* context)
 {
     if (Nrt_Story_canContinue(story) == NRT_FALSE)
     {
@@ -305,15 +303,15 @@ int main()
         {
             Nrt_Story_resetState(story);
         }
-        Nrt_Input_BasicInteractionRect_addInteraction(interactRect, &interactWithNovelChan, NULL);
+        Nrt_Input_BasicInteractionRect_addInteraction(interactRect, &InteractWithNovelChan, NULL);
     }
 
     // Setting up Scene Construction
-    Nrt_NovelRunner_addSceneConstructionRequested(runner, &renderNovelChan, NULL);
+    Nrt_NovelRunner_addSceneConstructionRequested(runner, &RenderNovelChan, NULL);
 
     // Setting up Update methods
-    struct moveContext moveContext;
-    Nrt_NovelRunner_addUpdate(runner, moveNovelChan, &moveContext);
+    struct MoveContext moveContext;
+    Nrt_NovelRunner_addUpdate(runner, MoveNovelChan, &moveContext);
 
     // Run the novel!
     Nrt_NovelRunner_runNovel(runner);

--- a/src/NovelRT.Interop/Animation/NrtSpriteAnimatorFrame.cpp
+++ b/src/NovelRT.Interop/Animation/NrtSpriteAnimatorFrame.cpp
@@ -69,7 +69,7 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_SpriteAnimatorFrame_addFrameEnter(NrtSpriteAnimatorFrameHandle frame, void (*func)())
+    NrtResult Nrt_SpriteAnimatorFrame_addFrameEnter(NrtSpriteAnimatorFrameHandle frame, void (*func)(void*), void* context)
     {
         if (frame == nullptr || func == nullptr)
         {
@@ -78,12 +78,12 @@ extern "C"
         }
 
         Animation::SpriteAnimatorFrame* cppFrame = reinterpret_cast<Animation::SpriteAnimatorFrame*>(frame);
-        cppFrame->FrameEnter += func;
+        cppFrame->FrameEnter += std::bind(func, context);
 
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_SpriteAnimatorFrame_addFrameExit(NrtSpriteAnimatorFrameHandle frame, void (*func)())
+    NrtResult Nrt_SpriteAnimatorFrame_addFrameExit(NrtSpriteAnimatorFrameHandle frame, void (*func)(void*), void* context)
     {
         if (frame == nullptr || func == nullptr)
         {
@@ -92,7 +92,7 @@ extern "C"
         }
 
         Animation::SpriteAnimatorFrame* cppFrame = reinterpret_cast<Animation::SpriteAnimatorFrame*>(frame);
-        cppFrame->FrameExit += func;
+        cppFrame->FrameExit += std::bind(func, context);
 
         return NRT_SUCCESS;
     }

--- a/src/NovelRT.Interop/Animation/NrtSpriteAnimatorFrame.cpp
+++ b/src/NovelRT.Interop/Animation/NrtSpriteAnimatorFrame.cpp
@@ -69,7 +69,9 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_SpriteAnimatorFrame_addFrameEnter(NrtSpriteAnimatorFrameHandle frame, void (*func)(void*), void* context)
+    NrtResult Nrt_SpriteAnimatorFrame_addFrameEnter(NrtSpriteAnimatorFrameHandle frame,
+                                                    void (*func)(void*),
+                                                    void* context)
     {
         if (frame == nullptr || func == nullptr)
         {
@@ -83,7 +85,9 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_SpriteAnimatorFrame_addFrameExit(NrtSpriteAnimatorFrameHandle frame, void (*func)(void*), void* context)
+    NrtResult Nrt_SpriteAnimatorFrame_addFrameExit(NrtSpriteAnimatorFrameHandle frame,
+                                                   void (*func)(void*),
+                                                   void* context)
     {
         if (frame == nullptr || func == nullptr)
         {

--- a/src/NovelRT.Interop/Ecs/NrtComponentBufferMemoryContainer.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtComponentBufferMemoryContainer.cpp
@@ -23,9 +23,7 @@ extern "C"
         auto func = [=](SparseSetMemoryContainer::ByteIteratorView lhs, SparseSetMemoryContainer::ByteIteratorView rhs,
                         size_t size) {
             fnPtr(reinterpret_cast<NrtSparseSetMemoryContainer_ByteIteratorViewHandle>(&lhs),
-                  reinterpret_cast<NrtSparseSetMemoryContainer_ByteIteratorViewHandle>(&rhs),
-                  size,
-                  context);
+                  reinterpret_cast<NrtSparseSetMemoryContainer_ByteIteratorViewHandle>(&rhs), size, context);
         };
 
         return reinterpret_cast<NrtComponentBufferMemoryContainerHandle>(

--- a/src/NovelRT.Interop/Ecs/NrtComponentBufferMemoryContainer.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtComponentBufferMemoryContainer.cpp
@@ -17,12 +17,15 @@ extern "C"
     NrtComponentBufferMemoryContainerHandle Nrt_ComponentBufferMemoryContainer_Create(size_t poolSize,
                                                                                       void* deleteInstructionState,
                                                                                       size_t sizeOfDataTypeInBytes,
-                                                                                      NrtComponentUpdateFnPtr fnPtr)
+                                                                                      NrtComponentUpdateFnPtr fnPtr,
+                                                                                      void* context)
     {
         auto func = [=](SparseSetMemoryContainer::ByteIteratorView lhs, SparseSetMemoryContainer::ByteIteratorView rhs,
                         size_t size) {
             fnPtr(reinterpret_cast<NrtSparseSetMemoryContainer_ByteIteratorViewHandle>(&lhs),
-                  reinterpret_cast<NrtSparseSetMemoryContainer_ByteIteratorViewHandle>(&rhs), size);
+                  reinterpret_cast<NrtSparseSetMemoryContainer_ByteIteratorViewHandle>(&rhs),
+                  size,
+                  context);
         };
 
         return reinterpret_cast<NrtComponentBufferMemoryContainerHandle>(

--- a/src/NovelRT.Interop/Ecs/NrtComponentCache.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtComponentCache.cpp
@@ -17,6 +17,7 @@ extern "C"
                                                              size_t sizeOfDataType,
                                                              const void* deleteInstructionState,
                                                              NrtComponentUpdateFnPtr updateFnPtr,
+                                                             void* context,
                                                              NrtComponentTypeId* outputResult)
     {
         if (componentCache == nullptr || deleteInstructionState == nullptr || outputResult == nullptr)
@@ -32,7 +33,8 @@ extern "C"
                         sizeOfDataType, deleteInstructionState, [=](auto lhs, auto rhs, auto size) {
                             updateFnPtr(reinterpret_cast<NrtSparseSetMemoryContainer_ByteIteratorViewHandle>(&lhs),
                                         reinterpret_cast<NrtSparseSetMemoryContainer_ByteIteratorViewHandle>(&rhs),
-                                        size);
+                                        size,
+                                        context);
                         });
 
             return NRT_SUCCESS;

--- a/src/NovelRT.Interop/Ecs/NrtComponentCache.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtComponentCache.cpp
@@ -33,8 +33,7 @@ extern "C"
                         sizeOfDataType, deleteInstructionState, [=](auto lhs, auto rhs, auto size) {
                             updateFnPtr(reinterpret_cast<NrtSparseSetMemoryContainer_ByteIteratorViewHandle>(&lhs),
                                         reinterpret_cast<NrtSparseSetMemoryContainer_ByteIteratorViewHandle>(&rhs),
-                                        size,
-                                        context);
+                                        size, context);
                         });
 
             return NRT_SUCCESS;

--- a/src/NovelRT.Interop/Ecs/NrtSystemScheduler.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtSystemScheduler.cpp
@@ -19,11 +19,11 @@ extern "C"
         return reinterpret_cast<NrtSystemSchedulerHandle>(new SystemScheduler(maximumThreadCount));
     }
 
-    void Nrt_SystemScheduler_RegisterSystem(NrtSystemSchedulerHandle scheduler, NrtSystemUpdateFnPtr systemUpdatePtr)
+    void Nrt_SystemScheduler_RegisterSystem(NrtSystemSchedulerHandle scheduler, NrtSystemUpdateFnPtr systemUpdatePtr, void* context)
     {
         auto schedulerPtr = reinterpret_cast<SystemScheduler*>(scheduler);
         schedulerPtr->RegisterSystem([=](auto timestamp, auto catalogue) {
-            systemUpdatePtr(timestamp.ticks, reinterpret_cast<NrtCatalogueHandle>(&catalogue));
+            systemUpdatePtr(timestamp.ticks, reinterpret_cast<NrtCatalogueHandle>(&catalogue), context);
         });
     }
 

--- a/src/NovelRT.Interop/Ecs/NrtSystemScheduler.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtSystemScheduler.cpp
@@ -19,7 +19,9 @@ extern "C"
         return reinterpret_cast<NrtSystemSchedulerHandle>(new SystemScheduler(maximumThreadCount));
     }
 
-    void Nrt_SystemScheduler_RegisterSystem(NrtSystemSchedulerHandle scheduler, NrtSystemUpdateFnPtr systemUpdatePtr, void* context)
+    void Nrt_SystemScheduler_RegisterSystem(NrtSystemSchedulerHandle scheduler,
+                                            NrtSystemUpdateFnPtr systemUpdatePtr,
+                                            void* context)
     {
         auto schedulerPtr = reinterpret_cast<SystemScheduler*>(scheduler);
         schedulerPtr->RegisterSystem([=](auto timestamp, auto catalogue) {

--- a/src/NovelRT.Interop/Graphics/NrtCamera.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtCamera.cpp
@@ -80,7 +80,7 @@ extern "C"
     }
 
     NrtResult Nrt_Camera_setForceResizeCallback(NrtCameraHandle camera,
-                                                void (*callback)(NrtCameraHandle, NrtGeoVector2F))
+                                                void (*callback)(NrtCameraHandle, NrtGeoVector2F, void*), void* context)
     {
         if (camera == nullptr)
         {
@@ -90,8 +90,8 @@ extern "C"
 
         Camera* cameraPtr = reinterpret_cast<Camera*>(camera);
         cameraPtr->forceResizeCallback() =
-            std::function<void(Camera*, GeoVector2F)>([callback](auto camera, auto newSize) {
-                callback(reinterpret_cast<NrtCameraHandle>(camera), *reinterpret_cast<NrtGeoVector2F*>(&newSize));
+            std::function<void(Camera*, GeoVector2F)>([callback, context](auto camera, auto newSize) {
+                callback(reinterpret_cast<NrtCameraHandle>(camera), *reinterpret_cast<NrtGeoVector2F*>(&newSize), context);
             });
 
         return NRT_SUCCESS;

--- a/src/NovelRT.Interop/Graphics/NrtCamera.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtCamera.cpp
@@ -80,7 +80,8 @@ extern "C"
     }
 
     NrtResult Nrt_Camera_setForceResizeCallback(NrtCameraHandle camera,
-                                                void (*callback)(NrtCameraHandle, NrtGeoVector2F, void*), void* context)
+                                                void (*callback)(NrtCameraHandle, NrtGeoVector2F, void*),
+                                                void* context)
     {
         if (camera == nullptr)
         {
@@ -89,10 +90,10 @@ extern "C"
         }
 
         Camera* cameraPtr = reinterpret_cast<Camera*>(camera);
-        cameraPtr->forceResizeCallback() =
-            std::function<void(Camera*, GeoVector2F)>([callback, context](auto camera, auto newSize) {
-                callback(reinterpret_cast<NrtCameraHandle>(camera), *reinterpret_cast<NrtGeoVector2F*>(&newSize), context);
-            });
+        cameraPtr->forceResizeCallback() = std::function<void(Camera*, GeoVector2F)>([callback, context](auto camera,
+                                                                                                         auto newSize) {
+            callback(reinterpret_cast<NrtCameraHandle>(camera), *reinterpret_cast<NrtGeoVector2F*>(&newSize), context);
+        });
 
         return NRT_SUCCESS;
     }

--- a/src/NovelRT.Interop/Input/NrtBasicInteractionRect.cpp
+++ b/src/NovelRT.Interop/Input/NrtBasicInteractionRect.cpp
@@ -108,7 +108,9 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_Input_BasicInteractionRect_addInteraction(NrtBasicInteractionRectHandle object, void (*action)(void*), void* context)
+    NrtResult Nrt_Input_BasicInteractionRect_addInteraction(NrtBasicInteractionRectHandle object,
+                                                            void (*action)(void*),
+                                                            void* context)
     {
         if (object == nullptr)
         {

--- a/src/NovelRT.Interop/Input/NrtBasicInteractionRect.cpp
+++ b/src/NovelRT.Interop/Input/NrtBasicInteractionRect.cpp
@@ -108,7 +108,7 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_Input_BasicInteractionRect_addInteraction(NrtBasicInteractionRectHandle object, void (*ptr)())
+    NrtResult Nrt_Input_BasicInteractionRect_addInteraction(NrtBasicInteractionRectHandle object, void (*action)(void*), void* context)
     {
         if (object == nullptr)
         {
@@ -117,7 +117,7 @@ extern "C"
         }
 
         auto obj = reinterpret_cast<Input::BasicInteractionRect*>(object);
-        obj->Interacted += ptr;
+        obj->Interacted += std::bind(action, context);
         return NRT_SUCCESS;
     }
 

--- a/src/NovelRT.Interop/NrtNovelRunner.cpp
+++ b/src/NovelRT.Interop/NrtNovelRunner.cpp
@@ -197,7 +197,7 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_addUpdate(NrtNovelRunnerHandle runner, void (*func)(NrtTimestamp))
+    NrtResult Nrt_NovelRunner_addUpdate(NrtNovelRunnerHandle runner, void (*func)(NrtTimestamp, void*), void* context)
     {
         if (runner == nullptr || func == nullptr)
         {
@@ -207,12 +207,12 @@ extern "C"
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
 
-        cRunner->Update += [func](Timing::Timestamp delta) { func(reinterpret_cast<NrtTimestamp&>(delta)); };
+        cRunner->Update += [func, context](Timing::Timestamp delta) { func(reinterpret_cast<NrtTimestamp&>(delta), context); };
 
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_addSceneConstructionRequested(NrtNovelRunnerHandle runner, void (*func)())
+    NrtResult Nrt_NovelRunner_addSceneConstructionRequested(NrtNovelRunnerHandle runner, void (*func)(void*), void* context)
     {
         if (runner == nullptr || func == nullptr)
         {
@@ -222,7 +222,7 @@ extern "C"
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
 
-        cRunner->SceneConstructionRequested += [func]() { func(); };
+        cRunner->SceneConstructionRequested += [func, context]() { func(context); };
         return NRT_SUCCESS;
     }
 

--- a/src/NovelRT.Interop/NrtNovelRunner.cpp
+++ b/src/NovelRT.Interop/NrtNovelRunner.cpp
@@ -207,12 +207,15 @@ extern "C"
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
 
-        cRunner->Update += [func, context](Timing::Timestamp delta) { func(reinterpret_cast<NrtTimestamp&>(delta), context); };
+        cRunner->Update +=
+            [func, context](Timing::Timestamp delta) { func(reinterpret_cast<NrtTimestamp&>(delta), context); };
 
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_addSceneConstructionRequested(NrtNovelRunnerHandle runner, void (*func)(void*), void* context)
+    NrtResult Nrt_NovelRunner_addSceneConstructionRequested(NrtNovelRunnerHandle runner,
+                                                            void (*func)(void*),
+                                                            void* context)
     {
         if (runner == nullptr || func == nullptr)
         {

--- a/src/NovelRT.Interop/SceneGraph/NrtSceneNode.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtSceneNode.cpp
@@ -10,18 +10,20 @@
 using namespace NovelRT;
 
 std::list<std::shared_ptr<SceneGraph::SceneNode>> _sceneNodeCollection;
-void (*_voidFunction)(NrtSceneNodeHandle) = NULL;
-int32_t (*_intFunction)(NrtSceneNodeHandle) = NULL;
 
-// Defining internal methods first to prevent compilation issues
-void Internal_VoidSceneNodeFunctionInvoker(const std::shared_ptr<SceneGraph::SceneNode> node)
+void Internal_VoidSceneNodeFunctionInvoker(
+  void (*action)(NrtSceneNodeHandle, void*), void* context,
+  const std::shared_ptr<SceneGraph::SceneNode> node)
 {
-    _voidFunction(reinterpret_cast<NrtSceneNodeHandle>(node.get()));
+    action(reinterpret_cast<NrtSceneNodeHandle>(node.get()), context);
 }
 
-int32_t Internal_Int32TSceneNodeFunctionInvoker(const std::shared_ptr<SceneGraph::SceneNode> node)
+int32_t Internal_Int32TSceneNodeFunctionInvoker(
+  int32_t (*action)(NrtSceneNodeHandle, void*),
+  void* context,
+  const std::shared_ptr<SceneGraph::SceneNode> node)
 {
-    return _intFunction(reinterpret_cast<NrtSceneNodeHandle>(node.get()));
+    return action(reinterpret_cast<NrtSceneNodeHandle>(node.get()), context);
 }
 
 #ifdef __cplusplus
@@ -87,7 +89,7 @@ extern "C"
             nodePointer->isAdjacent(reinterpret_cast<SceneGraph::SceneNode*>(secondNode)->shared_from_this()));
     }
 
-    NrtResult Nrt_SceneNode_traverseBreadthFirst(NrtSceneNodeHandle node, void (*action)(NrtSceneNodeHandle))
+    NrtResult Nrt_SceneNode_traverseBreadthFirst(NrtSceneNodeHandle node, void (*action)(NrtSceneNodeHandle,void*), void* context)
     {
         if (node == nullptr || action == nullptr)
         {
@@ -96,13 +98,14 @@ extern "C"
         }
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
-        _voidFunction = action;
-        nodePointer->traverseBreadthFirst(Internal_VoidSceneNodeFunctionInvoker);
+        auto func = std::bind(Internal_VoidSceneNodeFunctionInvoker, action, context, std::placeholders::_1);
+        nodePointer->traverseBreadthFirst(func);
         return NRT_SUCCESS;
     }
 
     NrtResult Nrt_SceneNode_traverseBreadthFirstWithIterator(NrtSceneNodeHandle node,
-                                                             int32_t (*action)(NrtSceneNodeHandle),
+                                                             int32_t (*action)(NrtSceneNodeHandle, void*),
+                                                             void* context,
                                                              NrtSceneNodeBreadthFirstIteratorHandle* outputIterator)
     {
         if (node == nullptr || action == nullptr || outputIterator == nullptr)
@@ -113,16 +116,16 @@ extern "C"
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
 
-        _intFunction = action;
+        auto func = std::bind(Internal_Int32TSceneNodeFunctionInvoker, action, context, std::placeholders::_1);
         SceneGraph::SceneNode::breadth_first_traversal_result_iterator<int32_t>* itPtr =
             new SceneGraph::SceneNode::breadth_first_traversal_result_iterator<int32_t>(
-                nodePointer, Internal_Int32TSceneNodeFunctionInvoker);
+                nodePointer, func);
         *outputIterator = reinterpret_cast<NrtSceneNodeBreadthFirstIteratorHandle>(itPtr);
 
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_SceneNode_traverseDepthFirst(NrtSceneNodeHandle node, void (*action)(NrtSceneNodeHandle))
+    NrtResult Nrt_SceneNode_traverseDepthFirst(NrtSceneNodeHandle node, void (*action)(NrtSceneNodeHandle, void*), void* context)
     {
         if (node == nullptr || action == nullptr)
         {
@@ -132,13 +135,14 @@ extern "C"
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
 
-        _voidFunction = action;
-        nodePointer->traverseDepthFirst(Internal_VoidSceneNodeFunctionInvoker);
+        auto func = std::bind(Internal_VoidSceneNodeFunctionInvoker, action, context, std::placeholders::_1);
+        nodePointer->traverseDepthFirst(func);
         return NRT_SUCCESS;
     }
 
     NrtResult Nrt_SceneNode_traverseDepthFirstWithIterator(NrtSceneNodeHandle node,
-                                                           int32_t (*action)(NrtSceneNodeHandle),
+                                                           int32_t (*action)(NrtSceneNodeHandle, void*),
+                                                           void* context,
                                                            NrtSceneNodeDepthFirstIteratorHandle* outputIterator)
     {
         if (node == nullptr || action == nullptr || outputIterator == nullptr)
@@ -149,10 +153,10 @@ extern "C"
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
 
-        _intFunction = action;
+        auto func = std::bind(Internal_Int32TSceneNodeFunctionInvoker, action, context, std::placeholders::_1);
         SceneGraph::SceneNode::depth_first_traversal_result_iterator<int32_t>* itPtr =
             new SceneGraph::SceneNode::depth_first_traversal_result_iterator<int32_t>(
-                nodePointer, Internal_Int32TSceneNodeFunctionInvoker);
+                nodePointer, func);
         *outputIterator = reinterpret_cast<NrtSceneNodeDepthFirstIteratorHandle>(itPtr);
 
         return NRT_SUCCESS;

--- a/src/NovelRT.Interop/SceneGraph/NrtSceneNode.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtSceneNode.cpp
@@ -11,17 +11,16 @@ using namespace NovelRT;
 
 std::list<std::shared_ptr<SceneGraph::SceneNode>> _sceneNodeCollection;
 
-void Internal_VoidSceneNodeFunctionInvoker(
-  void (*action)(NrtSceneNodeHandle, void*), void* context,
-  const std::shared_ptr<SceneGraph::SceneNode> node)
+void Internal_VoidSceneNodeFunctionInvoker(void (*action)(NrtSceneNodeHandle, void*),
+                                           void* context,
+                                           const std::shared_ptr<SceneGraph::SceneNode> node)
 {
     action(reinterpret_cast<NrtSceneNodeHandle>(node.get()), context);
 }
 
-int32_t Internal_Int32TSceneNodeFunctionInvoker(
-  int32_t (*action)(NrtSceneNodeHandle, void*),
-  void* context,
-  const std::shared_ptr<SceneGraph::SceneNode> node)
+int32_t Internal_Int32TSceneNodeFunctionInvoker(int32_t (*action)(NrtSceneNodeHandle, void*),
+                                                void* context,
+                                                const std::shared_ptr<SceneGraph::SceneNode> node)
 {
     return action(reinterpret_cast<NrtSceneNodeHandle>(node.get()), context);
 }
@@ -89,7 +88,9 @@ extern "C"
             nodePointer->isAdjacent(reinterpret_cast<SceneGraph::SceneNode*>(secondNode)->shared_from_this()));
     }
 
-    NrtResult Nrt_SceneNode_traverseBreadthFirst(NrtSceneNodeHandle node, void (*action)(NrtSceneNodeHandle,void*), void* context)
+    NrtResult Nrt_SceneNode_traverseBreadthFirst(NrtSceneNodeHandle node,
+                                                 void (*action)(NrtSceneNodeHandle, void*),
+                                                 void* context)
     {
         if (node == nullptr || action == nullptr)
         {
@@ -118,14 +119,15 @@ extern "C"
 
         auto func = std::bind(Internal_Int32TSceneNodeFunctionInvoker, action, context, std::placeholders::_1);
         SceneGraph::SceneNode::breadth_first_traversal_result_iterator<int32_t>* itPtr =
-            new SceneGraph::SceneNode::breadth_first_traversal_result_iterator<int32_t>(
-                nodePointer, func);
+            new SceneGraph::SceneNode::breadth_first_traversal_result_iterator<int32_t>(nodePointer, func);
         *outputIterator = reinterpret_cast<NrtSceneNodeBreadthFirstIteratorHandle>(itPtr);
 
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_SceneNode_traverseDepthFirst(NrtSceneNodeHandle node, void (*action)(NrtSceneNodeHandle, void*), void* context)
+    NrtResult Nrt_SceneNode_traverseDepthFirst(NrtSceneNodeHandle node,
+                                               void (*action)(NrtSceneNodeHandle, void*),
+                                               void* context)
     {
         if (node == nullptr || action == nullptr)
         {
@@ -155,8 +157,7 @@ extern "C"
 
         auto func = std::bind(Internal_Int32TSceneNodeFunctionInvoker, action, context, std::placeholders::_1);
         SceneGraph::SceneNode::depth_first_traversal_result_iterator<int32_t>* itPtr =
-            new SceneGraph::SceneNode::depth_first_traversal_result_iterator<int32_t>(
-                nodePointer, func);
+            new SceneGraph::SceneNode::depth_first_traversal_result_iterator<int32_t>(nodePointer, func);
         *outputIterator = reinterpret_cast<NrtSceneNodeDepthFirstIteratorHandle>(itPtr);
 
         return NRT_SUCCESS;

--- a/src/NovelRT.Interop/SceneGraph/NrtSceneNodeBreadthFirstIterator.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtSceneNodeBreadthFirstIterator.cpp
@@ -9,7 +9,9 @@
 
 using namespace NovelRT;
 
-int32_t Internal_BreadthFirstIteratorFunctionDelegate(int32_t (*action)(NrtSceneNodeHandle, void* context), void* context, const std::shared_ptr<SceneGraph::SceneNode>& node)
+int32_t Internal_BreadthFirstIteratorFunctionDelegate(int32_t (*action)(NrtSceneNodeHandle, void* context),
+                                                      void* context,
+                                                      const std::shared_ptr<SceneGraph::SceneNode>& node)
 {
     return action(reinterpret_cast<NrtSceneNodeHandle>(node.get()), context);
 }
@@ -34,8 +36,7 @@ extern "C"
 
         auto func = std::bind(Internal_BreadthFirstIteratorFunctionDelegate, action, context, std::placeholders::_1);
         SceneGraph::SceneNode::breadth_first_traversal_result_iterator<int32_t> iterator =
-            SceneGraph::SceneNode::breadth_first_traversal_result_iterator<int32_t>(
-                nodePointer, func);
+            SceneGraph::SceneNode::breadth_first_traversal_result_iterator<int32_t>(nodePointer, func);
         *outputIterator = reinterpret_cast<NrtSceneNodeBreadthFirstIteratorHandle>(&iterator);
         return NRT_SUCCESS;
     }

--- a/src/NovelRT.Interop/SceneGraph/NrtSceneNodeBreadthFirstIterator.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtSceneNodeBreadthFirstIterator.cpp
@@ -9,11 +9,9 @@
 
 using namespace NovelRT;
 
-int32_t (*_function)(NrtSceneNodeHandle) = NULL;
-
-int32_t Internal_BreadthFirstIteratorFunctionDelegate(const std::shared_ptr<SceneGraph::SceneNode>& node)
+int32_t Internal_BreadthFirstIteratorFunctionDelegate(int32_t (*action)(NrtSceneNodeHandle, void* context), void* context, const std::shared_ptr<SceneGraph::SceneNode>& node)
 {
-    return _function(reinterpret_cast<NrtSceneNodeHandle>(node.get()));
+    return action(reinterpret_cast<NrtSceneNodeHandle>(node.get()), context);
 }
 
 #ifdef __cplusplus
@@ -22,10 +20,11 @@ extern "C"
 #endif
 
     NrtResult Nrt_SceneNodeBreadthFirstIterator_create(NrtSceneNodeHandle node,
-                                                       int32_t (*func)(NrtSceneNodeHandle),
+                                                       int32_t (*action)(NrtSceneNodeHandle, void* context),
+                                                       void* context,
                                                        NrtSceneNodeBreadthFirstIteratorHandle* outputIterator)
     {
-        if (node == nullptr || func == nullptr)
+        if (node == nullptr || action == nullptr)
         {
             Nrt_setErrMsgIsNullptrInternal();
             return NRT_FAILURE_NULLPTR_PROVIDED;
@@ -33,10 +32,10 @@ extern "C"
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
 
-        _function = func;
+        auto func = std::bind(Internal_BreadthFirstIteratorFunctionDelegate, action, context, std::placeholders::_1);
         SceneGraph::SceneNode::breadth_first_traversal_result_iterator<int32_t> iterator =
             SceneGraph::SceneNode::breadth_first_traversal_result_iterator<int32_t>(
-                nodePointer, Internal_BreadthFirstIteratorFunctionDelegate);
+                nodePointer, func);
         *outputIterator = reinterpret_cast<NrtSceneNodeBreadthFirstIteratorHandle>(&iterator);
         return NRT_SUCCESS;
     }

--- a/src/NovelRT.Interop/SceneGraph/NrtSceneNodeDepthFirstIterator.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtSceneNodeDepthFirstIterator.cpp
@@ -9,11 +9,11 @@
 
 using namespace NovelRT;
 
-int32_t (*_depthFunction)(NrtSceneNodeHandle) = NULL;
-
-int32_t Internal_DepthFirstIteratorFunctionDelegate(const std::shared_ptr<SceneGraph::SceneNode>& node)
+int32_t Internal_DepthFirstIteratorFunctionDelegate(
+  int32_t (*action)(NrtSceneNodeHandle, void*), void* context,
+  const std::shared_ptr<SceneGraph::SceneNode>& node)
 {
-    return _depthFunction(reinterpret_cast<NrtSceneNodeHandle>(node.get()));
+    return action(reinterpret_cast<NrtSceneNodeHandle>(node.get()), context);
 }
 
 #ifdef __cplusplus
@@ -22,10 +22,11 @@ extern "C"
 #endif
 
     NrtResult Nrt_SceneNodeDepthFirstIterator_create(NrtSceneNodeHandle node,
-                                                     int32_t (*func)(NrtSceneNodeHandle),
+                                                     int32_t (*action)(NrtSceneNodeHandle, void* context),
+                                                     void* context,
                                                      NrtSceneNodeDepthFirstIteratorHandle* outputIterator)
     {
-        if (node == nullptr || func == nullptr)
+        if (node == nullptr || action == nullptr)
         {
             Nrt_setErrMsgIsNullptrInternal();
             return NRT_FAILURE_NULLPTR_PROVIDED;
@@ -33,10 +34,10 @@ extern "C"
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
 
-        _depthFunction = func;
+        auto func = std::bind(Internal_DepthFirstIteratorFunctionDelegate, action, context, std::placeholders::_1);
         SceneGraph::SceneNode::depth_first_traversal_result_iterator<int32_t> iterator =
             SceneGraph::SceneNode::depth_first_traversal_result_iterator<int32_t>(
-                nodePointer, Internal_DepthFirstIteratorFunctionDelegate);
+                nodePointer, func);
         *outputIterator = reinterpret_cast<NrtSceneNodeDepthFirstIteratorHandle>(&iterator);
 
         return NRT_SUCCESS;

--- a/src/NovelRT.Interop/SceneGraph/NrtSceneNodeDepthFirstIterator.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtSceneNodeDepthFirstIterator.cpp
@@ -9,9 +9,9 @@
 
 using namespace NovelRT;
 
-int32_t Internal_DepthFirstIteratorFunctionDelegate(
-  int32_t (*action)(NrtSceneNodeHandle, void*), void* context,
-  const std::shared_ptr<SceneGraph::SceneNode>& node)
+int32_t Internal_DepthFirstIteratorFunctionDelegate(int32_t (*action)(NrtSceneNodeHandle, void*),
+                                                    void* context,
+                                                    const std::shared_ptr<SceneGraph::SceneNode>& node)
 {
     return action(reinterpret_cast<NrtSceneNodeHandle>(node.get()), context);
 }
@@ -36,8 +36,7 @@ extern "C"
 
         auto func = std::bind(Internal_DepthFirstIteratorFunctionDelegate, action, context, std::placeholders::_1);
         SceneGraph::SceneNode::depth_first_traversal_result_iterator<int32_t> iterator =
-            SceneGraph::SceneNode::depth_first_traversal_result_iterator<int32_t>(
-                nodePointer, func);
+            SceneGraph::SceneNode::depth_first_traversal_result_iterator<int32_t>(nodePointer, func);
         *outputIterator = reinterpret_cast<NrtSceneNodeDepthFirstIteratorHandle>(&iterator);
 
         return NRT_SUCCESS;

--- a/tests/NovelRT.Tests/Interop/Ecs/NrtCatalogueTest.cpp
+++ b/tests/NovelRT.Tests/Interop/Ecs/NrtCatalogueTest.cpp
@@ -34,28 +34,30 @@ protected:
 
         Nrt_ComponentCache_RegisterComponentTypeUnsafe(
             componentCache, sizeof(int32_t), &intDeleteState,
-            [](auto lhs, auto rhs, auto) {
+            [](auto lhs, auto rhs, auto, auto) {
                 auto intLhs =
                     reinterpret_cast<int32_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(lhs));
                 auto intRhs =
                     reinterpret_cast<int32_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(rhs));
                 *intLhs += *intRhs;
             },
+            nullptr,
             &intComponentTypeId);
 
         Nrt_ComponentCache_RegisterComponentTypeUnsafe(
             componentCache, sizeof(size_t), &sizeTDeleteState,
-            [](auto lhs, auto rhs, auto) {
+            [](auto lhs, auto rhs, auto, auto) {
                 auto sizeTLhs =
                     reinterpret_cast<size_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(lhs));
                 auto sizeTRhs =
                     reinterpret_cast<size_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(rhs));
                 *sizeTLhs += *sizeTRhs;
             },
+            nullptr,
             &sizeTComponentTypeId);
 
         Nrt_ComponentCache_RegisterComponentTypeUnsafe(
-            componentCache, sizeof(char), &charDeleteState, [](auto, auto, auto) {}, &charComponentTypeId);
+            componentCache, sizeof(char), &charDeleteState, [](auto, auto, auto, auto) {}, nullptr, &charComponentTypeId);
 
         auto compViewInt = Nrt_Catalogue_GetComponentViewByIdUnsafe(catalogue, intComponentTypeId);
         auto compViewSizeT = Nrt_Catalogue_GetComponentViewByIdUnsafe(catalogue, sizeTComponentTypeId);

--- a/tests/NovelRT.Tests/Interop/Ecs/NrtCatalogueTest.cpp
+++ b/tests/NovelRT.Tests/Interop/Ecs/NrtCatalogueTest.cpp
@@ -41,8 +41,7 @@ protected:
                     reinterpret_cast<int32_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(rhs));
                 *intLhs += *intRhs;
             },
-            nullptr,
-            &intComponentTypeId);
+            nullptr, &intComponentTypeId);
 
         Nrt_ComponentCache_RegisterComponentTypeUnsafe(
             componentCache, sizeof(size_t), &sizeTDeleteState,
@@ -53,11 +52,11 @@ protected:
                     reinterpret_cast<size_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(rhs));
                 *sizeTLhs += *sizeTRhs;
             },
-            nullptr,
-            &sizeTComponentTypeId);
+            nullptr, &sizeTComponentTypeId);
 
         Nrt_ComponentCache_RegisterComponentTypeUnsafe(
-            componentCache, sizeof(char), &charDeleteState, [](auto, auto, auto, auto) {}, nullptr, &charComponentTypeId);
+            componentCache, sizeof(char), &charDeleteState, [](auto, auto, auto, auto) {}, nullptr,
+            &charComponentTypeId);
 
         auto compViewInt = Nrt_Catalogue_GetComponentViewByIdUnsafe(catalogue, intComponentTypeId);
         auto compViewSizeT = Nrt_Catalogue_GetComponentViewByIdUnsafe(catalogue, sizeTComponentTypeId);

--- a/tests/NovelRT.Tests/Interop/Ecs/NrtComponentBufferMemoryContainerTest.cpp
+++ b/tests/NovelRT.Tests/Interop/Ecs/NrtComponentBufferMemoryContainerTest.cpp
@@ -12,8 +12,8 @@ using namespace NovelRT::Ecs;
 TEST(InteropComponentBufferMemoryContainerTest, GetDeleteInstructionStateReturnsCorrectState)
 {
     int32_t deleteState = -1;
-    auto container =
-        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto, auto, auto, auto) {}, nullptr);
+    auto container = Nrt_ComponentBufferMemoryContainer_Create(
+        1, &deleteState, sizeof(int32_t), [](auto, auto, auto, auto) {}, nullptr);
     auto deleteInstructionState = Nrt_ComponentBufferMemoryContainer_GetDeleteInstructionState(container);
     EXPECT_EQ(std::memcmp(Nrt_ComponentBufferMemoryContainer_ImmutableDataView_GetDataHandle(deleteInstructionState),
                           &deleteState, sizeof(int32_t)),
@@ -27,8 +27,8 @@ TEST(InteropComponentBufferMemoryContainerTest, PushComponentUpdateInstructionAd
 {
     int32_t deleteState = -1;
     int32_t updateState = 10;
-    auto container =
-        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto, auto, auto, auto) {}, nullptr);
+    auto container = Nrt_ComponentBufferMemoryContainer_Create(
+        1, &deleteState, sizeof(int32_t), [](auto, auto, auto, auto) {}, nullptr);
 
     ASSERT_EQ(Nrt_ComponentBufferMemoryContainer_PushComponentUpdateInstruction(container, 0, 0, &updateState),
               NRT_SUCCESS);
@@ -50,11 +50,13 @@ TEST(InteropComponentBufferMemoryContainerTest, PushComponentUpdateInstructionUp
 {
     int32_t deleteState = -1;
     int32_t updateState = 10;
-    auto container =
-        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto lhs, auto rhs, auto, auto) {
+    auto container = Nrt_ComponentBufferMemoryContainer_Create(
+        1, &deleteState, sizeof(int32_t),
+        [](auto lhs, auto rhs, auto, auto) {
             *reinterpret_cast<int32_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(lhs)) +=
                 *reinterpret_cast<int32_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(rhs));
-        }, nullptr);
+        },
+        nullptr);
 
     ASSERT_EQ(Nrt_ComponentBufferMemoryContainer_PushComponentUpdateInstruction(container, 0, 0, &updateState),
               NRT_SUCCESS);
@@ -82,8 +84,8 @@ TEST(InteropComponentBufferMemoryContainerTest, PushComponentUpdateInstructionRe
 {
     int32_t deleteState = -1;
     int32_t updateState = 10;
-    auto container =
-        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto, auto, auto, auto) {}, nullptr);
+    auto container = Nrt_ComponentBufferMemoryContainer_Create(
+        1, &deleteState, sizeof(int32_t), [](auto, auto, auto, auto) {}, nullptr);
 
     ASSERT_EQ(Nrt_ComponentBufferMemoryContainer_PushComponentUpdateInstruction(container, 0, 0, &updateState),
               NRT_SUCCESS);
@@ -107,8 +109,8 @@ TEST(InteropComponentBufferMemoryContainerTest, IterationWorksCorrectly)
 {
     int32_t deleteState = -1;
     int32_t updateState = 10;
-    auto container =
-        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto, auto, auto, auto) {}, nullptr);
+    auto container = Nrt_ComponentBufferMemoryContainer_Create(
+        1, &deleteState, sizeof(int32_t), [](auto, auto, auto, auto) {}, nullptr);
 
     ASSERT_EQ(Nrt_ComponentBufferMemoryContainer_PushComponentUpdateInstruction(container, 0, 0, &updateState),
               NRT_SUCCESS);
@@ -149,11 +151,13 @@ TEST(InteropComponentBufferMemoryContainerTest, ConcurrentAccessWorksCorrectly)
 {
     int32_t deleteState = -1;
     int32_t updateState = 10;
-    auto container =
-        Nrt_ComponentBufferMemoryContainer_Create(2, &deleteState, sizeof(int32_t), [](auto lhs, auto rhs, auto, auto) {
+    auto container = Nrt_ComponentBufferMemoryContainer_Create(
+        2, &deleteState, sizeof(int32_t),
+        [](auto lhs, auto rhs, auto, auto) {
             *reinterpret_cast<int32_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(lhs)) +=
                 *reinterpret_cast<int32_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(rhs));
-        }, nullptr);
+        },
+        nullptr);
 
     for (int i = 0; i < 2000; ++i)
     {

--- a/tests/NovelRT.Tests/Interop/Ecs/NrtComponentBufferMemoryContainerTest.cpp
+++ b/tests/NovelRT.Tests/Interop/Ecs/NrtComponentBufferMemoryContainerTest.cpp
@@ -13,7 +13,7 @@ TEST(InteropComponentBufferMemoryContainerTest, GetDeleteInstructionStateReturns
 {
     int32_t deleteState = -1;
     auto container =
-        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto, auto, auto) {});
+        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto, auto, auto, auto) {}, nullptr);
     auto deleteInstructionState = Nrt_ComponentBufferMemoryContainer_GetDeleteInstructionState(container);
     EXPECT_EQ(std::memcmp(Nrt_ComponentBufferMemoryContainer_ImmutableDataView_GetDataHandle(deleteInstructionState),
                           &deleteState, sizeof(int32_t)),
@@ -28,7 +28,7 @@ TEST(InteropComponentBufferMemoryContainerTest, PushComponentUpdateInstructionAd
     int32_t deleteState = -1;
     int32_t updateState = 10;
     auto container =
-        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto, auto, auto) {});
+        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto, auto, auto, auto) {}, nullptr);
 
     ASSERT_EQ(Nrt_ComponentBufferMemoryContainer_PushComponentUpdateInstruction(container, 0, 0, &updateState),
               NRT_SUCCESS);
@@ -51,10 +51,10 @@ TEST(InteropComponentBufferMemoryContainerTest, PushComponentUpdateInstructionUp
     int32_t deleteState = -1;
     int32_t updateState = 10;
     auto container =
-        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto lhs, auto rhs, auto) {
+        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto lhs, auto rhs, auto, auto) {
             *reinterpret_cast<int32_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(lhs)) +=
                 *reinterpret_cast<int32_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(rhs));
-        });
+        }, nullptr);
 
     ASSERT_EQ(Nrt_ComponentBufferMemoryContainer_PushComponentUpdateInstruction(container, 0, 0, &updateState),
               NRT_SUCCESS);
@@ -83,7 +83,7 @@ TEST(InteropComponentBufferMemoryContainerTest, PushComponentUpdateInstructionRe
     int32_t deleteState = -1;
     int32_t updateState = 10;
     auto container =
-        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto, auto, auto) {});
+        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto, auto, auto, auto) {}, nullptr);
 
     ASSERT_EQ(Nrt_ComponentBufferMemoryContainer_PushComponentUpdateInstruction(container, 0, 0, &updateState),
               NRT_SUCCESS);
@@ -108,7 +108,7 @@ TEST(InteropComponentBufferMemoryContainerTest, IterationWorksCorrectly)
     int32_t deleteState = -1;
     int32_t updateState = 10;
     auto container =
-        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto, auto, auto) {});
+        Nrt_ComponentBufferMemoryContainer_Create(1, &deleteState, sizeof(int32_t), [](auto, auto, auto, auto) {}, nullptr);
 
     ASSERT_EQ(Nrt_ComponentBufferMemoryContainer_PushComponentUpdateInstruction(container, 0, 0, &updateState),
               NRT_SUCCESS);
@@ -150,10 +150,10 @@ TEST(InteropComponentBufferMemoryContainerTest, ConcurrentAccessWorksCorrectly)
     int32_t deleteState = -1;
     int32_t updateState = 10;
     auto container =
-        Nrt_ComponentBufferMemoryContainer_Create(2, &deleteState, sizeof(int32_t), [](auto lhs, auto rhs, auto) {
+        Nrt_ComponentBufferMemoryContainer_Create(2, &deleteState, sizeof(int32_t), [](auto lhs, auto rhs, auto, auto) {
             *reinterpret_cast<int32_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(lhs)) +=
                 *reinterpret_cast<int32_t*>(Nrt_SparseSetMemoryContainer_ByteIteratorView_GetDataHandle(rhs));
-        });
+        }, nullptr);
 
     for (int i = 0; i < 2000; ++i)
     {

--- a/tests/NovelRT.Tests/Interop/Ecs/NrtComponentCacheTest.cpp
+++ b/tests/NovelRT.Tests/Interop/Ecs/NrtComponentCacheTest.cpp
@@ -32,7 +32,7 @@ TEST_F(InteropComponentCacheTest, RegisterComponentTypeSucceeds)
     int32_t deleteState = NAN;
     NrtComponentTypeId id = 0;
     EXPECT_EQ(Nrt_ComponentCache_RegisterComponentTypeUnsafe(
-                  cache, sizeof(int32_t), &deleteState, [](auto, auto, auto) {}, &id),
+                  cache, sizeof(int32_t), &deleteState, [](auto, auto, auto, auto) {}, nullptr, &id),
               NRT_SUCCESS);
 }
 
@@ -41,7 +41,7 @@ TEST_F(InteropComponentCacheTest, GetComponentBufferByIdReturnsValidBuffer)
     int32_t deleteState = NAN;
     NrtComponentTypeId id = 0;
     ASSERT_EQ(Nrt_ComponentCache_RegisterComponentTypeUnsafe(
-                  cache, sizeof(int32_t), &deleteState, [](auto, auto, auto) {}, &id),
+                  cache, sizeof(int32_t), &deleteState, [](auto, auto, auto, auto) {}, nullptr, &id),
               NRT_SUCCESS);
 
     NrtComponentBufferMemoryContainerHandle buffer = nullptr;

--- a/tests/NovelRT.Tests/Interop/Ecs/NrtSystemSchedulerTest.cpp
+++ b/tests/NovelRT.Tests/Interop/Ecs/NrtSystemSchedulerTest.cpp
@@ -85,14 +85,17 @@ TEST_F(InteropSystemSchedulerTest, IndependentSystemsObtainValidCatalogue)
 
     ASSERT_EQ(Nrt_SystemScheduler_ExecuteIteration(scheduler, 0), NRT_SUCCESS);
 
-    Nrt_SystemScheduler_RegisterSystem(scheduler, [](auto delta, auto catalogue, auto) {
-        auto intSystem = reinterpret_cast<Catalogue*>(catalogue)->GetComponentView<int32_t>();
+    Nrt_SystemScheduler_RegisterSystem(
+        scheduler,
+        [](auto delta, auto catalogue, auto) {
+            auto intSystem = reinterpret_cast<Catalogue*>(catalogue)->GetComponentView<int32_t>();
 
-        for (auto [entity, component] : intSystem)
-        {
-            intSystem.PushComponentUpdateInstruction(entity, 10);
-        }
-    }, nullptr);
+            for (auto [entity, component] : intSystem)
+            {
+                intSystem.PushComponentUpdateInstruction(entity, 10);
+            }
+        },
+        nullptr);
 
     ASSERT_EQ(Nrt_SystemScheduler_ExecuteIteration(scheduler, 0), NRT_SUCCESS);
     ASSERT_EQ(Nrt_SystemScheduler_ExecuteIteration(scheduler, 0), NRT_SUCCESS);

--- a/tests/NovelRT.Tests/Interop/Ecs/NrtSystemSchedulerTest.cpp
+++ b/tests/NovelRT.Tests/Interop/Ecs/NrtSystemSchedulerTest.cpp
@@ -85,14 +85,14 @@ TEST_F(InteropSystemSchedulerTest, IndependentSystemsObtainValidCatalogue)
 
     ASSERT_EQ(Nrt_SystemScheduler_ExecuteIteration(scheduler, 0), NRT_SUCCESS);
 
-    Nrt_SystemScheduler_RegisterSystem(scheduler, [](auto delta, auto catalogue) {
+    Nrt_SystemScheduler_RegisterSystem(scheduler, [](auto delta, auto catalogue, auto) {
         auto intSystem = reinterpret_cast<Catalogue*>(catalogue)->GetComponentView<int32_t>();
 
         for (auto [entity, component] : intSystem)
         {
             intSystem.PushComponentUpdateInstruction(entity, 10);
         }
-    });
+    }, nullptr);
 
     ASSERT_EQ(Nrt_SystemScheduler_ExecuteIteration(scheduler, 0), NRT_SUCCESS);
     ASSERT_EQ(Nrt_SystemScheduler_ExecuteIteration(scheduler, 0), NRT_SUCCESS);

--- a/tests/NovelRT.Tests/Interop/SceneGraph/NovelRTSceneNodeTest.cpp
+++ b/tests/NovelRT.Tests/Interop/SceneGraph/NovelRTSceneNodeTest.cpp
@@ -161,7 +161,7 @@ TEST(InteropSceneNodeTest, childNodeIsReachableFromParentBreadthFirst)
     NrtSceneNodeHandle parentNode = Nrt_SceneNode_create();
     Nrt_SceneNode_insert(parentNode, childNode);
 
-    auto func = [](NrtSceneNodeHandle traversedNode) -> int32_t {
+    auto func = [](NrtSceneNodeHandle traversedNode, auto) -> int32_t {
         if (traversedNode == childNode)
         {
             return NRT_TRUE;
@@ -170,10 +170,10 @@ TEST(InteropSceneNodeTest, childNodeIsReachableFromParentBreadthFirst)
         return NRT_FALSE;
     };
 
-    int32_t (*vari)(NrtSceneNodeHandle) = func;
+    int32_t (*vari)(NrtSceneNodeHandle, void*) = func;
 
     NrtSceneNodeBreadthFirstIteratorHandle it = nullptr;
-    auto res = Nrt_SceneNode_traverseBreadthFirstWithIterator(parentNode, vari, &it);
+    auto res = Nrt_SceneNode_traverseBreadthFirstWithIterator(parentNode, vari, nullptr, &it);
 
     ASSERT_EQ(res, NRT_SUCCESS);
 
@@ -225,7 +225,7 @@ TEST(InteropSceneNodeTest, breadthFirstTraversalVisitsEachNodeOnceEvenWithCycle)
     ASSERT_TRUE(Nrt_SceneNode_insert(parentNode, childNode));
     ASSERT_TRUE(Nrt_SceneNode_insert(childNode, parentNode));
 
-    auto func = [](NrtSceneNodeHandle traversedNode) -> void {
+    auto func = [](NrtSceneNodeHandle traversedNode, auto) -> void {
         if (traversedNode == parentNode)
         {
             parentSceneNodeHitCount++;
@@ -240,9 +240,9 @@ TEST(InteropSceneNodeTest, breadthFirstTraversalVisitsEachNodeOnceEvenWithCycle)
         }
     };
 
-    void (*vari)(NrtSceneNodeHandle) = func;
+    void (*vari)(NrtSceneNodeHandle,void*) = func;
 
-    auto res = Nrt_SceneNode_traverseBreadthFirst(parentNode, vari);
+    auto res = Nrt_SceneNode_traverseBreadthFirst(parentNode, vari, nullptr);
     ASSERT_EQ(res, NRT_SUCCESS);
     ASSERT_EQ(1, parentSceneNodeHitCount);
     ASSERT_EQ(1, childSceneNodeHitCount);
@@ -263,7 +263,7 @@ TEST(InteropSceneNodeTest, depthFirstTraversalVisitsEachNodeOnceEvenWithCycle)
     ASSERT_TRUE(Nrt_SceneNode_insert(parentNode, childNode));
     ASSERT_TRUE(Nrt_SceneNode_insert(childNode, parentNode));
 
-    auto func = [](NrtSceneNodeHandle traversedNode) -> void {
+    auto func = [](NrtSceneNodeHandle traversedNode, auto) -> void {
         if (traversedNode == parentNode)
         {
             parentSceneNodeHitCount++;
@@ -278,9 +278,9 @@ TEST(InteropSceneNodeTest, depthFirstTraversalVisitsEachNodeOnceEvenWithCycle)
         }
     };
 
-    void (*vari)(NrtSceneNodeHandle) = func;
+    void (*vari)(NrtSceneNodeHandle, void*) = func;
 
-    auto res = Nrt_SceneNode_traverseDepthFirst(parentNode, vari);
+    auto res = Nrt_SceneNode_traverseDepthFirst(parentNode, vari, nullptr);
     ASSERT_EQ(res, NRT_SUCCESS);
     ASSERT_EQ(1, parentSceneNodeHitCount);
     ASSERT_EQ(1, childSceneNodeHitCount);

--- a/tests/NovelRT.Tests/Interop/SceneGraph/NovelRTSceneNodeTest.cpp
+++ b/tests/NovelRT.Tests/Interop/SceneGraph/NovelRTSceneNodeTest.cpp
@@ -240,7 +240,7 @@ TEST(InteropSceneNodeTest, breadthFirstTraversalVisitsEachNodeOnceEvenWithCycle)
         }
     };
 
-    void (*vari)(NrtSceneNodeHandle,void*) = func;
+    void (*vari)(NrtSceneNodeHandle, void*) = func;
 
     auto res = Nrt_SceneNode_traverseBreadthFirst(parentNode, vari, nullptr);
     ASSERT_EQ(res, NRT_SUCCESS);


### PR DESCRIPTION
I did a rough grep for any function pointers we expose (`egrep -r '\(\*\w+\)\(.*\)'`) and updated them to also expose opaque context parameters, which can be specified by the user or interop library, so that we can easily pass through data through our interop bindings.

Furthermore, this PR also simplifies some cases where we were using global state to store function pointers, by replacing them wholesale with uses of `std::bind`. Further cleanup can likely be done in these cases - this is just the minimum set of changes that I could easily find to enable easier interop scenarios.