### PR TITLE
Added missing event handler removal methods for C interop.

### DIFF
--- a/include/NovelRT.Interop/NrtNovelRunner.h
+++ b/include/NovelRT.Interop/NrtNovelRunner.h
@@ -28,17 +28,17 @@ extern "C"
     NrtResult Nrt_NovelRunner_getRenderer(NrtNovelRunnerHandle runner, NrtRenderingServiceHandle* outputService);
     NrtResult Nrt_NovelRunner_getDebugService(NrtNovelRunnerHandle runner, NrtDebugServiceHandle* outputService);
 
-    NrtResult Nrt_NovelRunner_addUpdate(NrtNovelRunnerHandle runner,
+    NrtResult Nrt_NovelRunner_subscribeUpdate(NrtNovelRunnerHandle runner,
                                         void (*func)(NrtTimestamp, void*),
                                         void* context,
                                         NrtAtom* eventHandlerId);
-    NrtResult Nrt_NovelRunner_removeUpdate(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId);
+    NrtResult Nrt_NovelRunner_unsubscribeUpdate(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId);
 
-    NrtResult Nrt_NovelRunner_addSceneConstructionRequested(NrtNovelRunnerHandle runner,
+    NrtResult Nrt_NovelRunner_subscribeSceneConstructionRequested(NrtNovelRunnerHandle runner,
                                                             void (*func)(void*),
                                                             void* context,
                                                             NrtAtom* eventHandlerId);
-    NrtResult Nrt_NovelRunner_removeSceneConstructionRequested(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId);
+    NrtResult Nrt_NovelRunner_unsubscribeSceneConstructionRequested(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId);
 
     NrtResult Nrt_NovelRunner_getUpdateEvent(NrtNovelRunnerHandle runner,
                                              NrtUtilitiesEventWithTimestampHandle* outputEvent);

--- a/include/NovelRT.Interop/NrtNovelRunner.h
+++ b/include/NovelRT.Interop/NrtNovelRunner.h
@@ -29,16 +29,17 @@ extern "C"
     NrtResult Nrt_NovelRunner_getDebugService(NrtNovelRunnerHandle runner, NrtDebugServiceHandle* outputService);
 
     NrtResult Nrt_NovelRunner_subscribeUpdate(NrtNovelRunnerHandle runner,
-                                        void (*func)(NrtTimestamp, void*),
-                                        void* context,
-                                        NrtAtom* eventHandlerId);
+                                              void (*func)(NrtTimestamp, void*),
+                                              void* context,
+                                              NrtAtom* eventHandlerId);
     NrtResult Nrt_NovelRunner_unsubscribeUpdate(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId);
 
     NrtResult Nrt_NovelRunner_subscribeSceneConstructionRequested(NrtNovelRunnerHandle runner,
-                                                            void (*func)(void*),
-                                                            void* context,
-                                                            NrtAtom* eventHandlerId);
-    NrtResult Nrt_NovelRunner_unsubscribeSceneConstructionRequested(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId);
+                                                                  void (*func)(void*),
+                                                                  void* context,
+                                                                  NrtAtom* eventHandlerId);
+    NrtResult Nrt_NovelRunner_unsubscribeSceneConstructionRequested(NrtNovelRunnerHandle runner,
+                                                                    NrtAtom eventHandlerId);
 
     NrtResult Nrt_NovelRunner_getUpdateEvent(NrtNovelRunnerHandle runner,
                                              NrtUtilitiesEventWithTimestampHandle* outputEvent);

--- a/include/NovelRT.Interop/NrtNovelRunner.h
+++ b/include/NovelRT.Interop/NrtNovelRunner.h
@@ -28,18 +28,18 @@ extern "C"
     NrtResult Nrt_NovelRunner_getRenderer(NrtNovelRunnerHandle runner, NrtRenderingServiceHandle* outputService);
     NrtResult Nrt_NovelRunner_getDebugService(NrtNovelRunnerHandle runner, NrtDebugServiceHandle* outputService);
 
-    NrtResult Nrt_NovelRunner_subscribeUpdate(NrtNovelRunnerHandle runner,
-                                              void (*func)(NrtTimestamp, void*),
-                                              void* context,
-                                              NrtAtom* eventHandlerId);
-    NrtResult Nrt_NovelRunner_unsubscribeUpdate(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId);
+    NrtResult Nrt_NovelRunner_SubscribeToUpdate(NrtNovelRunnerHandle runner,
+                                                void (*func)(NrtTimestamp, void*),
+                                                void* context,
+                                                NrtAtom* eventHandlerId);
+    NrtResult Nrt_NovelRunner_UnsubscribeFromUpdate(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId);
 
