### PR TITLE
PluginManagement C support

### DIFF
--- a/include/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingComponent.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingComponent.h
@@ -1,0 +1,22 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_GRAPHICS_DEFAULTRENDERINGCOMPONENT_H
+#define NOVELRT_INTEROP_ECS_GRAPHICS_DEFAULTRENDERINGCOMPONENT_H
+
+#include "../../NrtTypedefs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    void Nrt_RenderComponent_PlusEquals_Operator(NrtRenderComponent* lhs, NrtRenderComponent rhs);
+    NrtBool Nrt_RenderComponent_Equals_Operator(NrtRenderComponent lhs, NrtRenderComponent rhs);
+    NrtBool Nrt_RenderComponent_NotEquals_Operator(NrtRenderComponent lhs, NrtRenderComponent rhs);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOVELRT_INTEROP_ECS_GRAPHICS_DEFAULTRENDERINGCOMPONENT_H

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.h
@@ -1,0 +1,91 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_GRAPHICS_DEFAULTRENDERINGSYSTEM_H
+#define NOVELRT_INTEROP_ECS_GRAPHICS_DEFAULTRENDERINGSYSTEM_H
+
+#include "../../NrtTypedefs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    NrtDefaultRenderingSystemHandle Nrt_DefaultRenderingSystem_create(
+            NrtIGraphicsPluginProviderPtrHandle graphicsPluginProvider,
+            NrtIWindowingPluginProviderPtrHandle windowingPluginProvider,
+            NrtIResourceManagementPluginProviderPtrHandle resourceManagementPluginProvider);
+
+    NrtResult Nrt_DefaultRenderingSystem_destroy(NrtDefaultRenderingSystemHandle system);
+
+    NrtResult Nrt_DefaultRenderingSystem_Update(
+            NrtDefaultRenderingSystemHandle system,
+            NrtTimestamp delta,
+            NrtCatalogueHandle catalogue);
+
+    NrtResult Nrt_DefaultRenderingSystem_GetOrLoadTexture(
+            NrtDefaultRenderingSystemHandle system,
+            const char* spriteName,
+            NrtTextureInfoFutureResultHandle *output);
+
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingTextureBasedOnId(
+            NrtDefaultRenderingSystemHandle system,
+            NrtAtom ecsId,
+            NrtTextureInfoThreadedPtrHandle *output);
+
+    NrtResult Nrt_DefaultRenderingSystem_LoadVertexDataRawUntyped(
+            NrtDefaultRenderingSystemHandle system,
+            const char* vertexDataName,
+            void* data,
+            size_t dataTypeSize,
+            size_t dataLength,
+            NrtVertexInfoFutureResultHandle *output);
+
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingVertexDataBasedOnName(
+            NrtDefaultRenderingSystemHandle system,
+            const char* vertexDataName,
+            NrtVertexInfoThreadedPtrHandle *output);
+
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingVertexDataBasedOnId(
+            NrtDefaultRenderingSystemHandle system,
+            NrtAtom ecsId,
+            NrtVertexInfoThreadedPtrHandle *output);
+
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingPipelineInfoBasedOnId(
+            NrtDefaultRenderingSystemHandle system,
+            NrtAtom ecsId,
+            NrtGraphicsPipelineInfoThreadedPtrHandle *output);
+
+    NrtResult Nrt_DefaultRenderingSystem_RegisterPipeline(
+            NrtDefaultRenderingSystemHandle system,
+            const char* pipelineName,
+            NrtGraphicsPipelinePtrHandle pipeline,
+            NrtGraphicsResourceMemoryVectorHandle customConstantBufferRegions,
+            NrtBool useEcsTransforms,
+            NrtGraphicsPipelineInfoThreadedPtrHandle *output);
+
+    NrtResult Nrt_DefaultRenderingSystem_AttachSpriteRenderingToEntity(
+            NrtDefaultRenderingSystemHandle system,
+            NrtEntityId entity,
+            NrtTextureInfoThreadedPtrHandle texture,
+            NrtCatalogueHandle catalogue);
+
+    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntity(
+            NrtDefaultRenderingSystemHandle system,
+            NrtTextureInfoThreadedPtrHandle texture,
+            NrtCatalogueHandle catalogue,
+            NrtEntityId *output);
+
+    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntityOutsideOfSystem(
+            NrtDefaultRenderingSystemHandle system,
+            NrtTextureInfoThreadedPtrHandle texture,
+            NrtSystemSchedulerHandle scheduler,
+            NrtEntityId *output);
+
+    NrtResult Nrt_DefaultRenderingSystem_ForceVertexTextureFutureResolution(NrtDefaultRenderingSystemHandle system);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOVELRT_INTEROP_ECS_GRAPHICS_DEFAULTRENDERINGSYSTEM_H

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.h
@@ -12,75 +12,66 @@ extern "C"
 #endif
 
     NrtDefaultRenderingSystemHandle Nrt_DefaultRenderingSystem_create(
-            NrtIGraphicsPluginProviderPtrHandle graphicsPluginProvider,
-            NrtIWindowingPluginProviderPtrHandle windowingPluginProvider,
-            NrtIResourceManagementPluginProviderPtrHandle resourceManagementPluginProvider);
+        NrtIGraphicsPluginProviderPtrHandle graphicsPluginProvider,
+        NrtIWindowingPluginProviderPtrHandle windowingPluginProvider,
+        NrtIResourceManagementPluginProviderPtrHandle resourceManagementPluginProvider);
 
     NrtResult Nrt_DefaultRenderingSystem_destroy(NrtDefaultRenderingSystemHandle system);
 
-    NrtResult Nrt_DefaultRenderingSystem_Update(
-            NrtDefaultRenderingSystemHandle system,
-            NrtTimestamp delta,
-            NrtCatalogueHandle catalogue);
+    NrtResult Nrt_DefaultRenderingSystem_Update(NrtDefaultRenderingSystemHandle system,
+                                                NrtTimestamp delta,
+                                                NrtCatalogueHandle catalogue);
 
-    NrtResult Nrt_DefaultRenderingSystem_GetOrLoadTexture(
-            NrtDefaultRenderingSystemHandle system,
-            const char* spriteName,
-            NrtTextureInfoFutureResultHandle *output);
+    NrtResult Nrt_DefaultRenderingSystem_GetOrLoadTexture(NrtDefaultRenderingSystemHandle system,
+                                                          const char* spriteName,
+                                                          NrtTextureInfoFutureResultHandle* output);
 
-    NrtResult Nrt_DefaultRenderingSystem_GetExistingTextureBasedOnId(
-            NrtDefaultRenderingSystemHandle system,
-            NrtAtom ecsId,
-            NrtTextureInfoThreadedPtrHandle *output);
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingTextureBasedOnId(NrtDefaultRenderingSystemHandle system,
+                                                                     NrtAtom ecsId,
+                                                                     NrtTextureInfoThreadedPtrHandle* output);
 
-    NrtResult Nrt_DefaultRenderingSystem_LoadVertexDataRawUntyped(
-            NrtDefaultRenderingSystemHandle system,
-            const char* vertexDataName,
-            void* data,
-            size_t dataTypeSize,
-            size_t dataLength,
-            NrtVertexInfoFutureResultHandle *output);
+    NrtResult Nrt_DefaultRenderingSystem_LoadVertexDataRawUntyped(NrtDefaultRenderingSystemHandle system,
+                                                                  const char* vertexDataName,
+                                                                  void* data,
+                                                                  size_t dataTypeSize,
+                                                                  size_t dataLength,
+                                                                  NrtVertexInfoFutureResultHandle* output);
 
-    NrtResult Nrt_DefaultRenderingSystem_GetExistingVertexDataBasedOnName(
-            NrtDefaultRenderingSystemHandle system,
-            const char* vertexDataName,
-            NrtVertexInfoThreadedPtrHandle *output);
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingVertexDataBasedOnName(NrtDefaultRenderingSystemHandle system,
+                                                                          const char* vertexDataName,
+                                                                          NrtVertexInfoThreadedPtrHandle* output);
 
