### PR TITLE
Switching doxygen workflow to use Windows

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -8,9 +8,12 @@ on:
 jobs:
   Build_and_Publish_Documentation:
     name: Build and Publish Documentation
-    runs-on: ubuntu-latest
-    container:
-      image: novelrt/novelrt-build:latest
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: cmd
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -25,17 +28,19 @@ jobs:
           gh auth login
           git config user.name "Novel-chan"
           git config user.email "admin@novelrt.dev"
-
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Run Windows Setup
+        run: scripts\machine-setup.cmd
+
       - name: Generate Documentation
-        run: scripts/cibuild.sh --documentation -DDOXYGEN_OUTPUT_DIR=$GITHUB_WORKSPACE/novelrt/docs
+        run: scripts\cibuild.cmd -documentation -DDOXYGEN_OUTPUT_DIRECTORY='$GITHUB_WORKSPACE\novelrt\docs'
 
       - name: Commit Documentation Updates
         if: ${{ success() }}
         run: |
-          git add ./docs/*
+          git add docs/*
           git commit -m "Updated documentation - $GITHUB_SHA"
           git push origin documentation/$GITHUB_SHA
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -35,7 +35,10 @@ function Generate() {
   if ($ci) {
   conan config install https://github.com/novelrt/ConanConfig.git
   conan install . -if "$BuildDir" --build=missing --profile windows-vs2019-amd64
-    $remaining = ,"-DNOVELRT_BUILD_DOCUMENTATION=OFF", "-DPython_FIND_REGISTRY=NEVER", "-DPython_FIND_STRATEGY=LOCATION" + $remaining
+      $remaining = ,"-DPython_FIND_REGISTRY=NEVER", "-DPython_FIND_STRATEGY=LOCATION" + $remaining
+      if ($documentation -eq $false) {
+        $remaining = ,"-DNOVELRT_BUILD_DOCUMENTATION=OFF" + $remaining
+      }
   }
 
   & cmake -S $RepoRoot -B $BuildDir -Wdev -Werror=dev -Wdeprecated -Werror=deprecated -A x64 -DCMAKE_BUILD_TYPE="$configuration" -DCMAKE_INSTALL_PREFIX="$InstallDir" $remaining


### PR DESCRIPTION
Since `gh` commands are not in the container we use for Linux, I've temporarily switched the workflow to use Windows only so that we can begin to produce documentation for the NovelRT website - realistically as long as this works, we wouldn't need to _switch_ to Linux either, unless we just want a faster build time for this workflow.

Also, fixed an obscure bug that prevented the `$documentation` flag from being set properly in the Windows CI script🙂 as well as an odd issue where the doxygen directory was not set properly, so nothing would get committed anyways. 