-    NrtResult Nrt_NovelRunner_subscribeSceneConstructionRequested(NrtNovelRunnerHandle runner,
-                                                                  void (*func)(void*),
-                                                                  void* context,
-                                                                  NrtAtom* eventHandlerId);
-    NrtResult Nrt_NovelRunner_unsubscribeSceneConstructionRequested(NrtNovelRunnerHandle runner,
-                                                                    NrtAtom eventHandlerId);
+    NrtResult Nrt_NovelRunner_SubscribeToSceneConstructionRequested(NrtNovelRunnerHandle runner,
+                                                                    void (*func)(void*),
+                                                                    void* context,
+                                                                    NrtAtom* eventHandlerId);
+    NrtResult Nrt_NovelRunner_UnsubscribeFromSceneConstructionRequested(NrtNovelRunnerHandle runner,
+                                                                        NrtAtom eventHandlerId);
 
     NrtResult Nrt_NovelRunner_getUpdateEvent(NrtNovelRunnerHandle runner,
                                              NrtUtilitiesEventWithTimestampHandle* outputEvent);

--- a/include/NovelRT.Interop/NrtNovelRunner.h
+++ b/include/NovelRT.Interop/NrtNovelRunner.h
@@ -28,10 +28,18 @@ extern "C"
     NrtResult Nrt_NovelRunner_getRenderer(NrtNovelRunnerHandle runner, NrtRenderingServiceHandle* outputService);
     NrtResult Nrt_NovelRunner_getDebugService(NrtNovelRunnerHandle runner, NrtDebugServiceHandle* outputService);
 
-    NrtResult Nrt_NovelRunner_addUpdate(NrtNovelRunnerHandle runner, void (*func)(NrtTimestamp, void*), void* context);
+    NrtResult Nrt_NovelRunner_addUpdate(NrtNovelRunnerHandle runner,
+                                        void (*func)(NrtTimestamp, void*),
+                                        void* context,
+                                        NrtAtom* eventHandlerId);
+    NrtResult Nrt_NovelRunner_removeUpdate(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId);
+
     NrtResult Nrt_NovelRunner_addSceneConstructionRequested(NrtNovelRunnerHandle runner,
                                                             void (*func)(void*),
-                                                            void* context);
+                                                            void* context,
+                                                            NrtAtom* eventHandlerId);
+    NrtResult Nrt_NovelRunner_removeSceneConstructionRequested(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId);
+
     NrtResult Nrt_NovelRunner_getUpdateEvent(NrtNovelRunnerHandle runner,
                                              NrtUtilitiesEventWithTimestampHandle* outputEvent);
     NrtResult Nrt_NovelRunner_getSceneConstructionEvent(NrtNovelRunnerHandle runner,

--- a/include/NovelRT/Utilities/Event.h
+++ b/include/NovelRT/Utilities/Event.h
@@ -86,6 +86,20 @@ namespace NovelRT::Utilities
                 _handlers.erase(match);
         }
 
+        void operator-=(Atom atom)
+        {
+            if (atom == Atom())
+                return;
+
+            for (auto it = _handlers.begin(); it != _handlers.end(); ++it)
+            {
+                if (it->getId() == atom) {
+                    _handlers.erase(it); // Remove the current item
+                    return;
+                }
+            }
+        }
+
         void operator()(TArgs... args) const
         {
             auto handlers = _handlers;

--- a/include/NovelRT/Utilities/Event.h
+++ b/include/NovelRT/Utilities/Event.h
@@ -93,7 +93,8 @@ namespace NovelRT::Utilities
 
             for (auto it = _handlers.begin(); it != _handlers.end(); ++it)
             {
-                if (it->getId() == atom) {
+                if (it->getId() == atom)
+                {
                     _handlers.erase(it); // Remove the current item
                     return;
                 }

--- a/samples/CAPI/main.c
+++ b/samples/CAPI/main.c
@@ -307,11 +307,11 @@ int main()
     }
 
     // Setting up Scene Construction
-    Nrt_NovelRunner_addSceneConstructionRequested(runner, &RenderNovelChan, NULL, NULL);
+    Nrt_NovelRunner_subscribeSceneConstructionRequested(runner, &RenderNovelChan, NULL, NULL);
 
     // Setting up Update methods
     struct MoveContext moveContext;
-    Nrt_NovelRunner_addUpdate(runner, MoveNovelChan, &moveContext, NULL);
+    Nrt_NovelRunner_subscribeUpdate(runner, MoveNovelChan, &moveContext, NULL);
 
     // Run the novel!
     Nrt_NovelRunner_runNovel(runner);

--- a/samples/CAPI/main.c
+++ b/samples/CAPI/main.c
@@ -307,11 +307,11 @@ int main()
     }
 
     // Setting up Scene Construction
-    Nrt_NovelRunner_subscribeSceneConstructionRequested(runner, &RenderNovelChan, NULL, NULL);
+    Nrt_NovelRunner_SubscribeToSceneConstructionRequested(runner, &RenderNovelChan, NULL, NULL);
 
     // Setting up Update methods
     struct MoveContext moveContext;
-    Nrt_NovelRunner_subscribeUpdate(runner, MoveNovelChan, &moveContext, NULL);
+    Nrt_NovelRunner_SubscribeToUpdate(runner, MoveNovelChan, &moveContext, NULL);
 
     // Run the novel!
     Nrt_NovelRunner_runNovel(runner);

--- a/samples/CAPI/main.c
+++ b/samples/CAPI/main.c
@@ -307,11 +307,11 @@ int main()
     }
 
     // Setting up Scene Construction