-    NrtResult Nrt_DefaultRenderingSystem_GetExistingVertexDataBasedOnId(
-            NrtDefaultRenderingSystemHandle system,
-            NrtAtom ecsId,
-            NrtVertexInfoThreadedPtrHandle *output);
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingVertexDataBasedOnId(NrtDefaultRenderingSystemHandle system,
+                                                                        NrtAtom ecsId,
+                                                                        NrtVertexInfoThreadedPtrHandle* output);
 
     NrtResult Nrt_DefaultRenderingSystem_GetExistingPipelineInfoBasedOnId(
-            NrtDefaultRenderingSystemHandle system,
-            NrtAtom ecsId,
-            NrtGraphicsPipelineInfoThreadedPtrHandle *output);
+        NrtDefaultRenderingSystemHandle system,
+        NrtAtom ecsId,
+        NrtGraphicsPipelineInfoThreadedPtrHandle *output);
 
     NrtResult Nrt_DefaultRenderingSystem_RegisterPipeline(
-            NrtDefaultRenderingSystemHandle system,
-            const char* pipelineName,
-            NrtGraphicsPipelinePtrHandle pipeline,
-            NrtGraphicsResourceMemoryVectorHandle customConstantBufferRegions,
-            NrtBool useEcsTransforms,
-            NrtGraphicsPipelineInfoThreadedPtrHandle *output);
+        NrtDefaultRenderingSystemHandle system,
+        const char* pipelineName,
+        NrtGraphicsPipelinePtrHandle pipeline,
+        NrtGraphicsResourceMemoryVectorHandle customConstantBufferRegions,
+        NrtBool useEcsTransforms,
+        NrtGraphicsPipelineInfoThreadedPtrHandle* output);
 
-    NrtResult Nrt_DefaultRenderingSystem_AttachSpriteRenderingToEntity(
-            NrtDefaultRenderingSystemHandle system,
-            NrtEntityId entity,
-            NrtTextureInfoThreadedPtrHandle texture,
-            NrtCatalogueHandle catalogue);
+    NrtResult Nrt_DefaultRenderingSystem_AttachSpriteRenderingToEntity(NrtDefaultRenderingSystemHandle system,
+                                                                       NrtEntityId entity,
+                                                                       NrtTextureInfoThreadedPtrHandle texture,
+                                                                       NrtCatalogueHandle catalogue);
 
-    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntity(
-            NrtDefaultRenderingSystemHandle system,
-            NrtTextureInfoThreadedPtrHandle texture,
-            NrtCatalogueHandle catalogue,
-            NrtEntityId *output);
+    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntity(NrtDefaultRenderingSystemHandle system,
+                                                            NrtTextureInfoThreadedPtrHandle texture,
+                                                            NrtCatalogueHandle catalogue,
+                                                            NrtEntityId* output);
 
-    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntityOutsideOfSystem(
-            NrtDefaultRenderingSystemHandle system,
-            NrtTextureInfoThreadedPtrHandle texture,
-            NrtSystemSchedulerHandle scheduler,
-            NrtEntityId *output);
+    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntityOutsideOfSystem(NrtDefaultRenderingSystemHandle system,
+                                                                           NrtTextureInfoThreadedPtrHandle texture,
+                                                                           NrtSystemSchedulerHandle scheduler,
+                                                                           NrtEntityId* output);
 
     NrtResult Nrt_DefaultRenderingSystem_ForceVertexTextureFutureResolution(NrtDefaultRenderingSystemHandle system);
 

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.h
@@ -48,7 +48,7 @@ extern "C"
     NrtResult Nrt_DefaultRenderingSystem_GetExistingPipelineInfoBasedOnId(
         NrtDefaultRenderingSystemHandle system,
         NrtAtom ecsId,
-        NrtGraphicsPipelineInfoThreadedPtrHandle *output);
+        NrtGraphicsPipelineInfoThreadedPtrHandle* output);;
 
     NrtResult Nrt_DefaultRenderingSystem_RegisterPipeline(
         NrtDefaultRenderingSystemHandle system,

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphics.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphics.h
@@ -1,0 +1,15 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_GRAPHICS_H
+#define NOVELRT_INTEROP_ECS_GRAPHICS_H
+
+// Ecs.Graphics Dependencies
+#include "NovelRT/Graphics/RGBAColour.h"
+
+#include "NrtDefaultRenderingComponent.h"
+#include "NrtGraphicsPrimitiveInfo.h"
+#include "NrtTextureInfo.h"
+#include "NrtVertexInfo.h"
+
+#endif // NOVELRT_INTEROP_ECS_GRAPHICS_H

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsTypedefs.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsTypedefs.h
@@ -1,0 +1,131 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_GRAPHICS_TYPEDEFS_H
+#define NOVELRT_INTEROP_ECS_GRAPHICS_TYPEDEFS_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct NrtGraphicsPipelineThreadedPtr* NrtGraphicsPipelineThreadedPtrHandle;
+    //Threading::ConcurrentSharedPtr<NovelRT::Graphics::GraphicsPipeline>
+    typedef struct NrtGraphicsPipelinePtr* NrtGraphicsPipelinePtrHandle;
+    //std::shared_ptr<NovelRT::Graphics::GraphicsPipeline>
+
+    typedef struct NrtGPUCustomConstantBuffers* NrtGPUCustomConstantBuffersHandle;
+    //Threading::ConcurrentSharedPtr<std::vector<NovelRT::Graphics::GraphicsMemoryRegion<NovelRT::Graphics::GraphicsResource>>>
+
+    typedef struct NrtGraphicsResourceRegionMemory* NrtGraphicsResourceMemoryRegionHandle;
+    //NovelRT::Graphics::GraphicsMemoryRegion<NovelRT::Graphics::GraphicsResource>
+    typedef struct NrtGraphicsResourceMemoryMap* NrtGraphicsResourceMemoryMapHandle;
+    //std::map<size_t, NovelRT::Graphics::GraphicsMemoryRegion<NovelRT::Graphics::GraphicsResource>>
+    typedef struct NrtGraphicsResourceMemoryVector* NrtGraphicsResourceMemoryVectorHandle;
+    //std::vector<NovelRT::Graphics::GraphicsMemoryRegion<NovelRT::Graphics::GraphicsResource>>
+
+    typedef struct
+    {
+        NrtGraphicsPipelineThreadedPtrHandle gpuPipeline;
+        NrtGPUCustomConstantBuffersHandle gpuCustomConstantBuffers;
+        NrtBool useEcsTransforms;
+        char* pipelineName;
+        NrtAtom ecsId;
+
+    } NrtGraphicsPipelineInfo;
+
+    typedef struct NrtGraphicsPipelineInfoThreadedPtr* NrtGraphicsPipelineInfoThreadedPtrHandle;
+    //Threading::ConcurrentSharedPtr<GraphicsPipelineInfo>
+
+    typedef struct
+    {
+        NrtGraphicsResourceMemoryRegionHandle gpuVertexRegion;
+        char* vertexInfoName;
+        NrtAtom ecsId;
+        void* stagingPtr;
+        size_t sizeOfVert;
+        size_t stagingPtrLength;
+        uint32_t stride;
+
+    }  NrtVertexInfo;
+
+    typedef struct NrtVertexInfoThreadedPtr* NrtVertexInfoThreadedPtrHandle;
+    //Threading::ConcurrentSharedPtr<VertexInfo>
+    typedef struct NrtVertexInfoFutureResult* NrtVertexInfoFutureResultHandle;
+    //Threading::FutureResult<VertexInfo>
+
+    typedef struct
+    {
+        NrtGraphicsResourceMemoryRegionHandle gpuTextureRegion;
+        char* textureName;
+        uint32_t width;
+        uint32_t height;
+        NrtAtom ecsId;
+
+    } NrtTextureInfo;
+
+    typedef struct NrtTextureInfoThreadedPtr* NrtTextureInfoThreadedPtrHandle;
+    //Threading::ConcurrentSharedPtr<TextureInfo>
+    typedef struct NrtTextureInfoFutureResult* NrtTextureInfoFutureResultHandle;
+    //Threading::FutureResult<TextureInfo>
+
+    typedef struct NrtEntityIdPtr* NrtEntityIdPtrHandle;
+    //Threading::ConcurrentSharedPtr<EntityId>
+
+    typedef struct NrtDefaultRenderingSystem*  NrtDefaultRenderingSystemHandle;
+    //NovelRT::Ecs::Graphics::DefaultRenderingSystem
+    typedef struct
+    {
+        NrtEntityId entityId;
+        NrtTextureInfoThreadedPtrHandle texturePtr;
+        NrtVertexInfoThreadedPtrHandle meshPtr;
+        NrtGraphicsPipelineInfoThreadedPtrHandle pipelinePtr;
+
+    } NrtAttachRenderToExistingEntityRequestInfo;
+
+    typedef struct
+    {
+        NrtGraphicsResourceMemoryRegionHandle gpuConstantBufferRegion;
+
+    } NrtConstantBufferInfo;
+
+    typedef struct
+    {
+        NrtEntityIdPtrHandle entityId;
+        NrtTextureInfoThreadedPtrHandle texturePtr;
+        NrtVertexInfoThreadedPtrHandle meshPtr;
+        NrtGraphicsPipelineInfoThreadedPtrHandle pipelinePtr;
+
+    } NrtCreateRenderEntityRequestInfo;
+
+    typedef struct
+    {
+        NrtAtom vertexDataId;
+        NrtAtom textureId;
+        NrtAtom pipelineId;
+        NrtAtom primitiveInfoId;
+        bool markedForDeletion;
+
+    } NrtRenderComponent;
+
+    typedef struct
+    {
+            NrtGeoVector3F Position;
+            NrtGeoVector2F UV;
+
+    } NrtTexturedVertexTest;
+
+    typedef struct
+    {
+        NrtAtom ecsVertexDataId;
+        NrtAtom ecsTextureId;
+        NrtAtom ecsPipelineId;
+        NrtGraphicsResourceMemoryMapHandle gpuTransformConstantBufferRegions;
+
+    } NrtGraphicsPrimitiveInfo;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOVELRT_INTEROP_ECS_GRAPHICS_TYPEDEFS_H

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsTypedefs.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsTypedefs.h
@@ -10,19 +10,19 @@ extern "C"
 #endif
 
     typedef struct NrtGraphicsPipelineThreadedPtr* NrtGraphicsPipelineThreadedPtrHandle;
-    //Threading::ConcurrentSharedPtr<NovelRT::Graphics::GraphicsPipeline>
+    // Threading::ConcurrentSharedPtr<NovelRT::Graphics::GraphicsPipeline>
     typedef struct NrtGraphicsPipelinePtr* NrtGraphicsPipelinePtrHandle;
-    //std::shared_ptr<NovelRT::Graphics::GraphicsPipeline>
+    // std::shared_ptr<NovelRT::Graphics::GraphicsPipeline>
 
     typedef struct NrtGPUCustomConstantBuffers* NrtGPUCustomConstantBuffersHandle;
-    //Threading::ConcurrentSharedPtr<std::vector<NovelRT::Graphics::GraphicsMemoryRegion<NovelRT::Graphics::GraphicsResource>>>
+    // Threading::ConcurrentSharedPtr<std::vector<NovelRT::Graphics::GraphicsMemoryRegion<NovelRT::Graphics::GraphicsResource>>>
 
     typedef struct NrtGraphicsResourceRegionMemory* NrtGraphicsResourceMemoryRegionHandle;
-    //NovelRT::Graphics::GraphicsMemoryRegion<NovelRT::Graphics::GraphicsResource>
+    // NovelRT::Graphics::GraphicsMemoryRegion<NovelRT::Graphics::GraphicsResource>
     typedef struct NrtGraphicsResourceMemoryMap* NrtGraphicsResourceMemoryMapHandle;
-    //std::map<size_t, NovelRT::Graphics::GraphicsMemoryRegion<NovelRT::Graphics::GraphicsResource>>
+    // std::map<size_t, NovelRT::Graphics::GraphicsMemoryRegion<NovelRT::Graphics::GraphicsResource>>
     typedef struct NrtGraphicsResourceMemoryVector* NrtGraphicsResourceMemoryVectorHandle;
-    //std::vector<NovelRT::Graphics::GraphicsMemoryRegion<NovelRT::Graphics::GraphicsResource>>
+    // std::vector<NovelRT::Graphics::GraphicsMemoryRegion<NovelRT::Graphics::GraphicsResource>>
 
     typedef struct
     {
@@ -35,7 +35,7 @@ extern "C"
     } NrtGraphicsPipelineInfo;
 
     typedef struct NrtGraphicsPipelineInfoThreadedPtr* NrtGraphicsPipelineInfoThreadedPtrHandle;
-    //Threading::ConcurrentSharedPtr<GraphicsPipelineInfo>
+    // Threading::ConcurrentSharedPtr<GraphicsPipelineInfo>
 
     typedef struct
     {
@@ -47,12 +47,12 @@ extern "C"
         size_t stagingPtrLength;
         uint32_t stride;
 
-    }  NrtVertexInfo;
+    } NrtVertexInfo;
 
     typedef struct NrtVertexInfoThreadedPtr* NrtVertexInfoThreadedPtrHandle;
