### PR TITLE
Fixed Rect getColourConfig() and added a destroy method

### DIFF
--- a/include/NovelRT.Interop/Graphics/NrtBasicFillRect.h
+++ b/include/NovelRT.Interop/Graphics/NrtBasicFillRect.h
@@ -28,7 +28,6 @@ extern "C"
                                                      NrtRenderObjectHandle* outputRenderObject);
     NrtResult Nrt_BasicFillRect_destroy(NrtBasicFillRectHandle rect);
 
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/NovelRT.Interop/Graphics/NrtBasicFillRect.h
+++ b/include/NovelRT.Interop/Graphics/NrtBasicFillRect.h
@@ -11,6 +11,9 @@ extern "C"
 {
 #endif
 
+    // destroy
+    NrtResult Nrt_BasicFillRect_destroy(NrtBasicFillRectHandle rect);
+
     // base type
     NrtTransform Nrt_BasicFillRect_getTransform(NrtBasicFillRectHandle rect);
     NrtResult Nrt_BasicFillRect_setTransform(NrtBasicFillRectHandle rect, NrtTransform inputTransform);

--- a/include/NovelRT.Interop/Graphics/NrtBasicFillRect.h
+++ b/include/NovelRT.Interop/Graphics/NrtBasicFillRect.h
@@ -11,9 +11,6 @@ extern "C"
 {
 #endif
 
-    // destroy
-    NrtResult Nrt_BasicFillRect_destroy(NrtBasicFillRectHandle rect);
-
     // base type
     NrtTransform Nrt_BasicFillRect_getTransform(NrtBasicFillRectHandle rect);
     NrtResult Nrt_BasicFillRect_setTransform(NrtBasicFillRectHandle rect, NrtTransform inputTransform);
@@ -29,6 +26,8 @@ extern "C"
 
     NrtResult Nrt_BasicFillRect_getAsRenderObjectPtr(NrtBasicFillRectHandle rect,
                                                      NrtRenderObjectHandle* outputRenderObject);
+    NrtResult Nrt_BasicFillRect_destroy(NrtBasicFillRectHandle rect);
+
 
 #ifdef __cplusplus
 }

--- a/include/NovelRT.Interop/Graphics/NrtImageRect.h
+++ b/include/NovelRT.Interop/Graphics/NrtImageRect.h
@@ -11,8 +11,6 @@ extern "C"
 {
 #endif
 
-    NrtResult Nrt_ImageRect_destroy(NrtImageRectHandle rect);
-
     NrtTransform Nrt_ImageRect_getTransform(NrtImageRectHandle rect);
     NrtResult Nrt_ImageRect_setTransform(NrtImageRectHandle rect, NrtTransform inputTransform);
     int32_t Nrt_ImageRect_getLayer(NrtImageRectHandle rect);
@@ -26,6 +24,8 @@ extern "C"
     NrtResult Nrt_ImageRect_setColourTint(NrtImageRectHandle rect, NrtRGBAConfigHandle inputColourTint);
 
     NrtResult Nrt_ImageRect_getAsRenderObjectPtr(NrtImageRectHandle rect, NrtRenderObjectHandle* outputRenderObject);
+    NrtResult Nrt_ImageRect_destroy(NrtImageRectHandle rect);
+
 
 #ifdef __cplusplus
 }

--- a/include/NovelRT.Interop/Graphics/NrtImageRect.h
+++ b/include/NovelRT.Interop/Graphics/NrtImageRect.h
@@ -26,7 +26,6 @@ extern "C"
     NrtResult Nrt_ImageRect_getAsRenderObjectPtr(NrtImageRectHandle rect, NrtRenderObjectHandle* outputRenderObject);
     NrtResult Nrt_ImageRect_destroy(NrtImageRectHandle rect);
 
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/NovelRT.Interop/Graphics/NrtImageRect.h
+++ b/include/NovelRT.Interop/Graphics/NrtImageRect.h
@@ -11,6 +11,8 @@ extern "C"
 {
 #endif
 
+    NrtResult Nrt_ImageRect_destroy(NrtImageRectHandle rect);
+
     NrtTransform Nrt_ImageRect_getTransform(NrtImageRectHandle rect);
     NrtResult Nrt_ImageRect_setTransform(NrtImageRectHandle rect, NrtTransform inputTransform);
     int32_t Nrt_ImageRect_getLayer(NrtImageRectHandle rect);

--- a/include/NovelRT.Interop/Graphics/NrtTextRect.h
+++ b/include/NovelRT.Interop/Graphics/NrtTextRect.h
@@ -12,8 +12,6 @@ extern "C"
 {
 #endif
 
-    NrtResult Nrt_TextRect_destroy(NrtTextRectHandle rect);
-
     NrtTransform Nrt_TextRect_getTransform(NrtTextRectHandle rect);
     NrtResult Nrt_TextRect_setTransform(NrtTextRectHandle rect, NrtTransform inputTransform);
     int32_t Nrt_TextRect_getLayer(NrtTextRectHandle rect);
@@ -29,6 +27,8 @@ extern "C"
     NrtResult Nrt_TextRect_setFontSet(NrtTextRectHandle rect, NrtFontSetHandle inputFontSet);
 
     NrtResult Nrt_TextRect_getAsRenderObjectPtr(NrtTextRectHandle rect, NrtRenderObjectHandle* outputRenderObject);
+    NrtResult Nrt_TextRect_destroy(NrtTextRectHandle rect);
+
 
 #ifdef __cplusplus
 }

--- a/include/NovelRT.Interop/Graphics/NrtTextRect.h
+++ b/include/NovelRT.Interop/Graphics/NrtTextRect.h
@@ -12,6 +12,8 @@ extern "C"
 {
 #endif
 
+    NrtResult Nrt_TextRect_destroy(NrtTextRectHandle rect);
+
     NrtTransform Nrt_TextRect_getTransform(NrtTextRectHandle rect);
     NrtResult Nrt_TextRect_setTransform(NrtTextRectHandle rect, NrtTransform inputTransform);
     int32_t Nrt_TextRect_getLayer(NrtTextRectHandle rect);

--- a/include/NovelRT.Interop/Graphics/NrtTextRect.h
+++ b/include/NovelRT.Interop/Graphics/NrtTextRect.h
@@ -29,7 +29,6 @@ extern "C"
     NrtResult Nrt_TextRect_getAsRenderObjectPtr(NrtTextRectHandle rect, NrtRenderObjectHandle* outputRenderObject);
     NrtResult Nrt_TextRect_destroy(NrtTextRectHandle rect);
 
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/NovelRT.Interop/Graphics/NrtBasicFillRect.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtBasicFillRect.cpp
@@ -14,6 +14,19 @@ extern "C"
 {
 #endif
 
+    NrtResult Nrt_BasicFillRect_destroy(NrtBasicFillRectHandle rect)
+    {
+        if (rect == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        delete reinterpret_cast<BasicFillRect*>(rect);
+
+        return NRT_SUCCESS;
+    }
+
     NrtTransform Nrt_BasicFillRect_getTransform(NrtBasicFillRectHandle rect)
     {
 
@@ -110,8 +123,9 @@ extern "C"
         }
 
         BasicFillRect* cppRect = reinterpret_cast<BasicFillRect*>(rect);
-        auto colourConfig = cppRect->getColourConfig();
-        *outputColourConfig = *reinterpret_cast<NrtRGBAConfigHandle*>(&colourConfig);
+        auto colourConfig = new RGBAConfig(0, 0, 0, 0);
+        *colourConfig = cppRect->getColourConfig();
+        *outputColourConfig = reinterpret_cast<NrtRGBAConfigHandle>(colourConfig);
 
         return NRT_SUCCESS;
     }

--- a/src/NovelRT.Interop/Graphics/NrtBasicFillRect.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtBasicFillRect.cpp
@@ -14,19 +14,6 @@ extern "C"
 {
 #endif
 
-    NrtResult Nrt_BasicFillRect_destroy(NrtBasicFillRectHandle rect)
-    {
-        if (rect == nullptr)
-        {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
-        }
-
-        delete reinterpret_cast<BasicFillRect*>(rect);
-
-        return NRT_SUCCESS;
-    }
-
     NrtTransform Nrt_BasicFillRect_getTransform(NrtBasicFillRectHandle rect)
     {
 
@@ -160,6 +147,19 @@ extern "C"
         }
 
         *outputRenderObject = reinterpret_cast<NrtRenderObjectHandle>(rect);
+
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_BasicFillRect_destroy(NrtBasicFillRectHandle rect)
+    {
+        if (rect == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        delete reinterpret_cast<BasicFillRect*>(rect);
 
         return NRT_SUCCESS;
     }

--- a/src/NovelRT.Interop/Graphics/NrtImageRect.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtImageRect.cpp
@@ -16,19 +16,6 @@ extern "C"
 {
 #endif
 
-    NrtResult Nrt_ImageRect_destroy(NrtImageRectHandle rect)
-    {
-        if (rect == nullptr)
-        {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
-        }
-
-        delete reinterpret_cast<ImageRect*>(rect);
-
-        return NRT_SUCCESS;
-    }
-
     NrtTransform Nrt_ImageRect_getTransform(NrtImageRectHandle rect)
     {
         ImageRect* imageRectPtr = reinterpret_cast<ImageRect*>(rect);
@@ -192,6 +179,19 @@ extern "C"
         }
 
         *outputRenderObject = reinterpret_cast<NrtRenderObjectHandle>(rect);
+
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_ImageRect_destroy(NrtImageRectHandle rect)
+    {
+        if (rect == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        delete reinterpret_cast<ImageRect*>(rect);
 
         return NRT_SUCCESS;
     }

--- a/src/NovelRT.Interop/Graphics/NrtImageRect.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtImageRect.cpp
@@ -16,6 +16,19 @@ extern "C"
 {
 #endif
 
+    NrtResult Nrt_ImageRect_destroy(NrtImageRectHandle rect)
+    {
+        if (rect == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        delete reinterpret_cast<ImageRect*>(rect);
+
+        return NRT_SUCCESS;
+    }
+
     NrtTransform Nrt_ImageRect_getTransform(NrtImageRectHandle rect)
     {
         ImageRect* imageRectPtr = reinterpret_cast<ImageRect*>(rect);
@@ -144,8 +157,9 @@ extern "C"
         }
 
         ImageRect* imageRectPtr = reinterpret_cast<ImageRect*>(rect);
-        RGBAConfig colour = imageRectPtr->colourTint();
-        *outputColourTint = *reinterpret_cast<NrtRGBAConfigHandle*>(&colour);
+        auto colourTint = new RGBAConfig(0, 0, 0, 0);
+        *colourTint = imageRectPtr->colourTint();
+        *outputColourTint = reinterpret_cast<NrtRGBAConfigHandle>(colourTint);
 
         return NRT_SUCCESS;
     }

--- a/src/NovelRT.Interop/Graphics/NrtTextRect.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtTextRect.cpp
@@ -14,6 +14,19 @@ extern "C"
 {
 #endif
 
+    NrtResult Nrt_TextRect_destroy(NrtTextRectHandle rect)
+    {
+        if (rect == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        delete reinterpret_cast<TextRect*>(rect);
+
+        return NRT_SUCCESS;
+    }
+
     NrtTransform Nrt_TextRect_getTransform(NrtTextRectHandle rect)
     {
         TextRect* textRectPtr = reinterpret_cast<TextRect*>(rect);
@@ -118,8 +131,9 @@ extern "C"
         }
 
         TextRect* textRectPtr = reinterpret_cast<TextRect*>(rect);
-        auto colourConfig = textRectPtr->getColourConfig();
-        *outputColourConfig = reinterpret_cast<NrtRGBAConfigHandle>(&colourConfig);
+        auto colourConfig = new RGBAConfig(0, 0, 0, 0);
+        *colourConfig = textRectPtr->getColourConfig();
+        *outputColourConfig = reinterpret_cast<NrtRGBAConfigHandle>(colourConfig);
 
         return NRT_SUCCESS;
     }

--- a/src/NovelRT.Interop/Graphics/NrtTextRect.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtTextRect.cpp
@@ -14,19 +14,6 @@ extern "C"
 {
 #endif
 
-    NrtResult Nrt_TextRect_destroy(NrtTextRectHandle rect)
-    {
-        if (rect == nullptr)
-        {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
-        }
-
-        delete reinterpret_cast<TextRect*>(rect);
-
-        return NRT_SUCCESS;
-    }
-
     NrtTransform Nrt_TextRect_getTransform(NrtTextRectHandle rect)
     {
         TextRect* textRectPtr = reinterpret_cast<TextRect*>(rect);
@@ -225,6 +212,19 @@ extern "C"
         }
 
         *outputRenderObject = reinterpret_cast<NrtRenderObjectHandle>(rect);
+
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_TextRect_destroy(NrtTextRectHandle rect)
+    {
+        if (rect == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        delete reinterpret_cast<TextRect*>(rect);
 
         return NRT_SUCCESS;
     }


### PR DESCRIPTION
- Added a new `destroy` methods to `BasicFillRect`, `ImageRect` and `TextRect`
- Fixed `getColourConfig()` (`BasicFillRect`, `TextRect`) and `getColourTint()` (`ImageRect`) segfault bug 