### PR TITLE
Improved C error handling

### DIFF
--- a/include/NovelRT.Interop/NrtErrorHandling.h
+++ b/include/NovelRT.Interop/NrtErrorHandling.h
@@ -29,6 +29,20 @@ extern "C"
     void Nrt_setErrMsgIsOutOfMemoryInternal();
     void Nrt_setErrMsgCustomInternal(const char* message);
 
+    NrtResult Nrt_getNullArgumentErrorInternal();
+    NrtResult Nrt_getNullInstanceErrorInternal();
+    NrtResult Nrt_getNaNErrorInternal();
+    NrtResult Nrt_getDivideByZeroErrorInternal();
+    NrtResult Nrt_getAlreadyDeletedOrRemovedErrorInternal();
+    NrtResult Nrt_getNotSupportedErrorInternal();
+    NrtResult Nrt_getInitialisationFailureErrorInternal();
+    NrtResult Nrt_getFunctionNotFoundErrorInternal();
+    NrtResult Nrt_getNotInitialisedErrorInternal();
+    NrtResult Nrt_getArgumentOutOfRangeErrorInternal();
+    NrtResult Nrt_getInvalidOperationErrorInternal();
+    NrtResult Nrt_getCharacterNotFoundErrorInternal();
+    NrtResult Nrt_getOutOfMemoryErrorInternal();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/NovelRT.Interop/Animation/NrtSpriteAnimator.cpp
+++ b/src/NovelRT.Interop/Animation/NrtSpriteAnimator.cpp
@@ -17,8 +17,7 @@ extern "C"
     {
         if (runner == nullptr || rect == nullptr || outputAnimator == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Animation::SpriteAnimator* animator = new Animation::SpriteAnimator(
@@ -31,8 +30,7 @@ extern "C"
     {
         if (animator == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Animation::SpriteAnimator* cppAnimator = reinterpret_cast<Animation::SpriteAnimator*>(animator);
@@ -44,8 +42,7 @@ extern "C"
     {
         if (animator == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Animation::SpriteAnimator* cppAnimator = reinterpret_cast<Animation::SpriteAnimator*>(animator);
@@ -57,8 +54,7 @@ extern "C"
     {
         if (animator == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Animation::SpriteAnimator* cppAnimator = reinterpret_cast<Animation::SpriteAnimator*>(animator);
@@ -77,14 +73,12 @@ extern "C"
     {
         if (animator == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (state == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Animation::SpriteAnimator* cppAnimator = reinterpret_cast<Animation::SpriteAnimator*>(animator);

--- a/src/NovelRT.Interop/Animation/NrtSpriteAnimatorFrame.cpp
+++ b/src/NovelRT.Interop/Animation/NrtSpriteAnimatorFrame.cpp
@@ -21,14 +21,12 @@ extern "C"
     {
         if (frame == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputTexture == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Animation::SpriteAnimatorFrame* cppFrame = reinterpret_cast<Animation::SpriteAnimatorFrame*>(frame);
@@ -42,14 +40,12 @@ extern "C"
     {
         if (frame == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (texture == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Animation::SpriteAnimatorFrame* cppFrame = reinterpret_cast<Animation::SpriteAnimatorFrame*>(frame);
@@ -71,8 +67,7 @@ extern "C"
     {
         if (frame == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Animation::SpriteAnimatorFrame* cppFrame = reinterpret_cast<Animation::SpriteAnimatorFrame*>(frame);
@@ -87,14 +82,12 @@ extern "C"
     {
         if (frame == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (frame == nullptr || func == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Animation::SpriteAnimatorFrame* cppFrame = reinterpret_cast<Animation::SpriteAnimatorFrame*>(frame);
@@ -109,14 +102,12 @@ extern "C"
     {
         if (frame == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (frame == nullptr || func == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Animation::SpriteAnimatorFrame* cppFrame = reinterpret_cast<Animation::SpriteAnimatorFrame*>(frame);

--- a/src/NovelRT.Interop/Animation/NrtSpriteAnimatorState.cpp
+++ b/src/NovelRT.Interop/Animation/NrtSpriteAnimatorState.cpp
@@ -23,14 +23,12 @@ extern "C"
     {
         if (state == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (stateTarget == nullptr || vector == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Animation::SpriteAnimatorState* cppState = reinterpret_cast<Animation::SpriteAnimatorState*>(state);
@@ -47,8 +45,7 @@ extern "C"
     {
         if (state == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Animation::SpriteAnimatorState* cppState = reinterpret_cast<Animation::SpriteAnimatorState*>(state);
@@ -68,8 +65,7 @@ extern "C"
     {
         if (state == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Animation::SpriteAnimatorState* cppState = reinterpret_cast<Animation::SpriteAnimatorState*>(state);
@@ -84,14 +80,12 @@ extern "C"
     {
         if (state == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (state == nullptr || outputFrames == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Animation::SpriteAnimatorState* cppState = reinterpret_cast<Animation::SpriteAnimatorState*>(state);
@@ -107,14 +101,12 @@ extern "C"
     {
         if (state == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (state == nullptr || frames == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Animation::SpriteAnimatorState* cppState = reinterpret_cast<Animation::SpriteAnimatorState*>(state);
@@ -129,14 +121,12 @@ extern "C"
     {
         if (state == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputTransitionState == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Animation::SpriteAnimatorState* cppState = reinterpret_cast<Animation::SpriteAnimatorState*>(state);
@@ -156,8 +146,7 @@ extern "C"
     {
         if (vector == nullptr || frame == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         std::vector<Animation::SpriteAnimatorFrame> cppVector =
@@ -173,14 +162,12 @@ extern "C"
     {
         if (vector == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputFrame == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         std::vector<Animation::SpriteAnimatorFrame> cppVector =
@@ -193,8 +180,7 @@ extern "C"
         }
         catch (const std::out_of_range)
         {
-            Nrt_setErrMsgIsArgumentOutOfRangeInternal();
-            return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+            return Nrt_getArgumentOutOfRangeErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -204,8 +190,7 @@ extern "C"
     {
         if (vector == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         std::vector<Animation::SpriteAnimatorFrame> cppVector =
@@ -218,8 +203,7 @@ extern "C"
     {
         if (vector == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         std::vector<Animation::SpriteAnimatorFrame>* cppVector =

--- a/src/NovelRT.Interop/Audio/NrtAudioService.cpp
+++ b/src/NovelRT.Interop/Audio/NrtAudioService.cpp
@@ -21,8 +21,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -40,8 +39,7 @@ extern "C"
         }
         catch (const Exceptions::InitialisationFailureException)
         {
-            Nrt_setErrMsgIsInitialisationFailureInternal();
-            return NRT_FAILURE_INITIALISATION_FAILURE;
+            return Nrt_getInitialisationFailureErrorInternal();
         }
     }
 
@@ -51,8 +49,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -64,8 +61,7 @@ extern "C"
         }
         catch (const Exceptions::NotInitialisedException)
         {
-            Nrt_setErrMsgIsNotInitialisedInternal();
-            return NRT_FAILURE_NOT_INITIALISED;
+            return Nrt_getNotInitialisedErrorInternal();
         }
 
         *output = reinterpret_cast<NrtAudioServiceIteratorHandle&>(out);
@@ -76,8 +72,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -88,8 +83,7 @@ extern "C"
         }
         catch (const Exceptions::NotInitialisedException)
         {
-            Nrt_setErrMsgIsNotInitialisedInternal();
-            return NRT_FAILURE_NOT_INITIALISED;
+            return Nrt_getNotInitialisedErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -102,8 +96,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -114,8 +107,7 @@ extern "C"
         }
         catch (const Exceptions::NotInitialisedException)
         {
-            Nrt_setErrMsgIsNotInitialisedInternal();
-            return NRT_FAILURE_NOT_INITIALISED;
+            return Nrt_getNotInitialisedErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -125,8 +117,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -137,8 +128,7 @@ extern "C"
         }
         catch (const Exceptions::NotInitialisedException)
         {
-            Nrt_setErrMsgIsNotInitialisedInternal();
-            return NRT_FAILURE_NOT_INITIALISED;
+            return Nrt_getNotInitialisedErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -150,8 +140,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -162,8 +151,7 @@ extern "C"
         }
         catch (const Exceptions::NotInitialisedException)
         {
-            Nrt_setErrMsgIsNotInitialisedInternal();
-            return NRT_FAILURE_NOT_INITIALISED;
+            return Nrt_getNotInitialisedErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -173,8 +161,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -185,8 +172,7 @@ extern "C"
         }
         catch (const Exceptions::NotInitialisedException)
         {
-            Nrt_setErrMsgIsNotInitialisedInternal();
-            return NRT_FAILURE_NOT_INITIALISED;
+            return Nrt_getNotInitialisedErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -196,8 +182,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -208,8 +193,7 @@ extern "C"
         }
         catch (const Exceptions::NotInitialisedException)
         {
-            Nrt_setErrMsgIsNotInitialisedInternal();
-            return NRT_FAILURE_NOT_INITIALISED;
+            return Nrt_getNotInitialisedErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -219,8 +203,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -231,8 +214,7 @@ extern "C"
         }
         catch (const Exceptions::NotInitialisedException)
         {
-            Nrt_setErrMsgIsNotInitialisedInternal();
-            return NRT_FAILURE_NOT_INITIALISED;
+            return Nrt_getNotInitialisedErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -242,8 +224,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -256,8 +237,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -268,8 +248,7 @@ extern "C"
         }
         catch (const Exceptions::NotInitialisedException)
         {
-            Nrt_setErrMsgIsNotInitialisedInternal();
-            return NRT_FAILURE_NOT_INITIALISED;
+            return Nrt_getNotInitialisedErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -279,8 +258,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -292,8 +270,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -304,8 +281,7 @@ extern "C"
         }
         catch (const Exceptions::NotInitialisedException)
         {
-            Nrt_setErrMsgIsNotInitialisedInternal();
-            return NRT_FAILURE_NOT_INITIALISED;
+            return Nrt_getNotInitialisedErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -315,8 +291,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -328,8 +303,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -341,8 +315,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -354,8 +327,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -367,8 +339,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);
@@ -380,8 +351,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto serv = reinterpret_cast<Audio::AudioService*>(service);

--- a/src/NovelRT.Interop/DotNet/NrtRuntimeService.cpp
+++ b/src/NovelRT.Interop/DotNet/NrtRuntimeService.cpp
@@ -25,8 +25,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRT::DotNet::RuntimeService* cService = reinterpret_cast<NovelRT::DotNet::RuntimeService*>(service);
@@ -38,8 +37,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRT::DotNet::RuntimeService* cService = reinterpret_cast<NovelRT::DotNet::RuntimeService*>(service);
@@ -50,13 +48,11 @@ extern "C"
         }
         catch (const Exceptions::InitialisationFailureException)
         {
-            Nrt_setErrMsgIsInitialisationFailureInternal();
-            return NRT_FAILURE_INITIALISATION_FAILURE;
+            return Nrt_getInitialisationFailureErrorInternal();
         }
         catch (const Exceptions::FunctionNotFoundException)
         {
-            Nrt_setErrMsgIsFunctionNotFoundInternal();
-            return NRT_FAILURE_FUNCTION_NOT_FOUND;
+            return Nrt_getFunctionNotFoundErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -66,8 +62,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRT::DotNet::RuntimeService* cService = reinterpret_cast<NovelRT::DotNet::RuntimeService*>(service);
@@ -79,8 +74,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRT::DotNet::RuntimeService* cService = reinterpret_cast<NovelRT::DotNet::RuntimeService*>(service);
@@ -91,13 +85,11 @@ extern "C"
         }
         catch (const Exceptions::InitialisationFailureException)
         {
-            Nrt_setErrMsgIsInitialisationFailureInternal();
-            return NRT_FAILURE_INITIALISATION_FAILURE;
+            return Nrt_getInitialisationFailureErrorInternal();
         }
         catch (const Exceptions::FunctionNotFoundException)
         {
-            Nrt_setErrMsgIsFunctionNotFoundInternal();
-            return NRT_FAILURE_FUNCTION_NOT_FOUND;
+            return Nrt_getFunctionNotFoundErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -107,14 +99,12 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (str == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRT::DotNet::RuntimeService* cService = reinterpret_cast<NovelRT::DotNet::RuntimeService*>(service);
@@ -125,13 +115,11 @@ extern "C"
         }
         catch (const Exceptions::InitialisationFailureException)
         {
-            Nrt_setErrMsgIsInitialisationFailureInternal();
-            return NRT_FAILURE_INITIALISATION_FAILURE;
+            return Nrt_getInitialisationFailureErrorInternal();
         }
         catch (const Exceptions::FunctionNotFoundException)
         {
-            Nrt_setErrMsgIsFunctionNotFoundInternal();
-            return NRT_FAILURE_FUNCTION_NOT_FOUND;
+            return Nrt_getFunctionNotFoundErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -141,14 +129,12 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputInkService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRT::DotNet::RuntimeService* cService = reinterpret_cast<NovelRT::DotNet::RuntimeService*>(service);
@@ -160,13 +146,11 @@ extern "C"
         }
         catch (const Exceptions::InitialisationFailureException)
         {
-            Nrt_setErrMsgIsInitialisationFailureInternal();
-            return NRT_FAILURE_INITIALISATION_FAILURE;
+            return Nrt_getInitialisationFailureErrorInternal();
         }
         catch (const Exceptions::FunctionNotFoundException)
         {
-            Nrt_setErrMsgIsFunctionNotFoundInternal();
-            return NRT_FAILURE_FUNCTION_NOT_FOUND;
+            return Nrt_getFunctionNotFoundErrorInternal();
         }
 
         _inkServiceCollection.push_back(inkServicePtr);

--- a/src/NovelRT.Interop/Ecs/Audio/NrtAudioSystem.cpp
+++ b/src/NovelRT.Interop/Ecs/Audio/NrtAudioSystem.cpp
@@ -21,8 +21,7 @@ extern "C"
     {
         if (system == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto sys = reinterpret_cast<Ecs::Audio::AudioSystem*>(system);
@@ -34,8 +33,7 @@ extern "C"
     {
         if (system == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto sys = reinterpret_cast<Ecs::SystemScheduler*>(system);
@@ -51,8 +49,7 @@ extern "C"
 
         if (context == nullptr || catalogue == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto sys = reinterpret_cast<Ecs::Audio::AudioSystem*>(context);
@@ -69,8 +66,7 @@ extern "C"
     {
         if (system == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto sys = reinterpret_cast<Ecs::Audio::AudioSystem*>(system);
@@ -85,8 +81,7 @@ extern "C"
     {
         if (system == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto sys = reinterpret_cast<Ecs::SystemScheduler*>(system);
@@ -103,8 +98,7 @@ extern "C"
     {
         if (system == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto sys = reinterpret_cast<Ecs::SystemScheduler*>(system);

--- a/src/NovelRT.Interop/Ecs/NrtCatalogue.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtCatalogue.cpp
@@ -3,6 +3,7 @@
 
 #include <NovelRT.Interop/Ecs/NrtCatalogue.h>
 #include <NovelRT/Ecs/Ecs.h>
+#include <NovelRT.Interop/NrtErrorHandling.h>
 
 using namespace NovelRT::Ecs;
 
@@ -23,12 +24,12 @@ extern "C"
     {
         if (catalogue == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputResult == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto returnPtr = new UnsafeComponentView(0, nullptr);
@@ -41,7 +42,7 @@ extern "C"
         catch (const std::out_of_range&)
         {
             delete returnPtr;
-            return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+            return Nrt_getArgumentOutOfRangeErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -66,7 +67,7 @@ extern "C"
     {
         if (catalogue == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         reinterpret_cast<Catalogue*>(catalogue)->DeleteEntity(entity);
@@ -78,7 +79,7 @@ extern "C"
     {
         if (catalogue == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<Catalogue*>(catalogue);

--- a/src/NovelRT.Interop/Ecs/NrtComponentBufferMemoryContainer.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtComponentBufferMemoryContainer.cpp
@@ -3,6 +3,7 @@
 
 #include <NovelRT.Interop/Ecs/NrtComponentBufferMemoryContainer.h>
 #include <NovelRT/Ecs/Ecs.h>
+#include <NovelRT.Interop/NrtErrorHandling.h>
 
 #include <vector>
 
@@ -51,12 +52,12 @@ extern "C"
     {
         if (container == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (componentData == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         try
@@ -67,7 +68,7 @@ extern "C"
         }
         catch (const std::out_of_range&)
         {
-            return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+            return Nrt_getArgumentOutOfRangeErrorInternal();
         }
         catch (const DuplicateKeyException&)
         {
@@ -82,12 +83,12 @@ extern "C"
     {
         if (container == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputResult == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         try
@@ -150,7 +151,7 @@ extern "C"
     {
         if (container == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<ComponentBufferMemoryContainer*>(container);
@@ -169,7 +170,7 @@ extern "C"
     {
         if (view == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<ComponentBufferMemoryContainer::ImmutableDataView*>(view);

--- a/src/NovelRT.Interop/Ecs/NrtComponentCache.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtComponentCache.cpp
@@ -3,6 +3,7 @@
 
 #include <NovelRT.Interop/Ecs/NrtComponentCache.h>
 #include <NovelRT/Ecs/Ecs.h>
+#include <NovelRT.Interop/NrtErrorHandling.h>
 
 using namespace NovelRT::Ecs;
 
@@ -22,12 +23,12 @@ extern "C"
     {
         if (componentCache == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (deleteInstructionState == nullptr || outputResult == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         try
@@ -45,7 +46,7 @@ extern "C"
         }
         catch (const std::bad_alloc&)
         {
-            return NRT_FAILURE_OUT_OF_MEMORY;
+            return Nrt_getOutOfMemoryErrorInternal();
         }
     }
 
@@ -55,12 +56,12 @@ extern "C"
     {
         if (componentCache == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputResult == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         *outputResult = reinterpret_cast<NrtComponentBufferMemoryContainerHandle>(
@@ -80,7 +81,7 @@ extern "C"
     {
         if (componentCache == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<ComponentCache*>(componentCache);

--- a/src/NovelRT.Interop/Ecs/NrtEntityCache.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtEntityCache.cpp
@@ -3,6 +3,7 @@
 
 #include <NovelRT.Interop/Ecs/NrtEntityCache.h>
 #include <NovelRT/Ecs/Ecs.h>
+#include <NovelRT.Interop/NrtErrorHandling.h>
 
 using namespace NovelRT::Ecs;
 
@@ -33,7 +34,7 @@ extern "C"
     {
         if (entityCache == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<EntityCache*>(entityCache);

--- a/src/NovelRT.Interop/Ecs/NrtEntityIdVector.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtEntityIdVector.cpp
@@ -3,6 +3,7 @@
 
 #include <NovelRT.Interop/Ecs/NrtEntityIdVector.h>
 #include <NovelRT/Ecs/Ecs.h>
+#include <NovelRT.Interop/NrtErrorHandling.h>
 
 #include <algorithm>
 #include <vector>
@@ -20,7 +21,7 @@ extern "C"
     {
         if (vector == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         reinterpret_cast<std::vector<EntityId>*>(vector)->emplace_back(entity);
@@ -32,7 +33,7 @@ extern "C"
     {
         if (vector == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto vecPtr = reinterpret_cast<std::vector<EntityId>*>(vector);
@@ -52,7 +53,7 @@ extern "C"
     {
         if (vector == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<std::vector<EntityId>*>(vector);

--- a/src/NovelRT.Interop/Ecs/NrtSparseSetMemoryContainer.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtSparseSetMemoryContainer.cpp
@@ -3,6 +3,7 @@
 
 #include <NovelRT.Interop/Ecs/NrtSparseSetMemoryContainer.h>
 #include <NovelRT/Ecs/Ecs.h>
+#include <NovelRT.Interop/NrtErrorHandling.h>
 
 using namespace NovelRT::Ecs;
 using namespace NovelRT::Exceptions;
@@ -23,12 +24,12 @@ extern "C"
     {
         if (container == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (value == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         try
@@ -43,7 +44,7 @@ extern "C"
         }
         catch (const std::bad_alloc&)
         {
-            return NRT_FAILURE_OUT_OF_MEMORY;
+            return Nrt_getOutOfMemoryErrorInternal();
         }
         catch (const std::exception&)
         {
@@ -62,7 +63,7 @@ extern "C"
     {
         if (container == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         try
@@ -97,12 +98,12 @@ extern "C"
     {
         if (container == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputResult == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         try
@@ -113,7 +114,7 @@ extern "C"
         }
         catch (const std::out_of_range&)
         {
-            return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+            return Nrt_getArgumentOutOfRangeErrorInternal();
         }
     }
 
@@ -130,12 +131,12 @@ extern "C"
     {
         if (container == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputResult == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         try
@@ -148,7 +149,7 @@ extern "C"
         }
         catch (const std::out_of_range&)
         {
-            return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+            return Nrt_getArgumentOutOfRangeErrorInternal();
         }
     }
 
@@ -169,12 +170,12 @@ extern "C"
     {
         if (container == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputResult == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         try
@@ -187,7 +188,7 @@ extern "C"
         }
         catch (const std::out_of_range&)
         {
-            return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+            return Nrt_getArgumentOutOfRangeErrorInternal();
         }
     }
 
@@ -275,7 +276,7 @@ extern "C"
     {
         if (container == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<SparseSetMemoryContainer*>(container);
@@ -313,7 +314,7 @@ extern "C"
     {
         if (view == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<SparseSetMemoryContainer::ByteIteratorView*>(view);
@@ -346,7 +347,7 @@ extern "C"
     {
         if (view == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<SparseSetMemoryContainer::ConstByteIteratorView*>(view);
@@ -384,12 +385,12 @@ extern "C"
     {
         if (iterator == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputId == nullptr || outputView == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         try
@@ -404,7 +405,7 @@ extern "C"
         }
         catch (const std::out_of_range&)
         {
-            return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+            return Nrt_getArgumentOutOfRangeErrorInternal();
         }
         catch (const std::exception&) // TODO: I'm not sure if this will throw anything else. Docs weren't clear. :(
         {
@@ -416,7 +417,7 @@ extern "C"
     {
         if (iterator == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<SparseSetMemoryContainer::Iterator*>(iterator);
@@ -454,12 +455,12 @@ extern "C"
     {
         if (iterator == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputId == nullptr || outputView == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         try
@@ -474,7 +475,7 @@ extern "C"
         }
         catch (const std::out_of_range&)
         {
-            return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+            return Nrt_getArgumentOutOfRangeErrorInternal();
         }
         catch (const std::exception&) // I'm not sure if this will throw anything else. Docs weren't clear. :(
         {
@@ -486,7 +487,7 @@ NrtResult Nrt_SparseSetMemoryContainer_ConstIterator_Destroy(NrtSparseSetMemoryC
 {
     if (iterator == nullptr)
     {
-        return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        return Nrt_getNullInstanceErrorInternal();
     }
 
     delete reinterpret_cast<SparseSetMemoryContainer::ConstIterator*>(iterator);

--- a/src/NovelRT.Interop/Ecs/NrtSystemScheduler.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtSystemScheduler.cpp
@@ -3,6 +3,7 @@
 
 #include <NovelRT.Interop/Ecs/NrtSystemScheduler.h>
 #include <NovelRT/Ecs/Ecs.h>
+#include <NovelRT.Interop/NrtErrorHandling.h>
 
 using namespace NovelRT::Ecs;
 using namespace NovelRT::Exceptions;
@@ -67,7 +68,7 @@ extern "C"
     {
         if (systemScheduler == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         try
@@ -77,15 +78,15 @@ extern "C"
         }
         catch (const std::bad_alloc&)
         {
-            return NRT_FAILURE_OUT_OF_MEMORY;
+            return Nrt_getOutOfMemoryErrorInternal();
         }
         catch (const std::out_of_range&)
         {
-            return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+            return Nrt_getArgumentOutOfRangeErrorInternal();
         }
         catch (const CharacterNotFoundException&)
         {
-            return NRT_FAILURE_CHARACTER_NOT_FOUND;
+            return Nrt_getCharacterNotFoundErrorInternal();
         }
         catch (const CompilationErrorException&)
         {
@@ -101,15 +102,15 @@ extern "C"
         }
         catch (const FunctionNotFoundException&)
         {
-            return NRT_FAILURE_FUNCTION_NOT_FOUND;
+            return Nrt_getFunctionNotFoundErrorInternal();
         }
         catch (const InitialisationFailureException&)
         {
-            return NRT_FAILURE_INITIALISATION_FAILURE;
+            return Nrt_getInitialisationFailureErrorInternal();
         }
         catch (const InvalidOperationException&)
         {
-            return NRT_FAILURE_INVALID_OPERATION;
+            return Nrt_getInvalidOperationErrorInternal();
         }
         catch (const KeyNotFoundException&)
         {
@@ -117,19 +118,19 @@ extern "C"
         }
         catch (const NotInitialisedException&)
         {
-            return NRT_FAILURE_NOT_INITIALISED;
+            return Nrt_getNotInitialisedErrorInternal();
         }
         catch (const NotSupportedException&)
         {
-            return NRT_FAILURE_NOT_SUPPORTED;
+            return Nrt_getNotSupportedErrorInternal();
         }
         catch (const NullPointerException&)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
         catch (const OutOfMemoryException&)
         {
-            return NRT_FAILURE_OUT_OF_MEMORY;
+            return Nrt_getOutOfMemoryErrorInternal();
         }
         catch (const RuntimeNotFoundException&)
         {
@@ -145,7 +146,7 @@ extern "C"
     {
         if (systemScheduler == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto schedulerPtr = reinterpret_cast<SystemScheduler*>(systemScheduler);
@@ -158,7 +159,7 @@ extern "C"
     {
         if (systemScheduler == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<SystemScheduler*>(systemScheduler);

--- a/src/NovelRT.Interop/Ecs/NrtUnsafeComponentView.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtUnsafeComponentView.cpp
@@ -3,6 +3,7 @@
 
 #include <NovelRT.Interop/Ecs/NrtUnsafeComponentView.h>
 #include <NovelRT/Ecs/Ecs.h>
+#include <NovelRT.Interop/NrtErrorHandling.h>
 #include <vector>
 
 using namespace NovelRT::Ecs;
@@ -26,12 +27,12 @@ extern "C"
     {
         if (componentView == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (instructionData == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         try
@@ -46,11 +47,11 @@ extern "C"
         }
         catch (const std::bad_alloc&)
         {
-            return NRT_FAILURE_OUT_OF_MEMORY;
+            return Nrt_getOutOfMemoryErrorInternal();
         }
         catch (const std::out_of_range&)
         {
-            return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+            return Nrt_getArgumentOutOfRangeErrorInternal();
         }
     }
 
@@ -58,7 +59,7 @@ extern "C"
     {
         if (componentView == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         try
@@ -72,11 +73,11 @@ extern "C"
         }
         catch (const std::bad_alloc&)
         {
-            return NRT_FAILURE_OUT_OF_MEMORY;
+            return Nrt_getOutOfMemoryErrorInternal();
         }
         catch (const std::out_of_range&)
         {
-            return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+            return Nrt_getArgumentOutOfRangeErrorInternal();
         }
     }
 
@@ -87,12 +88,12 @@ extern "C"
     {
         if (componentView == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputResult == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         try
@@ -149,7 +150,7 @@ extern "C"
     {
         if (componentView == nullptr)
         {
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<UnsafeComponentView*>(componentView);

--- a/src/NovelRT.Interop/Graphics/NrtBasicFillRect.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtBasicFillRect.cpp
@@ -25,8 +25,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         BasicFillRect* cppRect = reinterpret_cast<BasicFillRect*>(rect);
@@ -45,8 +44,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         BasicFillRect* cppRect = reinterpret_cast<BasicFillRect*>(rect);
@@ -69,8 +67,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         BasicFillRect* cppRect = reinterpret_cast<BasicFillRect*>(rect);
@@ -91,8 +88,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         BasicFillRect* cppRect = reinterpret_cast<BasicFillRect*>(rect);
@@ -105,8 +101,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         BasicFillRect* cppRect = reinterpret_cast<BasicFillRect*>(rect);
@@ -121,8 +116,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         BasicFillRect* cppRect = reinterpret_cast<BasicFillRect*>(rect);
@@ -136,14 +130,12 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputRenderObject == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         *outputRenderObject = reinterpret_cast<NrtRenderObjectHandle>(rect);
@@ -155,8 +147,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<BasicFillRect*>(rect);

--- a/src/NovelRT.Interop/Graphics/NrtCamera.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtCamera.cpp
@@ -34,8 +34,7 @@ extern "C"
     {
         if (camera == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Camera* cameraPtr = reinterpret_cast<Camera*>(camera);
@@ -55,8 +54,7 @@ extern "C"
     {
         if (camera == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Camera* cameraPtr = reinterpret_cast<Camera*>(camera);
@@ -85,8 +83,7 @@ extern "C"
     {
         if (camera == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Camera* cameraPtr = reinterpret_cast<Camera*>(camera);
@@ -116,8 +113,7 @@ extern "C"
     {
         if (camera == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Camera* cameraPtr = reinterpret_cast<Camera*>(camera);
@@ -133,8 +129,7 @@ extern "C"
             return NRT_SUCCESS;
         }
 
-        Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
-        return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
+        return Nrt_getAlreadyDeletedOrRemovedErrorInternal();
     }
 
 #ifdef __cplusplus

--- a/src/NovelRT.Interop/Graphics/NrtFontSet.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtFontSet.cpp
@@ -19,8 +19,7 @@ extern "C"
     {
         if (fontSet == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         FontSet* fontSetPtr = reinterpret_cast<FontSet*>(fontSet);
@@ -31,8 +30,7 @@ extern "C"
         }
         catch (const Exceptions::InvalidOperationException)
         {
-            Nrt_setErrMsgIsInvalidOperationInternal();
-            return NRT_FAILURE_INVALID_OPERATION;
+            return Nrt_getInvalidOperationErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -42,8 +40,7 @@ extern "C"
     {
         if (fontSet == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         FontSet* fontSetPtr = reinterpret_cast<FontSet*>(fontSet);
@@ -56,13 +53,12 @@ extern "C"
     {
         if (fontSet == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputFontSize == nullptr)
         {
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         FontSet* fontSetPtr = reinterpret_cast<FontSet*>(fontSet);

--- a/src/NovelRT.Interop/Graphics/NrtImageRect.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtImageRect.cpp
@@ -27,8 +27,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         ImageRect* imageRectPtr = reinterpret_cast<ImageRect*>(rect);
@@ -47,8 +46,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         ImageRect* imageRectPtr = reinterpret_cast<ImageRect*>(rect);
@@ -72,8 +70,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         ImageRect* imageRectPtr = reinterpret_cast<ImageRect*>(rect);
@@ -94,8 +91,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         ImageRect* imageRectPtr = reinterpret_cast<ImageRect*>(rect);
@@ -109,8 +105,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         ImageRect* imageRectPtr = reinterpret_cast<ImageRect*>(rect);
@@ -125,8 +120,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         ImageRect* imageRectPtr = reinterpret_cast<ImageRect*>(rect);
@@ -139,8 +133,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         ImageRect* imageRectPtr = reinterpret_cast<ImageRect*>(rect);
@@ -155,8 +148,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         ImageRect* imageRectPtr = reinterpret_cast<ImageRect*>(rect);
@@ -169,8 +161,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputRenderObject == nullptr)
@@ -187,8 +178,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<ImageRect*>(rect);

--- a/src/NovelRT.Interop/Graphics/NrtRGBAColour.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtRGBAColour.cpp
@@ -31,8 +31,7 @@ extern "C"
     {
         if (colourConfig == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         RGBAColour* colourConfigPtr = reinterpret_cast<RGBAColour*>(colourConfig);
@@ -51,8 +50,7 @@ extern "C"
     {
         if (colourConfig == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         RGBAColour* colourConfigPtr = reinterpret_cast<RGBAColour*>(colourConfig);
@@ -71,8 +69,7 @@ extern "C"
     {
         if (colourConfig == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         RGBAColour* colourConfigPtr = reinterpret_cast<RGBAColour*>(colourConfig);
@@ -91,8 +88,7 @@ extern "C"
     {
         if (colourConfig == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         RGBAColour* colourConfigPtr = reinterpret_cast<RGBAColour*>(colourConfig);
@@ -129,8 +125,7 @@ extern "C"
     {
         if (colourConfig == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         RGBAColour* colourConfigPtr = reinterpret_cast<RGBAColour*>(colourConfig);

--- a/src/NovelRT.Interop/Graphics/NrtRenderingService.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtRenderingService.cpp
@@ -28,8 +28,7 @@ extern "C"
     {
         if (windowingService == nullptr || outputRenderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         WindowingService* windowingServicePtr = reinterpret_cast<WindowingService*>(windowingService);
@@ -45,8 +44,7 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -57,8 +55,7 @@ extern "C"
         }
         catch (const Exceptions::InitialisationFailureException)
         {
-            Nrt_setErrMsgIsInitialisationFailureInternal();
-            return NRT_FAILURE_INITIALISATION_FAILURE;
+            return Nrt_getInitialisationFailureErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -68,8 +65,7 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -87,14 +83,12 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputImageRect == nullptr || filePath == nullptr || colourTint == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -115,14 +109,12 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputImageRect == nullptr || colourTint == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -142,14 +134,12 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputBasicFillRect == nullptr || colourConfig == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -171,14 +161,12 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputTextRect == nullptr || colourConfig == nullptr || fontFilePath == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -196,14 +184,12 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputCamera == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -216,8 +202,7 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -230,8 +215,7 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -245,14 +229,12 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (colour == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -266,14 +248,12 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputTexture == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -289,14 +269,12 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputTexture == nullptr || fileTarget == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -314,14 +292,12 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputFontSet == nullptr || fileTarget == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -336,8 +312,7 @@ extern "C"
     {
         if (renderingService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         RenderingService* renderingServicePtr = reinterpret_cast<RenderingService*>(renderingService);
@@ -354,8 +329,7 @@ extern "C"
             return NRT_SUCCESS;
         }
 
-        Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
-        return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
+        return Nrt_getAlreadyDeletedOrRemovedErrorInternal();
     }
 
 #ifdef __cplusplus

--- a/src/NovelRT.Interop/Graphics/NrtTextRect.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtTextRect.cpp
@@ -25,8 +25,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         TextRect* textRectPtr = reinterpret_cast<TextRect*>(rect);
@@ -45,8 +44,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         TextRect* textRectPtr = reinterpret_cast<TextRect*>(rect);
@@ -70,8 +68,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         TextRect* textRectPtr = reinterpret_cast<TextRect*>(rect);
@@ -92,8 +89,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         TextRect* textRectPtr = reinterpret_cast<TextRect*>(rect);
@@ -107,14 +103,12 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputColourConfig == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         TextRect* textRectPtr = reinterpret_cast<TextRect*>(rect);
@@ -129,8 +123,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         TextRect* textRectPtr = reinterpret_cast<TextRect*>(rect);
@@ -150,8 +143,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         TextRect* textRectPtr = reinterpret_cast<TextRect*>(rect);
@@ -161,8 +153,7 @@ extern "C"
         }
         catch (const Exceptions::CharacterNotFoundException)
         {
-            Nrt_setErrMsgIsCharacterNotFoundInternal();
-            return NRT_FAILURE_CHARACTER_NOT_FOUND;
+            return Nrt_getCharacterNotFoundErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -172,14 +163,12 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputFontSet == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         TextRect* textRectPtr = reinterpret_cast<TextRect*>(rect);
@@ -193,8 +182,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         TextRect* textRectPtr = reinterpret_cast<TextRect*>(rect);
@@ -207,8 +195,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         *outputRenderObject = reinterpret_cast<NrtRenderObjectHandle>(rect);
@@ -220,8 +207,7 @@ extern "C"
     {
         if (rect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<TextRect*>(rect);

--- a/src/NovelRT.Interop/Graphics/NrtTexture.cpp
+++ b/src/NovelRT.Interop/Graphics/NrtTexture.cpp
@@ -18,8 +18,7 @@ extern "C"
     {
         if (targetTexture == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Texture* texturePtr = reinterpret_cast<Texture*>(targetTexture);
@@ -29,9 +28,8 @@ extern "C"
             texturePtr->loadPngAsTexture(std::string(file));
         }
         catch (const Exceptions::InvalidOperationException)
-        { // todo: handle error message
-            Nrt_setErrMsgIsInvalidOperationInternal();
-            return NRT_FAILURE_INVALID_OPERATION;
+        {
+            return Nrt_getInvalidOperationErrorInternal();
         }
 
         return NRT_SUCCESS;

--- a/src/NovelRT.Interop/Ink/NrtInkService.cpp
+++ b/src/NovelRT.Interop/Ink/NrtInkService.cpp
@@ -20,8 +20,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Ink::InkService* inkService = reinterpret_cast<Ink::InkService*>(service);
@@ -33,8 +32,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         Ink::InkService* inkService = reinterpret_cast<Ink::InkService*>(service);
@@ -48,14 +46,12 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputStory == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Ink::InkService* inkService = reinterpret_cast<Ink::InkService*>(service);
@@ -70,14 +66,12 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputRuntimeService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Ink::InkService* inkService = reinterpret_cast<Ink::InkService*>(service);

--- a/src/NovelRT.Interop/Input/NrtBasicInteractionRect.cpp
+++ b/src/NovelRT.Interop/Input/NrtBasicInteractionRect.cpp
@@ -15,8 +15,7 @@ extern "C"
     {
         if (object == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto obj = reinterpret_cast<Input::BasicInteractionRect*>(object);
@@ -34,8 +33,7 @@ extern "C"
     {
         if (object == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto obj = reinterpret_cast<Input::BasicInteractionRect*>(object);
@@ -53,8 +51,7 @@ extern "C"
     {
         if (object == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto obj = reinterpret_cast<Input::BasicInteractionRect*>(object);
@@ -72,8 +69,7 @@ extern "C"
     {
         if (object == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto obj = reinterpret_cast<Input::BasicInteractionRect*>(object);
@@ -91,8 +87,7 @@ extern "C"
     {
         if (object == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto obj = reinterpret_cast<Input::BasicInteractionRect*>(object);
@@ -106,14 +101,12 @@ extern "C"
     {
         if (object == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (action == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto obj = reinterpret_cast<Input::BasicInteractionRect*>(object);

--- a/src/NovelRT.Interop/Input/NrtInteractionService.cpp
+++ b/src/NovelRT.Interop/Input/NrtInteractionService.cpp
@@ -32,8 +32,7 @@ extern "C"
 
         if (servicePtr == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         servicePtr->consumePlayerInput();
@@ -46,8 +45,7 @@ extern "C"
 
         if (servicePtr == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         servicePtr->executeClickedInteractable();
@@ -60,8 +58,7 @@ extern "C"
 
         if (servicePtr == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto vector = reinterpret_cast<Maths::GeoVector2F&>(value);
@@ -77,14 +74,12 @@ extern "C"
 
         if (servicePtr == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (output == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto changelog = servicePtr->getKeyState(reinterpret_cast<Input::KeyCode&>(value));
@@ -99,14 +94,12 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputRect == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto servicePtr = reinterpret_cast<Input::InteractionService*>(service);

--- a/src/NovelRT.Interop/Maths/NrtGeoBounds.cpp
+++ b/src/NovelRT.Interop/Maths/NrtGeoBounds.cpp
@@ -67,8 +67,7 @@ extern "C"
     {
         if (outputResult == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Maths::GeoBounds cFirst = *reinterpret_cast<const Maths::GeoBounds*>(&first);
@@ -89,8 +88,7 @@ extern "C"
         }
         catch (const Exceptions::NotSupportedException)
         {
-            Nrt_setErrMsgIsNotSupportedInternal();
-            return NRT_FAILURE_NOT_SUPPORTED;
+            return Nrt_getNotSupportedErrorInternal();
         }
     }
 

--- a/src/NovelRT.Interop/Maths/NrtQuadTree.cpp
+++ b/src/NovelRT.Interop/Maths/NrtQuadTree.cpp
@@ -27,14 +27,12 @@ extern "C"
     {
         if (tree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputParentTree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto treePointer = reinterpret_cast<Maths::QuadTree*>(tree);
@@ -55,14 +53,12 @@ extern "C"
     {
         if (tree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputPoint == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto treePointer = reinterpret_cast<Maths::QuadTree*>(tree);
@@ -81,14 +77,12 @@ extern "C"
     {
         if (tree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputCornerTree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto treePointer = reinterpret_cast<Maths::QuadTree*>(tree);
@@ -101,14 +95,12 @@ extern "C"
     {
         if (tree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputCornerTree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto treePointer = reinterpret_cast<Maths::QuadTree*>(tree);
@@ -121,14 +113,12 @@ extern "C"
     {
         if (tree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputCornerTree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto treePointer = reinterpret_cast<Maths::QuadTree*>(tree);
@@ -141,14 +131,12 @@ extern "C"
     {
         if (tree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputCornerTree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto treePointer = reinterpret_cast<Maths::QuadTree*>(tree);
@@ -177,14 +165,12 @@ extern "C"
     {
         if (tree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputResultVector == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         std::vector<std::shared_ptr<Maths::QuadTreePoint>>* points =
@@ -197,8 +183,7 @@ extern "C"
         }
         catch (const Exceptions::NotSupportedException)
         {
-            Nrt_setErrMsgIsNotSupportedInternal();
-            return NRT_FAILURE_NOT_SUPPORTED;
+            return Nrt_getNotSupportedErrorInternal();
         }
 
         *outputResultVector = reinterpret_cast<NrtPointVectorHandle>(points);
@@ -210,8 +195,7 @@ extern "C"
     {
         if (vector == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<std::vector<std::shared_ptr<Maths::QuadTreePoint>>*>(vector);
@@ -230,14 +214,12 @@ extern "C"
     {
         if (vector == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputPoint == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         try
@@ -246,8 +228,8 @@ extern "C"
                 reinterpret_cast<std::vector<std::shared_ptr<Maths::QuadTreePoint>>*>(vector)->at(index).get());
         }
         catch (const std::out_of_range)
-        { // todo: handle error message
-            return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+        {
+            return Nrt_getArgumentOutOfRangeErrorInternal();
         }
 
         return NRT_SUCCESS;
@@ -257,16 +239,14 @@ extern "C"
     {
         if (tree == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto ptr = reinterpret_cast<Maths::QuadTree*>(tree)->shared_from_this();
 
         if (std::find(_treeCollection.begin(), _treeCollection.end(), ptr) == _treeCollection.end())
         {
-            Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
-            return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
+            return Nrt_getAlreadyDeletedOrRemovedErrorInternal();
         }
 
         _treeCollection.remove(ptr);

--- a/src/NovelRT.Interop/Maths/NrtQuadTreePoint.cpp
+++ b/src/NovelRT.Interop/Maths/NrtQuadTreePoint.cpp
@@ -40,16 +40,14 @@ extern "C"
     {
         if (point == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto ptr = reinterpret_cast<Maths::QuadTreePoint*>(point)->shared_from_this();
 
         if (std::find(_pointCollection.begin(), _pointCollection.end(), ptr) == _pointCollection.end())
         { // TODO: This may prove to be a bottleneck later
-            Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
-            return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
+            return Nrt_getAlreadyDeletedOrRemovedErrorInternal();
         }
 
         _pointCollection.remove(reinterpret_cast<Maths::QuadTreePoint*>(point)->shared_from_this());

--- a/src/NovelRT.Interop/NrtDebugService.cpp
+++ b/src/NovelRT.Interop/NrtDebugService.cpp
@@ -22,8 +22,7 @@ extern "C"
     {
         if (sceneConstructionEvent == nullptr || renderingService == nullptr || outputService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Utilities::Event<> constructionEvent = *reinterpret_cast<Utilities::Event<>*>(sceneConstructionEvent);
@@ -45,8 +44,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         DebugService* cppService = reinterpret_cast<DebugService*>(service);
@@ -64,8 +62,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         DebugService* cppService = reinterpret_cast<DebugService*>(service);

--- a/src/NovelRT.Interop/NrtInteropErrorHandling.cpp
+++ b/src/NovelRT.Interop/NrtInteropErrorHandling.cpp
@@ -130,6 +130,84 @@ extern "C"
         customMessageSet = true;
     }
 
+    NrtResult Nrt_getNullArgumentErrorInternal()
+    {
+        Nrt_setErrMsgIsNullptrInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+
+    NrtResult Nrt_getNullInstanceErrorInternal()
+    {
+        Nrt_setErrMsgIsNullptrInternal();
+        return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+    }
+
+    NrtResult Nrt_getNaNErrorInternal()
+    {
+        Nrt_setErrMsgIsNaNInternal();
+        return NRT_FAILURE_NOT_A_NUMBER;
+    }
+
+    NrtResult Nrt_getDivideByZeroErrorInternal()
+    {
+        Nrt_setErrMsgIsDivideByZeroInternal();
+        return NRT_FAILURE_DIVIDE_BY_ZERO;
+    }
+
+    NrtResult Nrt_getAlreadyDeletedOrRemovedErrorInternal()
+    {
+        Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
+        return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
+    }
+
+    NrtResult Nrt_getNotSupportedErrorInternal()
+    {
+        Nrt_setErrMsgIsNotSupportedInternal();
+        return NRT_FAILURE_NOT_SUPPORTED;
+    }
+
+    NrtResult Nrt_getInitialisationFailureErrorInternal()
+    {
+        Nrt_setErrMsgIsInitialisationFailureInternal();
+        return NRT_FAILURE_INITIALISATION_FAILURE;
+    }
+
+    NrtResult Nrt_getFunctionNotFoundErrorInternal()
+    {
+        Nrt_setErrMsgIsFunctionNotFoundInternal();
+        return NRT_FAILURE_FUNCTION_NOT_FOUND;
+    }
+
+    NrtResult Nrt_getNotInitialisedErrorInternal()
+    {
+        Nrt_setErrMsgIsNotInitialisedInternal();
+        return NRT_FAILURE_NOT_INITIALISED;
+    }
+
+    NrtResult Nrt_getArgumentOutOfRangeErrorInternal()
+    {
+        Nrt_setErrMsgIsArgumentOutOfRangeInternal();
+        return NRT_FAILURE_ARGUMENT_OUT_OF_RANGE;
+    }
+
+    NrtResult Nrt_getInvalidOperationErrorInternal()
+    {
+        Nrt_setErrMsgIsInvalidOperationInternal();
+        return NRT_FAILURE_INVALID_OPERATION;
+    }
+
+    NrtResult Nrt_getCharacterNotFoundErrorInternal()
+    {
+        Nrt_setErrMsgIsCharacterNotFoundInternal();
+        return NRT_FAILURE_CHARACTER_NOT_FOUND;
+    }
+
+    NrtResult Nrt_getOutOfMemoryErrorInternal()
+    {
+        Nrt_setErrMsgIsOutOfMemoryInternal();
+        return /*regexo no*/ NRT_FAILURE_OUT_OF_MEMORY;
+    }
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/NovelRT.Interop/NrtLoggingService.cpp
+++ b/src/NovelRT.Interop/NrtLoggingService.cpp
@@ -32,8 +32,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRT::LoggingService* cService = reinterpret_cast<NovelRT::LoggingService*>(service);
@@ -46,8 +45,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRT::LoggingService* cService = reinterpret_cast<NovelRT::LoggingService*>(service);
@@ -60,14 +58,12 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (message == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRT::LoggingService* cService = reinterpret_cast<NovelRT::LoggingService*>(service);
@@ -80,14 +76,12 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (message == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRT::LoggingService* cService = reinterpret_cast<NovelRT::LoggingService*>(service);
@@ -100,14 +94,12 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (message == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRT::LoggingService* cService = reinterpret_cast<NovelRT::LoggingService*>(service);
@@ -120,14 +112,12 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (message == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRT::LoggingService* cService = reinterpret_cast<NovelRT::LoggingService*>(service);
@@ -140,8 +130,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRT::LoggingService* cService = reinterpret_cast<NovelRT::LoggingService*>(service);
@@ -156,14 +145,12 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (exceptionMessage == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRT::LoggingService* cService = reinterpret_cast<NovelRT::LoggingService*>(service);
@@ -177,14 +164,12 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (exceptionMessage == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRT::LoggingService* cService = reinterpret_cast<NovelRT::LoggingService*>(service);

--- a/src/NovelRT.Interop/NrtNovelRunner.cpp
+++ b/src/NovelRT.Interop/NrtNovelRunner.cpp
@@ -42,8 +42,7 @@ extern "C"
     {
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
@@ -55,8 +54,7 @@ extern "C"
     {
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
@@ -70,14 +68,12 @@ extern "C"
     {
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
@@ -86,8 +82,7 @@ extern "C"
         auto ptr = _interactionCollection.back().get();
         if (ptr == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
         *outputService = reinterpret_cast<NrtInteractionServiceHandle>(ptr);
 
@@ -98,14 +93,12 @@ extern "C"
     {
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
@@ -114,8 +107,7 @@ extern "C"
         auto ptr = _windowingCollection.back().get();
         if (ptr == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
         *outputService = reinterpret_cast<NrtWindowingServiceHandle>(ptr);
 
@@ -127,14 +119,12 @@ extern "C"
     {
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
@@ -143,8 +133,7 @@ extern "C"
         auto ptr = _runtimeCollection.back().get();
         if (ptr == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
         *outputService = reinterpret_cast<NrtRuntimeServiceHandle>(ptr);
 
@@ -156,14 +145,12 @@ extern "C"
     {
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
@@ -172,8 +159,7 @@ extern "C"
         auto ptr = _rendererCollection.back().get();
         if (ptr == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
         *outputService = reinterpret_cast<NrtRenderingServiceHandle>(ptr);
 
@@ -184,14 +170,12 @@ extern "C"
     {
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputService == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
@@ -200,8 +184,7 @@ extern "C"
         auto ptr = _debugServiceCollection.back().get();
         if (ptr == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
         *outputService = reinterpret_cast<NrtDebugServiceHandle>(ptr);
 
@@ -217,14 +200,12 @@ extern "C"
 
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (func == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
@@ -244,8 +225,7 @@ extern "C"
     {
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
@@ -264,14 +244,12 @@ extern "C"
 
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (func == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
@@ -290,8 +268,7 @@ extern "C"
     {
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
@@ -306,14 +283,12 @@ extern "C"
     {
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputEvent == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);
@@ -326,14 +301,12 @@ extern "C"
     {
         if (runner == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputEvent == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRunner* cRunner = reinterpret_cast<NovelRunner*>(runner);

--- a/src/NovelRT.Interop/SceneGraph/NrtQuadTreeNode.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtQuadTreeNode.cpp
@@ -15,8 +15,7 @@ extern "C"
     {
         if (points == nullptr || outputNode == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         std::array<std::shared_ptr<SceneGraph::QuadTreeScenePoint>, 4> cppArray =
@@ -30,14 +29,12 @@ extern "C"
     {
         if (node == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputPoint == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         SceneGraph::QuadTreeNode* cppNode = reinterpret_cast<SceneGraph::QuadTreeNode*>(node);
@@ -51,14 +48,12 @@ extern "C"
     {
         if (node == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputPoint == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         SceneGraph::QuadTreeNode* cppNode = reinterpret_cast<SceneGraph::QuadTreeNode*>(node);
@@ -72,14 +67,12 @@ extern "C"
     {
         if (node == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputPoint == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         SceneGraph::QuadTreeNode* cppNode = reinterpret_cast<SceneGraph::QuadTreeNode*>(node);
@@ -93,14 +86,12 @@ extern "C"
     {
         if (node == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputPoint == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         SceneGraph::QuadTreeNode* cppNode = reinterpret_cast<SceneGraph::QuadTreeNode*>(node);
@@ -119,8 +110,7 @@ extern "C"
         if (pointOne == nullptr || pointTwo == nullptr || pointThree == nullptr || pointFour == nullptr ||
             outputArray == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         std::shared_ptr<SceneGraph::QuadTreeScenePoint> cppPointOne = std::shared_ptr<SceneGraph::QuadTreeScenePoint>(

--- a/src/NovelRT.Interop/SceneGraph/NrtQuadTreeScenePoint.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtQuadTreeScenePoint.cpp
@@ -19,8 +19,7 @@ extern "C"
     {
         if (node == nullptr || outputPoint == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         Maths::GeoVector2F cPosition = *reinterpret_cast<const Maths::GeoVector2F*>(&position);
@@ -38,8 +37,7 @@ extern "C"
     {
         if (node == nullptr || outputPoint == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         std::shared_ptr<SceneGraph::SceneNode> cNode =
@@ -53,14 +51,12 @@ extern "C"
     {
         if (point == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputNode == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         SceneGraph::QuadTreeScenePoint* cppPoint = reinterpret_cast<SceneGraph::QuadTreeScenePoint*>(point);

--- a/src/NovelRT.Interop/SceneGraph/NrtRenderObjectNode.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtRenderObjectNode.cpp
@@ -20,8 +20,7 @@ extern "C"
     {
         if (object == nullptr || outputNode == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto ptr = reinterpret_cast<Graphics::RenderObject*>(object);
@@ -35,14 +34,12 @@ extern "C"
     {
         if (node == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputObject == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         SceneGraph::RenderObjectNode* cppNode = reinterpret_cast<SceneGraph::RenderObjectNode*>(node);
@@ -55,8 +52,7 @@ extern "C"
     {
         if (node == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto cppNode = reinterpret_cast<SceneGraph::RenderObjectNode*>(node)->getRenderObject();
@@ -69,8 +65,7 @@ extern "C"
             }
         }
 
-        Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
-        return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
+        return Nrt_getAlreadyDeletedOrRemovedErrorInternal();
     }
 
 #ifdef __cplusplus

--- a/src/NovelRT.Interop/SceneGraph/NrtScene.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtScene.cpp
@@ -21,14 +21,12 @@ extern "C"
     {
         if (scene == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputSet == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto cppScene = reinterpret_cast<SceneGraph::Scene*>(&scene);
@@ -58,8 +56,7 @@ extern "C"
     {
         if (scene == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto cppScene = reinterpret_cast<SceneGraph::Scene*>(&scene);

--- a/src/NovelRT.Interop/SceneGraph/NrtSceneNode.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtSceneNode.cpp
@@ -41,14 +41,12 @@ extern "C"
     {
         if (node == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputSet == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         std::set<std::shared_ptr<SceneGraph::SceneNode>>* nodeSet =
@@ -62,14 +60,12 @@ extern "C"
     {
         if (node == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputSet == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         std::set<std::shared_ptr<SceneGraph::SceneNode>>* nodeSet =
@@ -106,14 +102,12 @@ extern "C"
     {
         if (node == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (action == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
@@ -129,8 +123,7 @@ extern "C"
     {
         if (node == nullptr || action == nullptr || outputIterator == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
@@ -149,14 +142,12 @@ extern "C"
     {
         if (node == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (action == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
@@ -173,14 +164,12 @@ extern "C"
     {
         if (node == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (action == nullptr || outputIterator == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
@@ -204,16 +193,14 @@ extern "C"
     {
         if (node == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
         if (std::find(_sceneNodeCollection.begin(), _sceneNodeCollection.end(), nodePointer) ==
             _sceneNodeCollection.end())
         {
-            Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
-            return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
+            return Nrt_getAlreadyDeletedOrRemovedErrorInternal();
         }
 
         _sceneNodeCollection.remove(nodePointer);
@@ -224,8 +211,7 @@ extern "C"
     {
         if (nodeSet == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         delete reinterpret_cast<std::set<std::shared_ptr<SceneGraph::SceneNode>>*>(nodeSet);
@@ -243,14 +229,12 @@ extern "C"
     {
         if (nodeSet == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         if (outputSceneNode == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto cNodeSet = reinterpret_cast<std::set<std::shared_ptr<SceneGraph::SceneNode>>*>(nodeSet);

--- a/src/NovelRT.Interop/SceneGraph/NrtSceneNodeBreadthFirstIterator.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtSceneNodeBreadthFirstIterator.cpp
@@ -28,8 +28,7 @@ extern "C"
     {
         if (node == nullptr || action == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
@@ -45,8 +44,7 @@ extern "C"
     {
         if (iterator == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto cppIterator =
@@ -59,8 +57,7 @@ extern "C"
     {
         if (iterator == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto cppIterator =

--- a/src/NovelRT.Interop/SceneGraph/NrtSceneNodeDepthFirstIterator.cpp
+++ b/src/NovelRT.Interop/SceneGraph/NrtSceneNodeDepthFirstIterator.cpp
@@ -28,8 +28,7 @@ extern "C"
     {
         if (node == nullptr || action == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         auto nodePointer = reinterpret_cast<SceneGraph::SceneNode*>(node)->shared_from_this();
@@ -46,8 +45,7 @@ extern "C"
     {
         if (iterator == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto cppIterator =
@@ -60,8 +58,7 @@ extern "C"
     {
         if (iterator == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto cppIterator =

--- a/src/NovelRT.Interop/Timing/NrtStepTimer.cpp
+++ b/src/NovelRT.Interop/Timing/NrtStepTimer.cpp
@@ -14,8 +14,7 @@ extern "C"
     {
         if (output == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         NovelRT::Timing::StepTimer timer = NovelRT::Timing::StepTimer(targetFrameRate, maxSecondDelta);
@@ -59,8 +58,7 @@ extern "C"
     {
         if (timer == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRT::Timing::StepTimer time = reinterpret_cast<NovelRT::Timing::StepTimer&>(timer);
@@ -79,8 +77,7 @@ extern "C"
     {
         if (timer == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRT::Timing::StepTimer time = reinterpret_cast<NovelRT::Timing::StepTimer&>(timer);
@@ -110,8 +107,7 @@ extern "C"
     {
         if (timer == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRT::Timing::StepTimer time = reinterpret_cast<NovelRT::Timing::StepTimer&>(timer);
@@ -123,8 +119,7 @@ extern "C"
     {
         if (timer == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRT::Timing::StepTimer time = reinterpret_cast<NovelRT::Timing::StepTimer&>(timer);
@@ -136,8 +131,7 @@ extern "C"
     {
         if (event == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         NovelRT::Timing::StepTimer time = reinterpret_cast<NovelRT::Timing::StepTimer&>(timer);

--- a/src/NovelRT.Interop/Windowing/NrtWindowingService.cpp
+++ b/src/NovelRT.Interop/Windowing/NrtWindowingService.cpp
@@ -30,16 +30,14 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto servicePtr = reinterpret_cast<Windowing::WindowingService*>(service);
 
         if (windowTitle == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         servicePtr->initialiseWindow(displayNumber, windowTitle, static_cast<Windowing::WindowMode>(windowMode),
@@ -51,8 +49,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto servicePtr = reinterpret_cast<Windowing::WindowingService*>(service);
@@ -72,16 +69,14 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto servicePtr = reinterpret_cast<Windowing::WindowingService*>(service);
 
         if (value == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+            return Nrt_getNullArgumentErrorInternal();
         }
 
         servicePtr->setWindowTitle(value);
@@ -92,8 +87,7 @@ extern "C"
     {
         if (service == nullptr)
         {
-            Nrt_setErrMsgIsNullptrInternal();
-            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+            return Nrt_getNullInstanceErrorInternal();
         }
 
         auto servicePtr = reinterpret_cast<Windowing::WindowingService*>(service);


### PR DESCRIPTION
The current error handling system is a bit error prone, and error messages (`Nrt_setXErrMsg`) were sometimes forgotten.

As a quick fix before an entire error handling rework, there's now `Nrt_getXErrorInternal` methods that give an `NrtResult` while also setting the error message for it.

This makes maintaining errors easier and also shorter to write.