-    //Threading::ConcurrentSharedPtr<VertexInfo>
+    // Threading::ConcurrentSharedPtr<VertexInfo>
     typedef struct NrtVertexInfoFutureResult* NrtVertexInfoFutureResultHandle;
-    //Threading::FutureResult<VertexInfo>
+    // Threading::FutureResult<VertexInfo>
 
     typedef struct
     {
@@ -65,15 +65,15 @@ extern "C"
     } NrtTextureInfo;
 
     typedef struct NrtTextureInfoThreadedPtr* NrtTextureInfoThreadedPtrHandle;
-    //Threading::ConcurrentSharedPtr<TextureInfo>
+    // Threading::ConcurrentSharedPtr<TextureInfo>
     typedef struct NrtTextureInfoFutureResult* NrtTextureInfoFutureResultHandle;
-    //Threading::FutureResult<TextureInfo>
+    // Threading::FutureResult<TextureInfo>
 
     typedef struct NrtEntityIdPtr* NrtEntityIdPtrHandle;
-    //Threading::ConcurrentSharedPtr<EntityId>
+    // Threading::ConcurrentSharedPtr<EntityId>
 
     typedef struct NrtDefaultRenderingSystem*  NrtDefaultRenderingSystemHandle;
-    //NovelRT::Ecs::Graphics::DefaultRenderingSystem
+    // NovelRT::Ecs::Graphics::DefaultRenderingSystem
     typedef struct
     {
         NrtEntityId entityId;
@@ -110,8 +110,8 @@ extern "C"
 
     typedef struct
     {
-            NrtGeoVector3F Position;
-            NrtGeoVector2F UV;
+        NrtGeoVector3F Position;
+        NrtGeoVector2F UV;
 
     } NrtTexturedVertexTest;
 

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsTypedefs.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsTypedefs.h
@@ -72,7 +72,7 @@ extern "C"
     typedef struct NrtEntityIdPtr* NrtEntityIdPtrHandle;
     // Threading::ConcurrentSharedPtr<EntityId>
 
-    typedef struct NrtDefaultRenderingSystem*  NrtDefaultRenderingSystemHandle;
+    typedef struct NrtDefaultRenderingSystem* NrtDefaultRenderingSystemHandle;
     // NovelRT::Ecs::Graphics::DefaultRenderingSystem
     typedef struct
     {

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtGraphicsPrimitiveInfo.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtGraphicsPrimitiveInfo.h
@@ -1,0 +1,23 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_GRAPHICS_GRAPHICSPRIMITIVEINFO_H
+#define NOVELRT_INTEROP_ECS_GRAPHICS_GRAPHICSPRIMITIVEINFO_H
+
+#include "../../NrtTypedefs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    NrtBool Nrt_GraphicsPrimitiveInfo_Equals_Operator(NrtGraphicsPrimitiveInfo lhs, NrtGraphicsPrimitiveInfo rhs);
+    NrtBool Nrt_GraphicsPrimitiveInfo_Equals_Operator_With_RenderComponent(NrtGraphicsPrimitiveInfo lhs, NrtRenderComponent rhs);
+    NrtBool Nrt_GraphicsPrimitiveInfo_NotEquals_Operator(NrtGraphicsPrimitiveInfo lhs, NrtGraphicsPrimitiveInfo rhs);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif // NOVELRT_INTEROP_ECS_GRAPHICS_GRAPHICSPRIMITIVEINFO_H

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtGraphicsPrimitiveInfo.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtGraphicsPrimitiveInfo.h
@@ -20,5 +20,4 @@ extern "C"
 }
 #endif
 
-
 #endif // NOVELRT_INTEROP_ECS_GRAPHICS_GRAPHICSPRIMITIVEINFO_H

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtGraphicsPrimitiveInfo.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtGraphicsPrimitiveInfo.h
@@ -12,7 +12,8 @@ extern "C"
 #endif
 
     NrtBool Nrt_GraphicsPrimitiveInfo_Equals_Operator(NrtGraphicsPrimitiveInfo lhs, NrtGraphicsPrimitiveInfo rhs);
-    NrtBool Nrt_GraphicsPrimitiveInfo_Equals_Operator_With_RenderComponent(NrtGraphicsPrimitiveInfo lhs, NrtRenderComponent rhs);
+    NrtBool Nrt_GraphicsPrimitiveInfo_Equals_Operator_With_RenderComponent(NrtGraphicsPrimitiveInfo lhs,
+                                                                           NrtRenderComponent rhs);
     NrtBool Nrt_GraphicsPrimitiveInfo_NotEquals_Operator(NrtGraphicsPrimitiveInfo lhs, NrtGraphicsPrimitiveInfo rhs);
 
 #ifdef __cplusplus

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtTextureInfo.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtTextureInfo.h
@@ -1,0 +1,20 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_GRAPHICS_TEXTUREINFO_H
+#define NOVELRT_INTEROP_ECS_GRAPHICS_TEXTUREINFO_H
+
+#include "../../NrtTypedefs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    NrtBool Nrt_TextureInfo_Equals_Operator(NrtTextureInfo lhs, NrtTextureInfo rhs);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOVELRT_INTEROP_ECS_GRAPHICS_TEXTUREINFO_H

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtVertexInfo.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtVertexInfo.h
@@ -1,0 +1,20 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_GRAPHICS_VERTEXINFO_H
+#define NOVELRT_INTEROP_ECS_GRAPHICS_VERTEXINFO_H
+
+#include "../../NrtTypedefs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    NrtBool Nrt_VertexInfo_Equals_Operator(NrtVertexInfo lhs, NrtVertexInfo rhs);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOVELRT_INTEROP_ECS_GRAPHICS_VERTEXINFO_H

--- a/include/NovelRT.Interop/Ecs/NrtEcs.h
+++ b/include/NovelRT.Interop/Ecs/NrtEcs.h
@@ -12,5 +12,7 @@
 #include "NrtSparseSetMemoryContainer.h"
 #include "NrtSystemScheduler.h"
 #include "NrtUnsafeComponentView.h"
+#include "Graphics/NrtEcsGraphics.h"
+#include "Audio/NrtEcsAudio.h"
 
 #endif // NOVELRT_INTEROP_ECS_ECS_H

--- a/include/NovelRT.Interop/Ecs/NrtEcs.h
+++ b/include/NovelRT.Interop/Ecs/NrtEcs.h
@@ -4,6 +4,8 @@
 #ifndef NOVELRT_INTEROP_ECS_ECS_H
 #define NOVELRT_INTEROP_ECS_ECS_H
 
+#include "Audio/NrtEcsAudio.h"
+#include "Graphics/NrtEcsGraphics.h"
 #include "NrtCatalogue.h"
 #include "NrtComponentBufferMemoryContainer.h"
 #include "NrtComponentCache.h"
@@ -12,7 +14,5 @@
 #include "NrtSparseSetMemoryContainer.h"
 #include "NrtSystemScheduler.h"
 #include "NrtUnsafeComponentView.h"
-#include "Graphics/NrtEcsGraphics.h"
-#include "Audio/NrtEcsAudio.h"
 
 #endif // NOVELRT_INTEROP_ECS_ECS_H

--- a/include/NovelRT.Interop/Ecs/NrtEcsTypedefs.h
+++ b/include/NovelRT.Interop/Ecs/NrtEcsTypedefs.h
@@ -32,9 +32,10 @@ extern "C"
     typedef NrtAtom NrtEntityId;
     typedef NrtAtom NrtComponentTypeId;
 
-    #include "Graphics/NrtEcsGraphicsTypedefs.h"
-    #include "Audio/NrtEcsAudioTypedefs.h"
-    #include "PluginManagement/NrtEcsPluginManagementTypedefs.h"
+#include "Audio/NrtEcsAudioTypedefs.h"
+#include "Graphics/NrtEcsGraphicsTypedefs.h"
+#include "PluginManagement/NrtEcsPluginManagementTypedefs.h"
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/NovelRT.Interop/Ecs/NrtEcsTypedefs.h
+++ b/include/NovelRT.Interop/Ecs/NrtEcsTypedefs.h
@@ -32,6 +32,9 @@ extern "C"
     typedef NrtAtom NrtEntityId;
     typedef NrtAtom NrtComponentTypeId;
 
+    #include "Graphics/NrtEcsGraphicsTypedefs.h"
+    #include "Audio/NrtEcsAudioTypedefs.h"
+    #include "PluginManagement/NrtEcsPluginManagementTypedefs.h"
 #ifdef __cplusplus
 }
 #endif

