### PR TITLE
Automagically build linux docker images

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,0 +1,26 @@
+name: Build Docker Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/novelrt-build.linux.Dockerfile'
+
+jobs:
+  build_docker_images:
+    name: Build and push Docker Images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Build and push Linux docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          file: scripts/novelrt-build.linux.Dockerfile
+          tags:
+            - novelrt/novelrt-build:latest


### PR DESCRIPTION
CC @RubyNova

This should automagically build Linux docker images when the Dockerfile in `main` changes. Which *should* keep it up to date. Hopefully.

I need a few secrets setup though, like the login info for Docker Hub so that we can log in. Alternatively, we could use the GitHub container registry instead of Docker Hub: https://github.com/marketplace/actions/docker-login#github-container-registry