### PR TITLE
Make C# / Ink support conditional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ option(NOVELRT_BUILD_SAMPLES "Build NovelRT samples" ON)
 option(NOVELRT_BUILD_DOCUMENTATION "Build NovelRT documentation" ON)
 option(NOVELRT_BUILD_TESTS "Build NovelRT tests" ON)
 option(NOVELRT_INCLUDE_CONAN_PATHS "Include conan_paths toolchain" ON)
+option(NOVELRT_INCLUDE_INK "Include Ink functionality in the build" ON)
 
 set(NOVELRT_BZIP2_VERSION "1.0.8" CACHE STRING "BZip2 version")
 set(NOVELRT_DOTNET_VERSION "5.0.100" CACHE STRING "Dotnet version")
@@ -62,6 +63,12 @@ if(NOT DOXYGEN_FOUND)
 endif()
 
 add_subdirectory(src)
+
+if(NOVELRT_INCLUDE_INK)
+  message("Compiling with Ink support.")
+else()
+  message("Compiling without Ink support.")
+endif()
 
 if(NOVELRT_BUILD_SAMPLES)
   add_subdirectory(samples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,12 +64,6 @@ endif()
 
 add_subdirectory(src)
 
-if(NOVELRT_INCLUDE_INK)
-  message("Compiling with Ink support.")
-else()
-  message("Compiling without Ink support.")
-endif()
-
 if(NOVELRT_BUILD_SAMPLES)
   add_subdirectory(samples)
 endif()

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Currently, NovelRT supports the following in its base form:
 
 Current features in development include:
 - C++ HLAPI
-- Lua 5.3 LLAPI
 - CoreCLR hosting
 - Ink narrative scripting language support
 
@@ -43,7 +42,6 @@ If you wish to attempt to build a basic visual novel with the existing C++ API, 
 - gtest/gmock 1.10.0
 - libpng 1.6.34
 - libsndfile 1.0.28
-- Lua 5.3
 - OpenAL 1.19.1
 - spdlog 1.4.2
 - Microsoft GSL 3.1.0
@@ -88,7 +86,7 @@ _Prerequisites:_
 - Windows 10 x64
 
 (32-bit installation _may_ be covered in the future.)
-  
+
 Please download [Python 3 (x64) from here](https://www.python.org/downloads/) or from the Microsoft Store. Once that is done,
 install conan and our configurations should you require them:
 ```

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -5,7 +5,6 @@ glfw/3.3.2
 glm/0.9.9.7
 gtest/1.10.0
 libsndfile/1.0.30
-lua/5.3.5
 openal/1.19.1
 spdlog/1.8.2
 ms-gsl/3.1.0
@@ -18,7 +17,6 @@ cmake_paths
 freetype:shared=True
 glfw:shared=True
 libsndfile:shared=True
-lua:shared=True
 openal:shared=True
 PNG:shared=True
 BZip2:shared=True

--- a/include/NovelRT.Interop/NrtNovelRunner.h
+++ b/include/NovelRT.Interop/NrtNovelRunner.h
@@ -24,9 +24,9 @@ extern "C"
                                                     NrtInteractionServiceHandle* outputService);
     NrtResult Nrt_NovelRunner_getWindowingService(NrtNovelRunnerHandle runner,
                                                   NrtWindowingServiceHandle* outputService);
-    #ifdef NOVELRT_INK
+#ifdef NOVELRT_INK
     NrtResult Nrt_NovelRunner_getRuntimeService(NrtNovelRunnerHandle runner, NrtRuntimeServiceHandle* outputService);
-    #endif
+#endif
     NrtResult Nrt_NovelRunner_getRenderer(NrtNovelRunnerHandle runner, NrtRenderingServiceHandle* outputService);
     NrtResult Nrt_NovelRunner_getDebugService(NrtNovelRunnerHandle runner, NrtDebugServiceHandle* outputService);
 

--- a/include/NovelRT.Interop/NrtNovelRunner.h
+++ b/include/NovelRT.Interop/NrtNovelRunner.h
@@ -24,7 +24,9 @@ extern "C"
                                                     NrtInteractionServiceHandle* outputService);
     NrtResult Nrt_NovelRunner_getWindowingService(NrtNovelRunnerHandle runner,
                                                   NrtWindowingServiceHandle* outputService);
+    #ifdef NOVELRT_INK
     NrtResult Nrt_NovelRunner_getRuntimeService(NrtNovelRunnerHandle runner, NrtRuntimeServiceHandle* outputService);
+    #endif
     NrtResult Nrt_NovelRunner_getRenderer(NrtNovelRunnerHandle runner, NrtRenderingServiceHandle* outputService);
     NrtResult Nrt_NovelRunner_getDebugService(NrtNovelRunnerHandle runner, NrtDebugServiceHandle* outputService);
 

--- a/include/NovelRT.Interop/NrtTypedefs.h
+++ b/include/NovelRT.Interop/NrtTypedefs.h
@@ -69,10 +69,14 @@ extern "C"
 
 #include "Animation/NrtAnimationTypedefs.h"
 #include "Audio/NrtAudioTypedefs.h"
+#ifdef NOVELRT_INK
 #include "DotNet/NrtDotNetTypedefs.h"
+#endif
 #include "Ecs/NrtEcsTypedefs.h"
 #include "Graphics/NrtGraphicsTypedefs.h"
+#ifdef NOVELRT_INK
 #include "Ink/NrtInkTypedefs.h"
+#endif
 #include "Input/NrtInputTypedefs.h"
 #include "SceneGraph/NrtSceneGraphTypedefs.h"
 #include "Windowing/NrtWindowingTypedefs.h"

--- a/include/NovelRT.h
+++ b/include/NovelRT.h
@@ -69,9 +69,11 @@
 // LibSndfile
 #include <sndfile.h>
 
+#ifdef NOVELRT_INK
 // nethost
 #include "NovelRT/DotNet/coreclr_delegates.h"
 #include "NovelRT/DotNet/hostfxr.h"
+#endif
 
 // spdlog
 #if defined(_MSC_VER)
@@ -118,14 +120,14 @@
     typedef std::vector<ALuint> MusicBank;
     typedef class AudioService AudioService;
   }
-
+#ifdef NOVELRT_INK
   /**
    * @brief Contains features to interop with the .NET Core runtime.
    */
   namespace NovelRT::DotNet {
     typedef class RuntimeService RuntimeService;
   }
-
+#endif
   /**
    * @brief Contains graphics features, such as rendering, textures, cameras, etc.
    */
@@ -138,7 +140,7 @@
     typedef class RenderObject RenderObject;
     typedef class TextRect TextRect;
   }
-
+#ifdef NOVELRT_INK
   /**
    * @brief Contains bindings for Ink.
    */
@@ -146,7 +148,7 @@
     typedef class InkService InkService;
     typedef class Story Story;
   }
-
+#endif
   /**
    * @brief Contains input features, such as keyboard and mouse interactivity.
    */
@@ -235,9 +237,11 @@
   #include "NovelRT/Graphics/ImageRect.h"
   #include "NovelRT/Graphics/TextRect.h"
 
+#ifdef NOVELRT_INK
   // Ink types
   #include "NovelRT/Ink/Story.h"
   #include "NovelRT/Ink/InkService.h"
+#endif
 
   // Input types
   #include "NovelRT/Input/InteractionObject.h"
@@ -247,7 +251,9 @@
   // Engine service types
   #include "NovelRT/Audio/AudioService.h"
   #include "NovelRT/DebugService.h"
+#ifdef NOVELRT_INK
   #include "NovelRT/DotNet/RuntimeService.h"
+#endif
   #include "NovelRT/Input/InteractionService.h"
   #include "NovelRT/Windowing/WindowingService.h"
   #include "NovelRT/Graphics/RenderingService.h"
@@ -278,8 +284,10 @@
   // Audio
   #include "NovelRT.Interop/Audio/NrtAudioService.h"
 
+#ifdef NOVELRT_INK
   // DotNet
   #include "NovelRT.Interop/DotNet/NrtRuntimeService.h"
+#endif
 
   // Ecs
   #include "NovelRT.Interop/Ecs/NrtCatalogue.h"
@@ -301,9 +309,11 @@
   #include "NovelRT.Interop/Graphics/NrtTextRect.h"
   #include "NovelRT.Interop/Graphics/NrtTexture.h"
 
+#ifdef NOVELRT_INK
   // Ink
   #include "NovelRT.Interop/Ink/NrtInkService.h"
   #include "NovelRT.Interop/Ink/NrtStory.h"
+#endif
 
   // Input
   #include "NovelRT.Interop/Input/NrtBasicInteractionRect.h"
@@ -327,14 +337,14 @@
   #include "NovelRT.Interop/SceneGraph/NrtSceneNode.h"
   #include "NovelRT.Interop/SceneGraph/NrtSceneNodeBreadthFirstIterator.h"
   #include "NovelRT.Interop/SceneGraph/NrtSceneNodeDepthFirstIterator.h"
-  
+
   // Timing
   #include "NovelRT.Interop/Timing/NrtStepTimer.h"
   #include "NovelRT.Interop/Timing/NrtTimestamp.h"
-  
+
   // Utilities
   #include "NovelRT.Interop/Utilities/NrtMisc.h"
-  
+
   // Windowing
   #include "NovelRT.Interop/Windowing/NrtWindowingService.h"
 #endif

--- a/include/NovelRT/NovelRunner.h
+++ b/include/NovelRT/NovelRunner.h
@@ -33,9 +33,9 @@ namespace NovelRT
         std::shared_ptr<Windowing::WindowingService> _novelWindowingService;
         std::shared_ptr<Input::InteractionService> _novelInteractionService;
         std::shared_ptr<Audio::AudioService> _novelAudioService;
-        #ifdef NOVELRT_INK
+#ifdef NOVELRT_INK
         std::shared_ptr<DotNet::RuntimeService> _novelDotNetRuntimeService;
-        #endif
+#endif
         std::shared_ptr<Graphics::RenderingService> _novelRenderer;
         std::shared_ptr<DebugService> _novelDebugService;
         LoggingService _loggingService;
@@ -67,10 +67,10 @@ namespace NovelRT
         std::shared_ptr<DebugService> getDebugService() const noexcept;
         /// @brief Gets the Audio Service associated with this Runner.
         std::shared_ptr<Audio::AudioService> getAudioService() const noexcept;
-        #ifdef NOVELRT_INK
+#ifdef NOVELRT_INK
         /// @brief Gets the .NET Runtime Service associated with this Runner.
         std::shared_ptr<DotNet::RuntimeService> getDotNetRuntimeService() const noexcept;
-        #endif
+#endif
         /// @brief Gets the Windowing Service associated with this Runner.
         std::shared_ptr<Windowing::WindowingService> getWindowingService() const noexcept;
 

--- a/include/NovelRT/NovelRunner.h
+++ b/include/NovelRT/NovelRunner.h
@@ -33,7 +33,9 @@ namespace NovelRT
         std::shared_ptr<Windowing::WindowingService> _novelWindowingService;
         std::shared_ptr<Input::InteractionService> _novelInteractionService;
         std::shared_ptr<Audio::AudioService> _novelAudioService;
+        #ifdef NOVELRT_INK
         std::shared_ptr<DotNet::RuntimeService> _novelDotNetRuntimeService;
+        #endif
         std::shared_ptr<Graphics::RenderingService> _novelRenderer;
         std::shared_ptr<DebugService> _novelDebugService;
         LoggingService _loggingService;
@@ -65,8 +67,10 @@ namespace NovelRT
         std::shared_ptr<DebugService> getDebugService() const noexcept;
         /// @brief Gets the Audio Service associated with this Runner.
         std::shared_ptr<Audio::AudioService> getAudioService() const noexcept;
+        #ifdef NOVELRT_INK
         /// @brief Gets the .NET Runtime Service associated with this Runner.
         std::shared_ptr<DotNet::RuntimeService> getDotNetRuntimeService() const noexcept;
+        #endif
         /// @brief Gets the Windowing Service associated with this Runner.
         std::shared_ptr<Windowing::WindowingService> getWindowingService() const noexcept;
 

--- a/samples/CAPI/CMakeLists.txt
+++ b/samples/CAPI/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(lua 5.3 REQUIRED)
-
 set(SOURCES
   main.c
 )
@@ -7,29 +5,12 @@ set(SOURCES
 set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE C)
 
 add_executable(CAPI ${SOURCES})
-add_dependencies(CAPI Dotnet Resources)
+add_dependencies(CAPI Resources)
 target_link_libraries(CAPI
   PRIVATE
     Engine
     Interop
-    lua::lua
 )
-
-add_custom_command(
-  TARGET CAPI POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_directory
-    $<TARGET_FILE_DIR:Dotnet>
-    $<TARGET_FILE_DIR:CAPI>/dotnet
-)
-
-if(WIN32)
-  add_custom_command(
-    TARGET CAPI POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-      $<TARGET_FILE_DIR:CAPI>/dotnet/nethost.dll
-      $<TARGET_FILE_DIR:CAPI>
-  )
-endif()
 
 add_custom_command(
   TARGET CAPI POST_BUILD
@@ -51,3 +32,23 @@ add_custom_command(
     $<TARGET_FILE_DIR:Interop>
     $<TARGET_FILE_DIR:CAPI>
 )
+
+if(NOVELRT_INCLUDE_INK)
+  add_dependencies(CAPI Dotnet)
+  target_compile_definitions(CAPI PRIVATE NOVELRT_INK)
+  add_custom_command(
+  TARGET CAPI POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+    $<TARGET_FILE_DIR:Dotnet>
+    $<TARGET_FILE_DIR:CAPI>/dotnet
+  )
+
+  if(WIN32)
+    add_custom_command(
+      TARGET CAPI POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy
+        $<TARGET_FILE_DIR:CAPI>/dotnet/nethost.dll
+        $<TARGET_FILE_DIR:CAPI>
+    )
+  endif()
+endif()

--- a/samples/CAPI/main.c
+++ b/samples/CAPI/main.c
@@ -22,8 +22,10 @@ char flippedAxisTempBuffer[1024];
 NrtAudioServiceHandle audio = NULL;
 NrtInteractionServiceHandle input = NULL;
 NrtLoggingServiceHandle console = NULL;
+#ifdef NOVELRT_INK
 NrtRuntimeServiceHandle dotnet = NULL;
 NrtInkServiceHandle ink = NULL;
+#endif
 NrtStepTimerHandle timer = NULL;
 NrtRenderingServiceHandle renderer = NULL;
 NrtUtilitiesEventWithTimestampHandle updateEvent = NULL;
@@ -32,7 +34,9 @@ NrtRGBAConfigHandle colourChange = NULL;
 // Objects
 NrtImageRectHandle nChanRect = NULL;
 NrtBasicInteractionRectHandle interactRect = NULL;
+#ifdef NOVELRT_INK
 NrtStoryHandle story = NULL;
+#endif
 
 // Function to render NovelChan
 void RenderNovelChan(void* context)
@@ -145,6 +149,7 @@ void MoveNovelChan(NrtTimestamp delta, void* context)
     Nrt_Input_BasicInteractionRect_setTransform(interactRect, transform);
 }
 
+#ifdef NOVELRT_INK
 // Function to interact with Ink
 void InteractWithNovelChan(void* context)
 {
@@ -157,6 +162,7 @@ void InteractWithNovelChan(void* context)
     Nrt_LoggingService_logDebugLine(console, cSharpResult);
     Nrt_RuntimeService_freeString(dotnet, cSharpResult);
 }
+#endif
 
 int main()
 {
@@ -216,6 +222,7 @@ int main()
         return -1;
     }
 
+    #ifdef NOVELRT_INK
     // Getting & Initialising RuntimeService / InkService
     res = Nrt_NovelRunner_getRuntimeService(runner, &dotnet);
     if (res != NRT_SUCCESS)
@@ -243,6 +250,7 @@ int main()
             }
         }
     }
+    #endif
 
     // Changing Background Colour
     res = Nrt_NovelRunner_getRenderer(runner, &renderer);
@@ -275,6 +283,7 @@ int main()
     NrtTransform interactTransform = {nChanPosition, nChanSize, 0};
     res = Nrt_InteractionService_createBasicInteractionRect(input, interactTransform, 3, &interactRect);
 
+#ifdef NOVELRT_INK
     // Creating Ink Story
     if (inkServiceProvided == NRT_TRUE)
     {
@@ -305,6 +314,7 @@ int main()
         }
         Nrt_Input_BasicInteractionRect_addInteraction(interactRect, &InteractWithNovelChan, NULL);
     }
+#endif
 
     // Setting up Scene Construction
     Nrt_NovelRunner_SubscribeToSceneConstructionRequested(runner, &RenderNovelChan, NULL, NULL);

--- a/samples/CAPI/main.c
+++ b/samples/CAPI/main.c
@@ -222,7 +222,7 @@ int main()
         return -1;
     }
 
-    #ifdef NOVELRT_INK
+#ifdef NOVELRT_INK
     // Getting & Initialising RuntimeService / InkService
     res = Nrt_NovelRunner_getRuntimeService(runner, &dotnet);
     if (res != NRT_SUCCESS)
@@ -250,7 +250,7 @@ int main()
             }
         }
     }
-    #endif
+#endif
 
     // Changing Background Colour
     res = Nrt_NovelRunner_getRenderer(runner, &renderer);

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(Simple)
 add_subdirectory(CAPI)
-add_subdirectory(NovelRT.DotNet.Sample)
+if(NOVELRT_INCLUDE_INK)
+  add_subdirectory(NovelRT.DotNet.Sample)
+endif()

--- a/samples/Simple/CMakeLists.txt
+++ b/samples/Simple/CMakeLists.txt
@@ -1,32 +1,13 @@
-find_package(lua 5.3 REQUIRED)
-
 set(SOURCES
   main.cpp
 )
 
 add_executable(Simple ${SOURCES})
-add_dependencies(Simple Dotnet Resources)
+add_dependencies(Simple Resources)
 target_link_libraries(Simple
   PRIVATE
     Engine
 )
-
-add_custom_command(
-  TARGET Simple POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_directory
-    $<TARGET_FILE_DIR:Dotnet>
-    $<TARGET_FILE_DIR:Simple>/dotnet
-)
-
-#this is pure hacky hotfix goodness. We need to figure out a better way to do this in the future.
-if(WIN32)
-  add_custom_command(
-    TARGET Simple POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-      $<TARGET_FILE_DIR:Simple>/dotnet/nethost.dll
-      $<TARGET_FILE_DIR:Simple>
-  )
-endif()
 
 add_custom_command(
   TARGET Simple POST_BUILD
@@ -41,3 +22,23 @@ add_custom_command(
     $<TARGET_FILE_DIR:Engine>
     $<TARGET_FILE_DIR:Simple>
 )
+
+if(NOVELRT_INCLUDE_INK)
+  add_dependencies(Simple Dotnet)
+  target_compile_definitions(Simple PRIVATE NOVELRT_INK)
+  add_custom_command(
+    TARGET Simple POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+      $<TARGET_FILE_DIR:Dotnet>
+      $<TARGET_FILE_DIR:Simple>/dotnet
+  )
+  #this is pure hacky hotfix goodness. We need to figure out a better way to do this in the future.
+  if(WIN32)
+    add_custom_command(
+      TARGET Simple POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy
+        $<TARGET_FILE_DIR:Simple>/dotnet/nethost.dll
+        $<TARGET_FILE_DIR:Simple>
+    )
+  endif()
+endif()

--- a/samples/Simple/CMakeLists.txt
+++ b/samples/Simple/CMakeLists.txt
@@ -9,7 +9,6 @@ add_dependencies(Simple Dotnet Resources)
 target_link_libraries(Simple
   PRIVATE
     Engine
-    lua::lua
 )
 
 add_custom_command(

--- a/samples/Simple/main.cpp
+++ b/samples/Simple/main.cpp
@@ -3,27 +3,6 @@
 
 #include <NovelRT.h>
 
-// TODO: What do I do with these?
-extern "C"
-{
-#include <lauxlib.h>
-#include <lua.h>
-#include <lualib.h>
-}
-
-static int average(lua_State* luaState)
-{
-    int n = lua_gettop(luaState);
-    double sum = 0;
-    for (int i = 1; i <= n; i++)
-    {
-        sum += lua_tonumber(luaState, i);
-    }
-    lua_pushnumber(luaState, sum / n);
-    lua_pushnumber(luaState, sum);
-    return 2;
-}
-
 // TODO: Do we really need this anymore? No real reason to run this in WSL these days.
 #ifdef WIN32
 #define setenv(name, value, overwrite)                                                                                 \
@@ -33,8 +12,6 @@ static int average(lua_State* luaState)
 
 int main(int /*argc*/, char* /*argv*/[])
 {
-    lua_State* L;
-
     std::unique_ptr<NovelRT::Graphics::ImageRect> novelChanRect;
     std::unique_ptr<NovelRT::Graphics::TextRect> textRect;
     std::unique_ptr<NovelRT::Graphics::BasicFillRect> lineRect;
@@ -64,11 +41,6 @@ int main(int /*argc*/, char* /*argv*/[])
     std::filesystem::path soundsDirPath = resourcesDirPath / "Sounds";
 
     // setenv("DISPLAY", "localhost:0", true);
-    L = luaL_newstate();
-    luaL_openlibs(L);
-    lua_register(L, "average", average);
-    luaL_dofile(L, (scriptsDirPath / "avg.lua").string().c_str());
-    lua_close(L);
 
     auto runner = NovelRT::NovelRunner(0, "NovelRTTest", NovelRT::Windowing::WindowMode::Windowed);
     auto console = NovelRT::LoggingService(NovelRT::Utilities::Misc::CONSOLE_LOG_APP);

--- a/samples/Simple/main.cpp
+++ b/samples/Simple/main.cpp
@@ -151,6 +151,7 @@ int main(int /*argc*/, char* /*argv*/[])
     playAudioButtonTwoElectricBoogaloo =
         runner.getRenderer()->createBasicFillRect(theRealMvpTransform, 2, NovelRT::Graphics::RGBAConfig(0, 255, 0, 70));
 
+#ifdef NOVELRT_INK
     auto inkButtonTransform = NovelRT::Transform(
         NovelRT::Maths::GeoVector2F(novelChanTransform.position.x - 500, novelChanTransform.position.y - 200), 0,
         NovelRT::Maths::GeoVector2F(200, 200));
@@ -166,6 +167,7 @@ int main(int /*argc*/, char* /*argv*/[])
     inkText->setText("Ink!");
     inkInteractionRect = runner.getInteractionService()->createBasicInteractionRect(inkButtonTransform, -1);
     inkInteractionRect->subscribedKey() = NovelRT::Input::KeyCode::LeftMouseButton;
+#endif
 
     runner.getDebugService()->setIsFpsCounterVisible(true);
 
@@ -231,12 +233,16 @@ int main(int /*argc*/, char* /*argv*/[])
         playAudioButtonTwoElectricBoogaloo->executeObjectBehaviour();
         playAudioText->executeObjectBehaviour();
 
+#ifdef NOVELRT_INK
         inkButton->executeObjectBehaviour();
         inkText->executeObjectBehaviour();
+#endif
 
         memeInteractionRect->executeObjectBehaviour();
         interactionRect->executeObjectBehaviour();
+#ifdef NOVELRT_INK
         inkInteractionRect->executeObjectBehaviour();
+#endif
 
         novelChanRect->executeObjectBehaviour();
 
@@ -249,6 +255,7 @@ int main(int /*argc*/, char* /*argv*/[])
         lineRect->executeObjectBehaviour();
     };
 
+#ifdef NOVELRT_INK
     auto dotnetRuntimeService = runner.getDotNetRuntimeService();
     dotnetRuntimeService->initialise();
 
@@ -280,7 +287,7 @@ int main(int /*argc*/, char* /*argv*/[])
         console.logDebug(result);
         dotnetRuntimeService->freeString(result);
     };
-
+#endif
     audio->playMusic(bgm, -1);
     runner.runNovel();
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
-add_subdirectory(NovelRT.DotNet)
+if(NOVELRT_INCLUDE_INK)
+  add_subdirectory(NovelRT.DotNet)
+endif()
 add_subdirectory(NovelRT)
 add_subdirectory(NovelRT.Interop)

--- a/src/NovelRT.Interop/CMakeLists.txt
+++ b/src/NovelRT.Interop/CMakeLists.txt
@@ -10,8 +10,6 @@ set(SOURCES
 
   Audio/NrtAudioService.cpp
 
-  DotNet/NrtRuntimeService.cpp
-
   Ecs/NrtCatalogue.cpp
   Ecs/NrtComponentBufferMemoryContainer.cpp
   Ecs/NrtComponentCache.cpp
@@ -29,9 +27,6 @@ set(SOURCES
   Graphics/NrtRGBAConfig.cpp
   Graphics/NrtTextRect.cpp
   Graphics/NrtTexture.cpp
-
-  Ink/NrtInkService.cpp
-  Ink/NrtStory.cpp
 
   Input/NrtBasicInteractionRect.cpp
   Input/NrtInteractionService.cpp
@@ -112,3 +107,13 @@ endif()
 target_link_libraries(Interop
   PUBLIC
     Engine)
+
+if(NOVELRT_INCLUDE_INK)
+  set(SOURCES
+    ${SOURCES}
+    DotNet/NrtRuntimeService.cpp
+    Ink/NrtInkService.cpp
+    Ink/NrtStory.cpp
+  )
+  target_compile_definitions(Interop PRIVATE NOVELRT_INK)
+endif()

--- a/src/NovelRT.Interop/CMakeLists.txt
+++ b/src/NovelRT.Interop/CMakeLists.txt
@@ -56,6 +56,15 @@ set(SOURCES
   Windowing/NrtWindowingService.cpp
 )
 
+if(NOVELRT_INCLUDE_INK)
+  set(SOURCES
+    ${SOURCES}
+    DotNet/NrtRuntimeService.cpp
+    Ink/NrtInkService.cpp
+    Ink/NrtStory.cpp
+  )
+endif()
+
 add_library(Interop SHARED ${SOURCES})
 add_dependencies(Interop Engine)
 
@@ -109,11 +118,5 @@ target_link_libraries(Interop
     Engine)
 
 if(NOVELRT_INCLUDE_INK)
-  set(SOURCES
-    ${SOURCES}
-    DotNet/NrtRuntimeService.cpp
-    Ink/NrtInkService.cpp
-    Ink/NrtStory.cpp
-  )
   target_compile_definitions(Interop PRIVATE NOVELRT_INK)
 endif()

--- a/src/NovelRT.Interop/NrtNovelRunner.cpp
+++ b/src/NovelRT.Interop/NrtNovelRunner.cpp
@@ -12,7 +12,9 @@ using namespace NovelRT;
 std::list<std::shared_ptr<Audio::AudioService>> _audioCollection;
 std::list<std::shared_ptr<Input::InteractionService>> _interactionCollection;
 std::list<std::shared_ptr<Windowing::WindowingService>> _windowingCollection;
+#ifdef NOVELRT_INK
 std::list<std::shared_ptr<DotNet::RuntimeService>> _runtimeCollection;
+#endif
 std::list<std::shared_ptr<Graphics::RenderingService>> _rendererCollection;
 std::list<std::shared_ptr<DebugService>> _debugServiceCollection;
 
@@ -149,6 +151,7 @@ extern "C"
         return NRT_SUCCESS;
     }
 
+#ifdef NOVELRT_INK
     NrtResult Nrt_NovelRunner_getRuntimeService(NrtNovelRunnerHandle runner, NrtRuntimeServiceHandle* outputService)
     {
         if (runner == nullptr)
@@ -176,6 +179,7 @@ extern "C"
 
         return NRT_SUCCESS;
     }
+#endif
 
     NrtResult Nrt_NovelRunner_getRenderer(NrtNovelRunnerHandle runner, NrtRenderingServiceHandle* outputService)
     {

--- a/src/NovelRT/CMakeLists.txt
+++ b/src/NovelRT/CMakeLists.txt
@@ -69,8 +69,26 @@ set(SOURCES
   WorldObject.cpp
 )
 
+if(NOVELRT_INCLUDE_INK)
+  message("NovelRT is compiling with Ink / C# Support.")
+  set(SOURCES
+    DotNet/RuntimeService.cpp
+    Ink/InkService.cpp
+    Ink/Story.cpp
+    ${SOURCES}
+  )
+endif()
+
 add_library(Engine SHARED ${SOURCES})
-add_dependencies(Engine Dotnet)
+
+if(NOVELRT_INCLUDE_INK)
+  add_dependencies(Engine Dotnet)
+  target_compile_definitions(Engine PRIVATE NOVELRT_INK)
+  target_link_libraries(Engine PUBLIC
+    CoreCLR::nethost
+  )
+  find_package(Dotnet ${NOVELRT_DOTNET_VERSION} REQUIRED)
+endif()
 
 set_property(TARGET Engine PROPERTY OUTPUT_NAME "NovelRT")
 
@@ -138,20 +156,6 @@ target_link_libraries(Engine
     Vorbis::Vorbis
     Microsoft.GSL::Microsoft.GSL
 )
-
-if(NOVELRT_INCLUDE_INK)
-  find_package(Dotnet ${NOVELRT_DOTNET_VERSION} REQUIRED)
-  set(SOURCES
-    ${SOURCES}
-    DotNet/RuntimeService.cpp
-    Ink/InkService.cpp
-    Ink/Story.cpp
-  )
-  target_compile_definitions(Engine PRIVATE NOVELRT_INK)
-  target_link_libraries(Engine PUBLIC
-    CoreCLR::nethost
-  )
-endif()
 
 if(WIN32)
   target_link_libraries(Engine

--- a/src/NovelRT/CMakeLists.txt
+++ b/src/NovelRT/CMakeLists.txt
@@ -1,5 +1,4 @@
 find_package(BZip2 ${NOVELRT_BZIP2_VERSION} REQUIRED)
-find_package(Dotnet ${NOVELRT_DOTNET_VERSION} REQUIRED)
 find_package(flac ${NOVELRT_FLAC_VERSION} REQUIRED)
 find_package(Freetype ${NOVELRT_FREETYPE_VERSION} REQUIRED)
 find_package(glad ${NOVELRT_GLAD_VERSION} REQUIRED
@@ -29,8 +28,6 @@ set(SOURCES
 
   DebugService.cpp
 
-  DotNet/RuntimeService.cpp
-
   Ecs/Catalogue.cpp
   Ecs/ComponentBufferMemoryContainer.cpp
   Ecs/ComponentCache.cpp
@@ -49,9 +46,6 @@ set(SOURCES
   Graphics/RGBAConfig.cpp
   Graphics/TextRect.cpp
   Graphics/Texture.cpp
-
-  Ink/InkService.cpp
-  Ink/Story.cpp
 
   Input/BasicInteractionRect.cpp
   Input/InteractionObject.cpp
@@ -130,7 +124,6 @@ endif()
 target_link_libraries(Engine
   PUBLIC
     BZip2::BZip2
-    CoreCLR::nethost
     FLAC::FLAC
     Freetype::Freetype
     glad::glad
@@ -145,6 +138,20 @@ target_link_libraries(Engine
     Vorbis::Vorbis
     Microsoft.GSL::Microsoft.GSL
 )
+
+if(NOVELRT_INCLUDE_INK)
+  find_package(Dotnet ${NOVELRT_DOTNET_VERSION} REQUIRED)
+  set(SOURCES
+    ${SOURCES}
+    DotNet/RuntimeService.cpp
+    Ink/InkService.cpp
+    Ink/Story.cpp
+  )
+  target_compile_definitions(Engine PRIVATE NOVELRT_INK)
+  target_link_libraries(Engine PUBLIC
+    CoreCLR::nethost
+  )
+endif()
 
 if(WIN32)
   target_link_libraries(Engine

--- a/src/NovelRT/NovelRunner.cpp
+++ b/src/NovelRT/NovelRunner.cpp
@@ -3,10 +3,6 @@
 
 #include <NovelRT.h>
 
-#if !defined(NOVELRT_INK)
-#pragma message("Ink not being compiled with NovelRT.")
-#endif
-
 namespace NovelRT
 {
     NovelRunner::NovelRunner(int32_t displayNumber,

--- a/src/NovelRT/NovelRunner.cpp
+++ b/src/NovelRT/NovelRunner.cpp
@@ -3,6 +3,10 @@
 
 #include <NovelRT.h>
 
+#if !defined(NOVELRT_INK)
+#pragma message("Ink not being compiled with NovelRT.")
+#endif
+
 namespace NovelRT
 {
     NovelRunner::NovelRunner(int32_t displayNumber,
@@ -18,7 +22,9 @@ namespace NovelRT
           _novelWindowingService(std::make_shared<Windowing::WindowingService>()),
           _novelInteractionService(std::make_shared<Input::InteractionService>(getWindowingService())),
           _novelAudioService(std::make_shared<Audio::AudioService>()),
+#if NOVELRT_INK
           _novelDotNetRuntimeService(std::make_shared<DotNet::RuntimeService>()),
+#endif
           _novelRenderer(std::make_shared<Graphics::RenderingService>(getWindowingService())),
           _novelDebugService(std::make_shared<DebugService>(SceneConstructionRequested, getRenderer()))
     {
@@ -75,12 +81,12 @@ namespace NovelRT
     {
         return _novelAudioService;
     }
-
+#if NOVELRT_INK
     std::shared_ptr<DotNet::RuntimeService> NovelRunner::getDotNetRuntimeService() const noexcept
     {
         return _novelDotNetRuntimeService;
     }
-
+#endif
     std::shared_ptr<Windowing::WindowingService> NovelRunner::getWindowingService() const noexcept
     {
         return _novelWindowingService;

--- a/tests/NovelRT.Tests/CMakeLists.txt
+++ b/tests/NovelRT.Tests/CMakeLists.txt
@@ -64,23 +64,6 @@ target_link_libraries(Engine_Tests
 add_custom_command(
   TARGET Engine_Tests POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory
-    $<TARGET_FILE_DIR:Dotnet>
-    $<TARGET_FILE_DIR:Engine_Tests>/dotnet
-)
-
-#this is pure hacky hotfix goodness. We need to figure out a better way to do this in the future.
-if(WIN32)
-  add_custom_command(
-    TARGET Engine_Tests POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy
-      $<TARGET_FILE_DIR:Engine_Tests>/dotnet/nethost.dll
-      $<TARGET_FILE_DIR:Engine_Tests>
-  )
-endif()
-
-add_custom_command(
-  TARGET Engine_Tests POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_directory
     $<TARGET_FILE_DIR:Engine>
     $<TARGET_FILE_DIR:Engine_Tests>
 )
@@ -91,6 +74,25 @@ add_custom_command(
     $<TARGET_FILE_DIR:Interop>
     $<TARGET_FILE_DIR:Engine_Tests>
 )
+
+if(NOVELRT_INCLUDE_INK)
+  add_custom_command(
+    TARGET Engine_Tests POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+      $<TARGET_FILE_DIR:Dotnet>
+      $<TARGET_FILE_DIR:Engine_Tests>/dotnet
+  )
+
+  #this is pure hacky hotfix goodness. We need to figure out a better way to do this in the future.
+  if(WIN32)
+    add_custom_command(
+      TARGET Engine_Tests POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy
+        $<TARGET_FILE_DIR:Engine_Tests>/dotnet/nethost.dll
+        $<TARGET_FILE_DIR:Engine_Tests>
+    )
+  endif()
+endif()
 
 gtest_discover_tests(Engine_Tests
   EXTRA_ARGS "--gtest_output=xml:${CMAKE_CURRENT_BINARY_DIR}/../results/")


### PR DESCRIPTION
This PR adds a CMake and C++ preprocessor definition that controls whether or not any C# code is built.

Tested WITH and WITHOUT Ink - Samples and Tests should be passing at this time.

Default behaviour is to _include_ the C# / Ink support and C# bindings.

Resolves #319 