--- a/include/NovelRT.Interop/Ecs/NrtEcsTypedefs.h
+++ b/include/NovelRT.Interop/Ecs/NrtEcsTypedefs.h
@@ -34,7 +34,6 @@ extern "C"
 
 #include "Audio/NrtEcsAudioTypedefs.h"
 #include "Graphics/NrtEcsGraphicsTypedefs.h"
-#include "PluginManagement/NrtEcsPluginManagementTypedefs.h"
 
 #ifdef __cplusplus
 }

--- a/include/NovelRT.Interop/Ecs/PluginManagement/NrtEcsPluginManagementTypedefs.h
+++ b/include/NovelRT.Interop/Ecs/PluginManagement/NrtEcsPluginManagementTypedefs.h
@@ -1,0 +1,19 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_PLUGINMANAGEMENT_TYPEDEFS_H
+#define NOVELRT_INTEROP_ECS_PLUGINMANAGEMENT_TYPEDEFS_H
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct NrtIGraphicsPluginProviderPtr* NrtIGraphicsPluginProviderPtrHandle;
+    typedef struct NrtIWindowingPluginProviderPtr* NrtIWindowingPluginProviderPtrHandle;
+    typedef struct NrtIResourceManagementPluginProviderPtr* NrtIResourceManagementPluginProviderPtrHandle;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOVELRT_INTEROP_ECS_PLUGINMANAGEMENT_TYPEDEFS_H

--- a/include/NovelRT.Interop/NrtTypedefs.h
+++ b/include/NovelRT.Interop/NrtTypedefs.h
@@ -71,7 +71,6 @@ extern "C"
 #ifdef NOVELRT_INK
 #include "DotNet/NrtDotNetTypedefs.h"
 #endif
-#include "Ecs/Audio/NrtEcsAudioTypedefs.h"
 #include "Ecs/NrtEcsTypedefs.h"
 #ifdef NOVELRT_INK
 #include "Ink/NrtInkTypedefs.h"

--- a/include/NovelRT.Interop/NrtTypedefs.h
+++ b/include/NovelRT.Interop/NrtTypedefs.h
@@ -75,6 +75,7 @@ extern "C"
 #ifdef NOVELRT_INK
 #include "Ink/NrtInkTypedefs.h"
 #endif
+#include "PluginManagement/NrtPluginManagementTypedefs.h"
 #include "SceneGraph/NrtSceneGraphTypedefs.h"
 
 #ifdef __cplusplus

--- a/include/NovelRT.Interop/PluginManagement/NrtPluginManagementTypedefs.h
+++ b/include/NovelRT.Interop/PluginManagement/NrtPluginManagementTypedefs.h
@@ -1,8 +1,9 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
-#ifndef NOVELRT_INTEROP_ECS_PLUGINMANAGEMENT_TYPEDEFS_H
-#define NOVELRT_INTEROP_ECS_PLUGINMANAGEMENT_TYPEDEFS_H
+#ifndef NOVELRT_INTEROP_PLUGINMANAGEMENT_TYPEDEFS_H
+#define NOVELRT_INTEROP_PLUGINMANAGEMENT_TYPEDEFS_H
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -11,6 +12,8 @@ extern "C"
     typedef struct NrtIGraphicsPluginProviderPtr* NrtIGraphicsPluginProviderPtrHandle;
     typedef struct NrtIWindowingPluginProviderPtr* NrtIWindowingPluginProviderPtrHandle;
     typedef struct NrtIResourceManagementPluginProviderPtr* NrtIResourceManagementPluginProviderPtrHandle;
