### PR TITLE
Fix for system reallocation in ECS

### DIFF
--- a/src/NovelRT/Ecs/SystemScheduler.cpp
+++ b/src/NovelRT/Ecs/SystemScheduler.cpp
@@ -178,7 +178,7 @@ namespace NovelRT::Ecs
                     pair.threadLock.unlock();
                 }
 
-                if (remainder % amountOfWork != 0)
+                if (_systemIds.size() - amountOfWork != 0)
                 {
                     size_t threadWorkIndex =
                         (remainder / amountOfWork) < _threadWorkQueues.size() ? (remainder / amountOfWork) : 0;

--- a/src/NovelRT/Ecs/SystemScheduler.cpp
+++ b/src/NovelRT/Ecs/SystemScheduler.cpp
@@ -178,7 +178,7 @@ namespace NovelRT::Ecs
                     pair.threadLock.unlock();
                 }
 
-                if (_systemIds.size() - amountOfWork != 0)
+                if (_systemIds.size() - sizeOfProcessedWork != 0)
                 {
                     size_t threadWorkIndex =
                         (remainder / amountOfWork) < _threadWorkQueues.size() ? (remainder / amountOfWork) : 0;

--- a/src/NovelRT/Ecs/SystemScheduler.cpp
+++ b/src/NovelRT/Ecs/SystemScheduler.cpp
@@ -184,7 +184,7 @@ namespace NovelRT::Ecs
                         (remainder / amountOfWork) < _threadWorkQueues.size() ? (remainder / amountOfWork) : 0;
 
                     QueueLockPair& pair = _threadWorkQueues[threadWorkIndex];
-                    size_t startingIndex = _systemIds.size() - sizeOfProcessedWork;
+                    size_t startingIndex = _systemIds.size() - (_systemIds.size() - sizeOfProcessedWork);
 
                     pair.threadLock.lock();
 

--- a/tests/NovelRT.Tests/Ecs/SystemSchedulerTest.cpp
+++ b/tests/NovelRT.Tests/Ecs/SystemSchedulerTest.cpp
@@ -175,8 +175,6 @@ TEST_F(SystemSchedulerTest, IndependentSystemsCanHandleManySystems)
 
     scheduler->ExecuteIteration(Timestamp(0));
     EXPECT_EQ(scheduler->GetComponentCache().GetComponentBuffer<int32_t>().GetComponent(entity), 18);
-    
-
 
     for (int i = 0; i < 6; ++i) // 17 total systems
     {
@@ -219,5 +217,4 @@ TEST_F(SystemSchedulerTest, IndependentSystemsCanHandleManySystems)
 
     scheduler->ExecuteIteration(Timestamp(0));
     EXPECT_EQ(scheduler->GetComponentCache().GetComponentBuffer<int32_t>().GetComponent(entity), 86);
-    
 }

--- a/tests/NovelRT.Tests/Ecs/SystemSchedulerTest.cpp
+++ b/tests/NovelRT.Tests/Ecs/SystemSchedulerTest.cpp
@@ -156,6 +156,7 @@ TEST_F(SystemSchedulerTest, IndependentSystemsCanHandleRemainderWithFourThreads)
 TEST_F(SystemSchedulerTest, IndependentSystemsCanHandleManySystems)
 {
     EntityId entity = Atom::getNextEntityId();
+    uint32_t count = scheduler->GetWorkerThreadCount();
 
     scheduler->GetComponentCache().RegisterComponentType<int32_t>(-1);
     scheduler->GetComponentCache().GetComponentBuffer<int32_t>().PushComponentUpdateInstruction(0, entity, 10);
@@ -174,6 +175,8 @@ TEST_F(SystemSchedulerTest, IndependentSystemsCanHandleManySystems)
 
     scheduler->ExecuteIteration(Timestamp(0));
     EXPECT_EQ(scheduler->GetComponentCache().GetComponentBuffer<int32_t>().GetComponent(entity), 18);
+    
+
 
     for (int i = 0; i < 6; ++i) // 17 total systems
     {
@@ -216,4 +219,5 @@ TEST_F(SystemSchedulerTest, IndependentSystemsCanHandleManySystems)
 
     scheduler->ExecuteIteration(Timestamp(0));
     EXPECT_EQ(scheduler->GetComponentCache().GetComponentBuffer<int32_t>().GetComponent(entity), 86);
+    
 }


### PR DESCRIPTION
Resolves System Scheduler bug that caused overallocation when there was a remainder of work to be distributed.