### PR TITLE
Use the force, Novel-chan...

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Create documentation branch
-        run: git checkout -b documentation/$GITHUB_SHA
+        run: git checkout -b gh-pages
         
       - name: Prepare Secrets
         run: echo "${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_WORKSPACE/secret.txt
@@ -36,10 +36,5 @@ jobs:
         if: ${{ success() }}
         run: |
           git add $GITHUB_WORKSPACE/docs/*
-          git commit -m "Updated documentation - $GITHUB_SHA"
-          git push origin documentation/$GITHUB_SHA
-
-      - name: Create Pull Request
-        if: ${{ success() }}
-        run: |
-          gh pr create --title "${{ github.sha }} into gh-pages" --body "Updated documentation from commit ${{ github.sha }} in main." --base gh-pages --head documentation/${{ github.sha }}
+          git commit -m "Updated documentation - $GITHUB_SHA from main"
+          git push origin gh-pages --force


### PR DESCRIPTION
Modifying the flow to allow for force-pushing - should only be done to gh-pages branch.
This is done because previously by committing a document commit to the gh-pages branch, I caused the branch to diverge which did not allow future merging and caused rebasing to fail.

Resolves #352 