+    typedef struct NrtIInputPluginProviderPtr* NrtIInputPluginProviderPtrHandle;
+    typedef struct NrtDefaultPluginSelector* NrtDefaultPluginSelectorHandle;
 
 #ifdef __cplusplus
 }

--- a/include/NovelRT/Ecs/Graphics/DefaultRenderingSystem.h
+++ b/include/NovelRT/Ecs/Graphics/DefaultRenderingSystem.h
@@ -16,7 +16,7 @@ namespace NovelRT::Ecs::Graphics
         NovelRT::Maths::GeoVector2F UV;
     };
 
-    class DefaultRenderingSystem : public IEcsSystem
+    class DefaultRenderingSystem : public IEcsSystem, public std::enable_shared_from_this<DefaultRenderingSystem>
     {
     private:
         Utilities::Lazy<NovelRT::Graphics::GraphicsResourceManager> _resourceManager;

--- a/include/NovelRT/PluginManagement/IGraphicsPluginProvider.h
+++ b/include/NovelRT/PluginManagement/IGraphicsPluginProvider.h
@@ -10,7 +10,7 @@
 
 namespace NovelRT::PluginManagement
 {
-    class IGraphicsPluginProvider
+    class IGraphicsPluginProvider : public std::enable_shared_from_this<IGraphicsPluginProvider>
     {
     protected:
         [[nodiscard]] virtual Graphics::GraphicsProvider* GetGraphicsProviderInternal() = 0;

--- a/include/NovelRT/PluginManagement/IResourceManagementPluginProvider.h
+++ b/include/NovelRT/PluginManagement/IResourceManagementPluginProvider.h
@@ -10,7 +10,7 @@
 
 namespace NovelRT::PluginManagement
 {
-    class IResourceManagementPluginProvider
+    class IResourceManagementPluginProvider : public std::enable_shared_from_this<IResourceManagementPluginProvider>
     {
     private:
         [[nodiscard]] virtual ResourceManagement::ResourceLoader* GetResourceLoaderInternal() = 0;

--- a/include/NovelRT/PluginManagement/IWindowingPluginProvider.h
+++ b/include/NovelRT/PluginManagement/IWindowingPluginProvider.h
@@ -10,7 +10,7 @@
 
 namespace NovelRT::PluginManagement
 {
-    class IWindowingPluginProvider
+    class IWindowingPluginProvider : public std::enable_shared_from_this<IWindowingPluginProvider>
     {
     private:
         [[nodiscard]] virtual Windowing::IWindowingDevice* GetWindowingDeviceInternal() = 0;

--- a/src/NovelRT.Interop/CMakeLists.txt
+++ b/src/NovelRT.Interop/CMakeLists.txt
@@ -16,8 +16,14 @@ set(SOURCES
   Ecs/Audio/NrtAudioSystem.cpp
   Ecs/Audio/NrtAudioEmitterComponent.cpp
   Ecs/Audio/NrtAudioEmitterStateComponent.cpp
+  Ecs/Graphics/NrtDefaultRenderingComponent.cpp
+  Ecs/Graphics/NrtGraphicsPrimitiveInfo.cpp
+  Ecs/Graphics/NrtVertexInfo.cpp
+  Ecs/Graphics/NrtTextureInfo.cpp
+  Ecs/Graphics/NrtDefaultRenderingSystem.cpp
 
   Graphics/NrtRGBAColour.cpp
+  
 
   Maths/NrtGeoBounds.cpp
   Maths/NrtGeoMatrix4x4F.cpp

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingComponent.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingComponent.cpp
@@ -1,0 +1,32 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingComponent.h>
+#include <NovelRT/Ecs/Ecs.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    void Nrt_RenderComponent_PlusEquals_Operator(NrtRenderComponent* lhs, NrtRenderComponent rhs)
+    {
+        *reinterpret_cast<NovelRT::Ecs::Graphics::RenderComponent*>(lhs) +=
+            *reinterpret_cast<const NovelRT::Ecs::Graphics::RenderComponent*>(&rhs);
+    }
+
+    NrtBool Nrt_RenderComponent_Equals_Operator(NrtRenderComponent lhs, NrtRenderComponent rhs)
+    {
+        return *reinterpret_cast<const NovelRT::Ecs::Graphics::RenderComponent*>(&lhs) ==
+            *reinterpret_cast<const NovelRT::Ecs::Graphics::RenderComponent*>(&rhs);
+    }
+
+    NrtBool Nrt_RenderComponent_NotEquals_Operator(NrtRenderComponent lhs, NrtRenderComponent rhs)
+    {
+        return *reinterpret_cast<const NovelRT::Ecs::Graphics::RenderComponent*>(&lhs) !=
+            *reinterpret_cast<const NovelRT::Ecs::Graphics::RenderComponent*>(&rhs);
+    }
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingComponent.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingComponent.cpp
@@ -18,13 +18,13 @@ extern "C"
     NrtBool Nrt_RenderComponent_Equals_Operator(NrtRenderComponent lhs, NrtRenderComponent rhs)
     {
         return *reinterpret_cast<const NovelRT::Ecs::Graphics::RenderComponent*>(&lhs) ==
-            *reinterpret_cast<const NovelRT::Ecs::Graphics::RenderComponent*>(&rhs);
+               *reinterpret_cast<const NovelRT::Ecs::Graphics::RenderComponent*>(&rhs);
     }
 
     NrtBool Nrt_RenderComponent_NotEquals_Operator(NrtRenderComponent lhs, NrtRenderComponent rhs)
     {
         return *reinterpret_cast<const NovelRT::Ecs::Graphics::RenderComponent*>(&lhs) !=
-            *reinterpret_cast<const NovelRT::Ecs::Graphics::RenderComponent*>(&rhs);
+               *reinterpret_cast<const NovelRT::Ecs::Graphics::RenderComponent*>(&rhs);
     }
 
 #ifdef __cplusplus

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.cpp
@@ -1,0 +1,362 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <NovelRT.Interop/NrtErrorHandling.h>
+#include <NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.h>
+#include <NovelRT/Ecs/Ecs.h>
+
+using namespace NovelRT;
+using namespace Threading;
+using namespace Ecs::Graphics;
+using namespace PluginManagement;
+
+std::list<std::shared_ptr<DefaultRenderingSystem>> _DefaultRenderingSystemCollection;
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    NrtDefaultRenderingSystemHandle Nrt_DefaultRenderingSystem_create(
+            NrtIGraphicsPluginProviderPtrHandle graphicsPluginProvider,
+            NrtIWindowingPluginProviderPtrHandle windowingPluginProvider,
+            NrtIResourceManagementPluginProviderPtrHandle resourceManagementPluginProvider)
+    {
+        auto graphics = reinterpret_cast<PluginManagement::IGraphicsPluginProvider*>(graphicsPluginProvider)->shared_from_this();
+        auto window = reinterpret_cast<PluginManagement::IWindowingPluginProvider*>(windowingPluginProvider)->shared_from_this();
+        auto resources = reinterpret_cast<PluginManagement::IResourceManagementPluginProvider*>(
+                                        resourceManagementPluginProvider)->shared_from_this();
+
+        _DefaultRenderingSystemCollection.push_back(std::make_shared<DefaultRenderingSystem>(graphics, window, resources));
+
+        return reinterpret_cast<NrtDefaultRenderingSystemHandle>(_DefaultRenderingSystemCollection.back().get());
+    }
+
+    NrtResult Nrt_DefaultRenderingSystem_destroy(NrtDefaultRenderingSystemHandle system)
+    {
+        if (system == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        auto to_delete = reinterpret_cast<DefaultRenderingSystem*>(system)->shared_from_this();
+        if (std::find(_DefaultRenderingSystemCollection.begin(),
+                        _DefaultRenderingSystemCollection.end(),
+                        to_delete) == _DefaultRenderingSystemCollection.end())
+        {
+            Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
+            return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
+        }
+        _DefaultRenderingSystemCollection.remove(to_delete);
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_DefaultRenderingSystem_Update(
+            NrtDefaultRenderingSystemHandle system,
+            NrtTimestamp delta,
+            NrtCatalogueHandle catalogue)
+    {
+        if (system == nullptr || catalogue == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
+        auto CppDelta = Timing::Timestamp(delta);
+        auto CppCatalogue = reinterpret_cast<Ecs::Catalogue*>(catalogue);
+
+        CppSystem->Update(CppDelta, *CppCatalogue);
+
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_DefaultRenderingSystem_GetOrLoadTexture(
+            NrtDefaultRenderingSystemHandle system,
+            const char* spriteName,
+            NrtTextureInfoFutureResultHandle *output)
+    {
+        if (system == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        if (output == nullptr || spriteName == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+        }
+
+        std::string spriteString = spriteName;
+        auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
+        auto NewResult = new FutureResult<TextureInfo>(Threading::MakeConcurrentShared<TextureInfo>(), TextureInfo{});
+
+        *NewResult = CppSystem->GetOrLoadTexture(spriteString);
+        *output = reinterpret_cast<NrtTextureInfoFutureResultHandle>(NewResult);
+        return NRT_SUCCESS;
+
+    }
+
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingTextureBasedOnId(
+            NrtDefaultRenderingSystemHandle system,
+            NrtAtom ecsId,
+            NrtTextureInfoThreadedPtrHandle *output)
+    {
+        if (system == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        if (output == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+        }
+
+        auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
+        auto NewConcurrent = Threading::MakeConcurrentShared<TextureInfo>();
+
+        NewConcurrent = CppSystem->GetExistingTextureBasedOnId(ecsId);
+        *output = reinterpret_cast<NrtTextureInfoThreadedPtrHandle>(&NewConcurrent);
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_DefaultRenderingSystem_LoadVertexDataRawUntyped(
+            NrtDefaultRenderingSystemHandle system,
+            const char* vertexDataName,
+            void* data,
+            size_t dataTypeSize,
+            size_t dataLength,
+            NrtVertexInfoFutureResultHandle *output)
+    {
+        if (system == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        if (output == nullptr || vertexDataName == nullptr || data == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+        }
+
+        auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
+        std::string CppVertexDataName = vertexDataName;
+        auto NewResult = new FutureResult<VertexInfo>(Threading::MakeConcurrentShared<VertexInfo>(), VertexInfo{});
+
+        *NewResult = CppSystem->LoadVertexDataRawUntyped(CppVertexDataName, data, dataTypeSize, dataLength);
+        *output = reinterpret_cast<NrtVertexInfoFutureResultHandle>(NewResult);
+
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingVertexDataBasedOnName(
+            NrtDefaultRenderingSystemHandle system,
+            const char* vertexDataName,
+            NrtVertexInfoThreadedPtrHandle *output)
+    {
+        if (system == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        if (output == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+        }
+
+        auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
+        std::string CppVertexDataName = vertexDataName;
+        auto NewConcurrent = Threading::MakeConcurrentShared<VertexInfo>();
+
+        NewConcurrent = CppSystem->GetExistingVertexDataBasedOnName(CppVertexDataName);
+        *output = reinterpret_cast<NrtVertexInfoThreadedPtrHandle>(&NewConcurrent);
+
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingVertexDataBasedOnId(
+            NrtDefaultRenderingSystemHandle system,
+            NrtAtom ecsId,
+            NrtVertexInfoThreadedPtrHandle *output)
+    {
+        if (system == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        if (output == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+        }
+
+        auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
+        auto NewConcurrent = Threading::MakeConcurrentShared<VertexInfo>();
+
+        NewConcurrent = CppSystem->GetExistingVertexDataBasedOnId(ecsId);
+        *output = reinterpret_cast<NrtVertexInfoThreadedPtrHandle>(&NewConcurrent);
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingPipelineInfoBasedOnId(
+            NrtDefaultRenderingSystemHandle system,
+            NrtAtom ecsId,
+            NrtGraphicsPipelineInfoThreadedPtrHandle *output)
+    {
+        if (system == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        if (output == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+        }
+
+        auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
+        auto NewConcurrent = Threading::MakeConcurrentShared<GraphicsPipelineInfo>();
+
+        NewConcurrent = CppSystem->GetExistingPipelineInfoBasedOnId(ecsId);
+        *output = reinterpret_cast<NrtGraphicsPipelineInfoThreadedPtrHandle>(&NewConcurrent);
+        return NRT_SUCCESS;
+    }
+    NrtResult Nrt_DefaultRenderingSystem_RegisterPipeline(
+            NrtDefaultRenderingSystemHandle system,
+            const char* pipelineName,
+            NrtGraphicsPipelinePtrHandle pipeline,
+            NrtGraphicsResourceMemoryVectorHandle customConstantBufferRegions,
+            NrtBool useEcsTransforms,
+            NrtGraphicsPipelineInfoThreadedPtrHandle *output)
+    {
+        if (system == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        if (output == nullptr || pipelineName == nullptr || pipeline == nullptr || customConstantBufferRegions == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+        }
+
+        auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
+        std::string CppPipelineName = pipelineName;
+        auto CppPipeline = std::dynamic_pointer_cast<Graphics::GraphicsPipeline>(
+                        reinterpret_cast<Graphics::GraphicsPipeline*>(pipeline)->shared_from_this());
+        auto CppConstantBuffer = reinterpret_cast<std::vector<Graphics::GraphicsMemoryRegion<Graphics::GraphicsResource>>*>(customConstantBufferRegions);
+        auto NewConcurrent = Threading::MakeConcurrentShared<GraphicsPipelineInfo>();
+
+        NewConcurrent = CppSystem->RegisterPipeline(CppPipelineName, CppPipeline, *CppConstantBuffer, useEcsTransforms);
+        *output = reinterpret_cast<NrtGraphicsPipelineInfoThreadedPtrHandle>(&NewConcurrent);
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_DefaultRenderingSystem_AttachSpriteRenderingToEntity(
+            NrtDefaultRenderingSystemHandle system,
+            NrtEntityId entity,
+            NrtTextureInfoThreadedPtrHandle texture,
+            NrtCatalogueHandle catalogue)
+    {
+        if (system == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        if (texture == nullptr || catalogue == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+        }
+
+        auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
+        auto CppTextureInfo = reinterpret_cast<Threading::ConcurrentSharedPtr<TextureInfo>*>(texture);
+        auto CppCatalogue = reinterpret_cast<Ecs::Catalogue*>(catalogue);
+
+        CppSystem->AttachSpriteRenderingToEntity(entity, *CppTextureInfo, *CppCatalogue);
+
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntity(
+            NrtDefaultRenderingSystemHandle system,
+            NrtTextureInfoThreadedPtrHandle texture,
+            NrtCatalogueHandle catalogue,
+            NrtEntityId *output)
+    {
+        if (system == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        if (texture == nullptr || catalogue == nullptr || output == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+        }
+
+        auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
+        auto CppTextureInfo = reinterpret_cast<Threading::ConcurrentSharedPtr<TextureInfo>*>(texture);
+        auto CppCatalogue = reinterpret_cast<Ecs::Catalogue*>(catalogue);
+
+        auto NewEntity = CppSystem->CreateSpriteEntity(*CppTextureInfo, *CppCatalogue);
+        *output = *reinterpret_cast<NrtEntityId*>(&NewEntity);
+
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntityOutsideOfSystem(
+            NrtDefaultRenderingSystemHandle system,
+            NrtTextureInfoThreadedPtrHandle texture,
+            NrtSystemSchedulerHandle scheduler,
+            NrtEntityId *output)
+    {
+        if (system == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        if (texture == nullptr || scheduler == nullptr || output == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+        }
+
+        auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
+        auto CppTextureInfo = reinterpret_cast<Threading::ConcurrentSharedPtr<TextureInfo>*>(texture);
+        auto CppScheduler = reinterpret_cast<Ecs::SystemScheduler*>(scheduler);
+
+        auto NewEntity = CppSystem->CreateSpriteEntityOutsideOfSystem(*CppTextureInfo, *CppScheduler);
+        *output = *reinterpret_cast<NrtEntityId*>(&NewEntity);
+        return NRT_SUCCESS;
+    }
+
+    NrtResult Nrt_DefaultRenderingSystem_ForceVertexTextureFutureResolution(NrtDefaultRenderingSystemHandle system)
+    {
+        if (system == nullptr)
+        {
+            Nrt_setErrMsgIsNullptrInternal();
+            return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+        }
+
+        auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
+        CppSystem->ForceVertexTextureFutureResolution();
+        return NRT_SUCCESS;
+    }
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.cpp
@@ -1,8 +1,8 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
-#include <NovelRT.Interop/NrtErrorHandling.h>
 #include <NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.h>
+#include <NovelRT.Interop/NrtErrorHandling.h>
 #include <NovelRT/Ecs/Ecs.h>
 
 using namespace NovelRT;
@@ -18,16 +18,20 @@ extern "C"
 #endif
 
     NrtDefaultRenderingSystemHandle Nrt_DefaultRenderingSystem_create(
-            NrtIGraphicsPluginProviderPtrHandle graphicsPluginProvider,
-            NrtIWindowingPluginProviderPtrHandle windowingPluginProvider,
-            NrtIResourceManagementPluginProviderPtrHandle resourceManagementPluginProvider)
+        NrtIGraphicsPluginProviderPtrHandle graphicsPluginProvider,
+        NrtIWindowingPluginProviderPtrHandle windowingPluginProvider,
+        NrtIResourceManagementPluginProviderPtrHandle resourceManagementPluginProvider)
     {
-        auto graphics = reinterpret_cast<PluginManagement::IGraphicsPluginProvider*>(graphicsPluginProvider)->shared_from_this();
-        auto window = reinterpret_cast<PluginManagement::IWindowingPluginProvider*>(windowingPluginProvider)->shared_from_this();
-        auto resources = reinterpret_cast<PluginManagement::IResourceManagementPluginProvider*>(
-                                        resourceManagementPluginProvider)->shared_from_this();
+        auto graphics =
+            reinterpret_cast<PluginManagement::IGraphicsPluginProvider*>(graphicsPluginProvider)->shared_from_this();
+        auto window =
+            reinterpret_cast<PluginManagement::IWindowingPluginProvider*>(windowingPluginProvider)->shared_from_this();
+        auto resources =
+            reinterpret_cast<PluginManagement::IResourceManagementPluginProvider*>(resourceManagementPluginProvider)
+                ->shared_from_this();
 
-        _DefaultRenderingSystemCollection.push_back(std::make_shared<DefaultRenderingSystem>(graphics, window, resources));
+        _DefaultRenderingSystemCollection.push_back(
+            std::make_shared<DefaultRenderingSystem>(graphics, window, resources));
 
         return reinterpret_cast<NrtDefaultRenderingSystemHandle>(_DefaultRenderingSystemCollection.back().get());
     }
@@ -41,9 +45,8 @@ extern "C"
         }
 
         auto to_delete = reinterpret_cast<DefaultRenderingSystem*>(system)->shared_from_this();
-        if (std::find(_DefaultRenderingSystemCollection.begin(),
-                        _DefaultRenderingSystemCollection.end(),
-                        to_delete) == _DefaultRenderingSystemCollection.end())
+        if (std::find(_DefaultRenderingSystemCollection.begin(), _DefaultRenderingSystemCollection.end(), to_delete) ==
+            _DefaultRenderingSystemCollection.end())
         {
             Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
             return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
@@ -52,10 +55,9 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_DefaultRenderingSystem_Update(
-            NrtDefaultRenderingSystemHandle system,
-            NrtTimestamp delta,
-            NrtCatalogueHandle catalogue)
+    NrtResult Nrt_DefaultRenderingSystem_Update(NrtDefaultRenderingSystemHandle system,
+                                                NrtTimestamp delta,
+                                                NrtCatalogueHandle catalogue)
     {
         if (system == nullptr || catalogue == nullptr)
         {
@@ -72,10 +74,9 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_DefaultRenderingSystem_GetOrLoadTexture(
-            NrtDefaultRenderingSystemHandle system,
-            const char* spriteName,
-            NrtTextureInfoFutureResultHandle *output)
+    NrtResult Nrt_DefaultRenderingSystem_GetOrLoadTexture(NrtDefaultRenderingSystemHandle system,
+                                                          const char* spriteName,
+                                                          NrtTextureInfoFutureResultHandle* output)
     {
         if (system == nullptr)
         {
@@ -99,10 +100,9 @@ extern "C"
 
     }
 
-    NrtResult Nrt_DefaultRenderingSystem_GetExistingTextureBasedOnId(
-            NrtDefaultRenderingSystemHandle system,
-            NrtAtom ecsId,
-            NrtTextureInfoThreadedPtrHandle *output)
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingTextureBasedOnId(NrtDefaultRenderingSystemHandle system,
+                                                                     NrtAtom ecsId,
+                                                                     NrtTextureInfoThreadedPtrHandle* output)
     {
         if (system == nullptr)
         {
@@ -124,13 +124,12 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_DefaultRenderingSystem_LoadVertexDataRawUntyped(
-            NrtDefaultRenderingSystemHandle system,
-            const char* vertexDataName,
-            void* data,
-            size_t dataTypeSize,
-            size_t dataLength,
-            NrtVertexInfoFutureResultHandle *output)
+    NrtResult Nrt_DefaultRenderingSystem_LoadVertexDataRawUntyped(NrtDefaultRenderingSystemHandle system,
+                                                                  const char* vertexDataName,
+                                                                  void* data,
+                                                                  size_t dataTypeSize,
+                                                                  size_t dataLength,
+                                                                  NrtVertexInfoFutureResultHandle* output)
     {
         if (system == nullptr)
         {
@@ -154,10 +153,9 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_DefaultRenderingSystem_GetExistingVertexDataBasedOnName(
-            NrtDefaultRenderingSystemHandle system,
-            const char* vertexDataName,
-            NrtVertexInfoThreadedPtrHandle *output)
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingVertexDataBasedOnName(NrtDefaultRenderingSystemHandle system,
+                                                                          const char* vertexDataName,
+                                                                          NrtVertexInfoThreadedPtrHandle* output)
     {
         if (system == nullptr)
         {
@@ -181,10 +179,9 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_DefaultRenderingSystem_GetExistingVertexDataBasedOnId(
-            NrtDefaultRenderingSystemHandle system,
-            NrtAtom ecsId,
-            NrtVertexInfoThreadedPtrHandle *output)
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingVertexDataBasedOnId(NrtDefaultRenderingSystemHandle system,
+                                                                        NrtAtom ecsId,
+                                                                        NrtVertexInfoThreadedPtrHandle* output)
     {
         if (system == nullptr)
         {
@@ -207,9 +204,9 @@ extern "C"
     }
 
     NrtResult Nrt_DefaultRenderingSystem_GetExistingPipelineInfoBasedOnId(
-            NrtDefaultRenderingSystemHandle system,
-            NrtAtom ecsId,
-            NrtGraphicsPipelineInfoThreadedPtrHandle *output)
+        NrtDefaultRenderingSystemHandle system,
+        NrtAtom ecsId,
+        NrtGraphicsPipelineInfoThreadedPtrHandle* output)
     {
         if (system == nullptr)
         {
@@ -231,12 +228,12 @@ extern "C"
         return NRT_SUCCESS;
     }
     NrtResult Nrt_DefaultRenderingSystem_RegisterPipeline(
-            NrtDefaultRenderingSystemHandle system,
-            const char* pipelineName,
-            NrtGraphicsPipelinePtrHandle pipeline,
-            NrtGraphicsResourceMemoryVectorHandle customConstantBufferRegions,
-            NrtBool useEcsTransforms,
-            NrtGraphicsPipelineInfoThreadedPtrHandle *output)
+        NrtDefaultRenderingSystemHandle system,
+        const char* pipelineName,
+        NrtGraphicsPipelinePtrHandle pipeline,
+        NrtGraphicsResourceMemoryVectorHandle customConstantBufferRegions,
+        NrtBool useEcsTransforms,
+        NrtGraphicsPipelineInfoThreadedPtrHandle *output)
     {
         if (system == nullptr)
         {
@@ -244,7 +241,8 @@ extern "C"
             return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
         }
 
-        if (output == nullptr || pipelineName == nullptr || pipeline == nullptr || customConstantBufferRegions == nullptr)
+        if (output == nullptr || pipelineName == nullptr || pipeline == nullptr ||
+            customConstantBufferRegions == nullptr)
         {
             Nrt_setErrMsgIsNullptrInternal();
             return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
@@ -253,8 +251,10 @@ extern "C"
         auto CppSystem = reinterpret_cast<DefaultRenderingSystem*>(system);
         std::string CppPipelineName = pipelineName;
         auto CppPipeline = std::dynamic_pointer_cast<Graphics::GraphicsPipeline>(
-                        reinterpret_cast<Graphics::GraphicsPipeline*>(pipeline)->shared_from_this());
-        auto CppConstantBuffer = reinterpret_cast<std::vector<Graphics::GraphicsMemoryRegion<Graphics::GraphicsResource>>*>(customConstantBufferRegions);
+            reinterpret_cast<Graphics::GraphicsPipeline*>(pipeline)->shared_from_this());
+        auto CppConstantBuffer =
+            reinterpret_cast<std::vector<Graphics::GraphicsMemoryRegion<Graphics::GraphicsResource>>*>(
+                customConstantBufferRegions);
         auto NewConcurrent = Threading::MakeConcurrentShared<GraphicsPipelineInfo>();
 
         NewConcurrent = CppSystem->RegisterPipeline(CppPipelineName, CppPipeline, *CppConstantBuffer, useEcsTransforms);
@@ -262,11 +262,10 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_DefaultRenderingSystem_AttachSpriteRenderingToEntity(
-            NrtDefaultRenderingSystemHandle system,
-            NrtEntityId entity,
-            NrtTextureInfoThreadedPtrHandle texture,
-            NrtCatalogueHandle catalogue)
+    NrtResult Nrt_DefaultRenderingSystem_AttachSpriteRenderingToEntity(NrtDefaultRenderingSystemHandle system,
+                                                                       NrtEntityId entity,
+                                                                       NrtTextureInfoThreadedPtrHandle texture,
+                                                                       NrtCatalogueHandle catalogue)
     {
         if (system == nullptr)
         {
@@ -289,11 +288,10 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntity(
-            NrtDefaultRenderingSystemHandle system,
-            NrtTextureInfoThreadedPtrHandle texture,
-            NrtCatalogueHandle catalogue,
-            NrtEntityId *output)
+    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntity(NrtDefaultRenderingSystemHandle system,
+                                                            NrtTextureInfoThreadedPtrHandle texture,
+                                                            NrtCatalogueHandle catalogue,
+                                                            NrtEntityId* output)
     {
         if (system == nullptr)
         {
@@ -317,11 +315,10 @@ extern "C"
         return NRT_SUCCESS;
     }
 
-    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntityOutsideOfSystem(
-            NrtDefaultRenderingSystemHandle system,
-            NrtTextureInfoThreadedPtrHandle texture,
-            NrtSystemSchedulerHandle scheduler,
-            NrtEntityId *output)
+    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntityOutsideOfSystem(NrtDefaultRenderingSystemHandle system,
+                                                                           NrtTextureInfoThreadedPtrHandle texture,
+                                                                           NrtSystemSchedulerHandle scheduler,
+                                                                           NrtEntityId* output)
     {
         if (system == nullptr)
         {

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.cpp
@@ -97,7 +97,6 @@ extern "C"
         *NewResult = CppSystem->GetOrLoadTexture(spriteString);
         *output = reinterpret_cast<NrtTextureInfoFutureResultHandle>(NewResult);
         return NRT_SUCCESS;
-
     }
 
     NrtResult Nrt_DefaultRenderingSystem_GetExistingTextureBasedOnId(NrtDefaultRenderingSystemHandle system,
@@ -233,7 +232,7 @@ extern "C"
         NrtGraphicsPipelinePtrHandle pipeline,
         NrtGraphicsResourceMemoryVectorHandle customConstantBufferRegions,
         NrtBool useEcsTransforms,
-        NrtGraphicsPipelineInfoThreadedPtrHandle *output)
+        NrtGraphicsPipelineInfoThreadedPtrHandle* output)
     {
         if (system == nullptr)
         {

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtGraphicsPrimitiveInfo.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtGraphicsPrimitiveInfo.cpp
@@ -1,0 +1,31 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <NovelRT.Interop/Ecs/Graphics/NrtGraphicsPrimitiveInfo.h>
+#include <NovelRT/Ecs/Ecs.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+    using namespace NovelRT::Ecs::Graphics;
+
+#endif
+
+    NrtBool Nrt_GraphicsPrimitiveInfo_Equals_Operator(NrtGraphicsPrimitiveInfo lhs, NrtGraphicsPrimitiveInfo rhs)
+    {
+        return *reinterpret_cast<const GraphicsPrimitiveInfo*>(&lhs) == *reinterpret_cast<const GraphicsPrimitiveInfo*>(&rhs);
+    }
+
+    NrtBool Nrt_GraphicsPrimitiveInfo_Equals_Operator_With_RenderComponent(NrtGraphicsPrimitiveInfo lhs, NrtRenderComponent rhs)
+    {
+        return *reinterpret_cast<const GraphicsPrimitiveInfo*>(&lhs) == *reinterpret_cast<const RenderComponent*>(&rhs);
+    }
+
+    NrtBool Nrt_GraphicsPrimitiveInfo_NotEquals_Operator(NrtGraphicsPrimitiveInfo lhs, NrtGraphicsPrimitiveInfo rhs)
+    {
+        return !(Nrt_GraphicsPrimitiveInfo_Equals_Operator(lhs, rhs));
+    }
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtGraphicsPrimitiveInfo.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtGraphicsPrimitiveInfo.cpp
@@ -13,10 +13,12 @@ extern "C"
 
     NrtBool Nrt_GraphicsPrimitiveInfo_Equals_Operator(NrtGraphicsPrimitiveInfo lhs, NrtGraphicsPrimitiveInfo rhs)
     {
-        return *reinterpret_cast<const GraphicsPrimitiveInfo*>(&lhs) == *reinterpret_cast<const GraphicsPrimitiveInfo*>(&rhs);
+        return *reinterpret_cast<const GraphicsPrimitiveInfo*>(&lhs) ==
+               *reinterpret_cast<const GraphicsPrimitiveInfo*>(&rhs);
     }
 
-    NrtBool Nrt_GraphicsPrimitiveInfo_Equals_Operator_With_RenderComponent(NrtGraphicsPrimitiveInfo lhs, NrtRenderComponent rhs)
+    NrtBool Nrt_GraphicsPrimitiveInfo_Equals_Operator_With_RenderComponent(NrtGraphicsPrimitiveInfo lhs,
+                                                                           NrtRenderComponent rhs)
     {
         return *reinterpret_cast<const GraphicsPrimitiveInfo*>(&lhs) == *reinterpret_cast<const RenderComponent*>(&rhs);
     }

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtTextureInfo.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtTextureInfo.cpp
@@ -1,0 +1,20 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <NovelRT.Interop/Ecs/Graphics/NrtTextureInfo.h>
+#include <NovelRT/Ecs/Ecs.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+    using namespace NovelRT::Ecs::Graphics;
+#endif
+
+    NrtBool Nrt_TextureInfo_Equals_Operator(NrtTextureInfo lhs, NrtTextureInfo rhs)
+    {
+        return *reinterpret_cast<const TextureInfo*>(&lhs) == *reinterpret_cast<const TextureInfo*>(&rhs);
+    }
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtVertexInfo.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtVertexInfo.cpp
@@ -18,4 +18,3 @@ extern "C"
 #ifdef __cplusplus
 }
 #endif
-

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtVertexInfo.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtVertexInfo.cpp
@@ -1,0 +1,21 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <NovelRT.Interop/Ecs/Graphics/NrtVertexInfo.h>
+#include <NovelRT/Ecs/Ecs.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+    using namespace NovelRT::Ecs::Graphics;
+#endif
+
+    NrtBool Nrt_VertexInfo_Equals_Operator(NrtVertexInfo lhs, NrtVertexInfo rhs)
+    {
+        return *reinterpret_cast<const VertexInfo*>(&lhs) == *reinterpret_cast<const VertexInfo*>(&rhs);
+    }
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
An interface for C programs to use the PlugingManagement C++ classes and methods.
It contains:
- Minimal Typedefs in Input, ResourceManagement and Windowing folders;
- Added enable_shared_from_this<> to GraphicsSurfaceContext, IGraphicsSurface and IPluginProvider classes for pointer manipulation;
- Opaque handles for the necessary complex types;
- Constr/Deconstr for DefaultPluginSelector, IGraphicsPluginProvider, IWindowingPluginProvider, IResourceManagementPluginProvider and IInputPluginProvider classes as well as support for its methods.