-    Nrt_NovelRunner_addSceneConstructionRequested(runner, &RenderNovelChan, NULL);
+    Nrt_NovelRunner_addSceneConstructionRequested(runner, &RenderNovelChan, NULL, NULL);
 
     // Setting up Update methods
     struct MoveContext moveContext;
-    Nrt_NovelRunner_addUpdate(runner, MoveNovelChan, &moveContext);
+    Nrt_NovelRunner_addUpdate(runner, MoveNovelChan, &moveContext, NULL);
 
     // Run the novel!
     Nrt_NovelRunner_runNovel(runner);

--- a/src/NovelRT.Interop/NrtNovelRunner.cpp
+++ b/src/NovelRT.Interop/NrtNovelRunner.cpp
@@ -234,9 +234,9 @@ extern "C"
     }
 
     NrtResult Nrt_NovelRunner_SubscribeToUpdate(NrtNovelRunnerHandle runner,
-                                              void (*func)(NrtTimestamp, void*),
-                                              void* context,
-                                              NrtAtom* eventHandlerId)
+                                                void (*func)(NrtTimestamp, void*),
+                                                void* context,
+                                                NrtAtom* eventHandlerId)
     {
         using namespace NovelRT::Utilities;
 
@@ -281,9 +281,9 @@ extern "C"
     }
 
     NrtResult Nrt_NovelRunner_SubscribeToSceneConstructionRequested(NrtNovelRunnerHandle runner,
-                                                                  void (*func)(void*),
-                                                                  void* context,
-                                                                  NrtAtom* eventHandlerId)
+                                                                    void (*func)(void*),
+                                                                    void* context,
+                                                                    NrtAtom* eventHandlerId)
     {
         using namespace NovelRT::Utilities;
 
@@ -310,7 +310,8 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_UnsubscribeFromSceneConstructionRequested(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId)
+    NrtResult Nrt_NovelRunner_UnsubscribeFromSceneConstructionRequested(NrtNovelRunnerHandle runner,
+                                                                        NrtAtom eventHandlerId)
     {
         if (runner == nullptr)
         {

--- a/src/NovelRT.Interop/NrtNovelRunner.cpp
+++ b/src/NovelRT.Interop/NrtNovelRunner.cpp
@@ -233,7 +233,7 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_addUpdate(NrtNovelRunnerHandle runner,
+    NrtResult Nrt_NovelRunner_subscribeUpdate(NrtNovelRunnerHandle runner,
                                         void (*func)(NrtTimestamp, void*),
                                         void* context,
                                         NrtAtom* eventHandlerId)
@@ -265,7 +265,7 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_removeUpdate(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId)
+    NrtResult Nrt_NovelRunner_unsubscribeUpdate(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId)
     {
         if (runner == nullptr)
         {
@@ -280,7 +280,7 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_addSceneConstructionRequested(NrtNovelRunnerHandle runner,
+    NrtResult Nrt_NovelRunner_subscribeSceneConstructionRequested(NrtNovelRunnerHandle runner,
                                                             void (*func)(void*),
                                                             void* context,
                                                             NrtAtom* eventHandlerId)
@@ -310,7 +310,7 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_removeSceneConstructionRequested(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId)
+    NrtResult Nrt_NovelRunner_unsubscribeSceneConstructionRequested(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId)
     {
         if (runner == nullptr)
         {

--- a/src/NovelRT.Interop/NrtNovelRunner.cpp
+++ b/src/NovelRT.Interop/NrtNovelRunner.cpp
@@ -233,8 +233,13 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_addUpdate(NrtNovelRunnerHandle runner, void (*func)(NrtTimestamp, void*), void* context)
+    NrtResult Nrt_NovelRunner_addUpdate(NrtNovelRunnerHandle runner,
+                                        void (*func)(NrtTimestamp, void*),
+                                        void* context,
+                                        NrtAtom* eventHandlerId)
     {
+        using namespace NovelRT::Utilities;
+
         if (runner == nullptr)
         {
             Nrt_setErrMsgIsNullptrInternal();
@@ -249,16 +254,39 @@ extern "C"
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
 
-        cRunner->Update +=
-            [func, context](Timing::Timestamp delta) { func(reinterpret_cast<NrtTimestamp&>(delta), context); };
+        auto eventHandler = EventHandler<Timing::Timestamp>([func, context](Timing::Timestamp delta)
+                                                            { func(reinterpret_cast<NrtTimestamp&>(delta), context); });
+        if (eventHandlerId != nullptr)
+        {
+            *eventHandlerId = eventHandler.getId();
+        }
+        cRunner->Update += eventHandler;
+
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_NovelRunner_removeUpdate(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId)
+    {
+        if (runner == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
+
+        cRunner->Update -= Atom(eventHandlerId);
 
         return NRT_SUCCESS;
     }
 
     NrtResult Nrt_NovelRunner_addSceneConstructionRequested(NrtNovelRunnerHandle runner,
                                                             void (*func)(void*),
-                                                            void* context)
+                                                            void* context,
+                                                            NrtAtom* eventHandlerId)
     {
+        using namespace NovelRT::Utilities;
+
         if (runner == nullptr)
         {
             Nrt_setErrMsgIsNullptrInternal();
@@ -273,7 +301,27 @@ extern "C"
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
 
-        cRunner->SceneConstructionRequested += [func, context]() { func(context); };
+        auto eventHandler = EventHandler<>([func, context]() { func(context); });
+        if (eventHandlerId != nullptr)
+        {
+            *eventHandlerId = eventHandler.getId();
+        }
+        cRunner->SceneConstructionRequested += eventHandler;
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_NovelRunner_removeSceneConstructionRequested(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId)
+    {
+        if (runner == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
+
+        cRunner->SceneConstructionRequested -= Atom(eventHandlerId);
+
         return NRT_SUCCESS;
     }
 

--- a/src/NovelRT.Interop/NrtNovelRunner.cpp
+++ b/src/NovelRT.Interop/NrtNovelRunner.cpp
@@ -233,7 +233,7 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_subscribeUpdate(NrtNovelRunnerHandle runner,
+    NrtResult Nrt_NovelRunner_SubscribeToUpdate(NrtNovelRunnerHandle runner,
                                               void (*func)(NrtTimestamp, void*),
                                               void* context,
                                               NrtAtom* eventHandlerId)
@@ -265,7 +265,7 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_unsubscribeUpdate(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId)
+    NrtResult Nrt_NovelRunner_UnsubscribeFromUpdate(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId)
     {
         if (runner == nullptr)
         {
@@ -280,7 +280,7 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_subscribeSceneConstructionRequested(NrtNovelRunnerHandle runner,
+    NrtResult Nrt_NovelRunner_SubscribeToSceneConstructionRequested(NrtNovelRunnerHandle runner,
                                                                   void (*func)(void*),
                                                                   void* context,
                                                                   NrtAtom* eventHandlerId)
@@ -310,7 +310,7 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_NovelRunner_unsubscribeSceneConstructionRequested(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId)
+    NrtResult Nrt_NovelRunner_UnsubscribeFromSceneConstructionRequested(NrtNovelRunnerHandle runner, NrtAtom eventHandlerId)
     {
         if (runner == nullptr)
         {

--- a/src/NovelRT.Interop/NrtNovelRunner.cpp
+++ b/src/NovelRT.Interop/NrtNovelRunner.cpp
@@ -234,9 +234,9 @@ extern "C"
     }
 
     NrtResult Nrt_NovelRunner_subscribeUpdate(NrtNovelRunnerHandle runner,
-                                        void (*func)(NrtTimestamp, void*),
-                                        void* context,
-                                        NrtAtom* eventHandlerId)
+                                              void (*func)(NrtTimestamp, void*),
+                                              void* context,
+                                              NrtAtom* eventHandlerId)
     {
         using namespace NovelRT::Utilities;
 
@@ -254,8 +254,8 @@ extern "C"
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
 
-        auto eventHandler = EventHandler<Timing::Timestamp>([func, context](Timing::Timestamp delta)
-                                                            { func(reinterpret_cast<NrtTimestamp&>(delta), context); });
+        auto eventHandler = EventHandler<Timing::Timestamp>(
+            [func, context](Timing::Timestamp delta) { func(reinterpret_cast<NrtTimestamp&>(delta), context); });
         if (eventHandlerId != nullptr)
         {
             *eventHandlerId = eventHandler.getId();
@@ -281,9 +281,9 @@ extern "C"
     }
 
     NrtResult Nrt_NovelRunner_subscribeSceneConstructionRequested(NrtNovelRunnerHandle runner,
-                                                            void (*func)(void*),
-                                                            void* context,
-                                                            NrtAtom* eventHandlerId)
+                                                                  void (*func)(void*),
+                                                                  void* context,
+                                                                  NrtAtom* eventHandlerId)
     {
         using namespace NovelRT::Utilities;
 


### PR DESCRIPTION
Those methods were missing for some reason, now they're there!