### PR TITLE
Reworked Atom factory methods into an actual engine feature.

### DIFF
--- a/include/NovelRT/Atom.h
+++ b/include/NovelRT/Atom.h
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <cstddef>
 #include <limits>
+#include <string>
 
 #ifndef NOVELRT_ATOM_H
 #define NOVELRT_ATOM_H
@@ -71,29 +72,33 @@ namespace NovelRT
             return _value;
         }
 
-        // TODO: These should be internal to NovelRT
-
-        static Atom GetNextEventHandlerId() noexcept;
-
-        static Atom GetNextFontSetId() noexcept;
-
-        static Atom GetNextTextureId() noexcept;
-
-        static Atom GetNextComponentTypeId() noexcept;
-
-        static Atom GetNextEntityId() noexcept;
-
-        static Atom GetNextSystemId() noexcept;
-
-        static Atom GetNextEcsTextureId() noexcept;
-
-        static Atom GetNextEcsVertexDataId() noexcept;
-
-        static Atom GetNextEcsPrimitiveId() noexcept;
-
-        static Atom GetNextEcsGraphicsPipelineId() noexcept;
-
         static Atom GetNextEcsPrimitiveInfoConfigurationId() noexcept;
+    };
+
+    class AtomFactory
+    {
+    private:
+        std::atomic_uintptr_t _currentValue;
+        bool _moved;
+
+    public:
+        AtomFactory() noexcept;
+        explicit AtomFactory(Atom startingValue) noexcept;
+        AtomFactory(const AtomFactory& other) noexcept;
+        AtomFactory(AtomFactory&& other) noexcept;
+        AtomFactory& operator=(const AtomFactory& other) noexcept;
+        AtomFactory& operator=(AtomFactory&& other) noexcept;
+        ~AtomFactory() = default;
+
+        [[nodiscard]] Atom GetNext();
+
+        void SetToValue(Atom newValue);
+    };
+
+    class AtomFactoryDatabase
+    {
+    public:
+        [[nodiscard]] static AtomFactory& GetFactory(const std::string& factoryName) noexcept;
     };
 
     class AtomHashFunction

--- a/include/NovelRT/Ecs/EcsUtils.h
+++ b/include/NovelRT/Ecs/EcsUtils.h
@@ -30,14 +30,13 @@ namespace NovelRT::Ecs
             "Component type must be trivially copyable for use with a ComponentTypeId. See the documentation for "
             "more information.");
 
+        static AtomFactory& _componentTypeIdFactory = AtomFactoryDatabase::GetFactory("ComponentTypeId");
+
         auto& componentTypeId = GetComponentTypeIds()[typeid(TComponent)];
 
         if (componentTypeId == Atom(0))
         {
-            // TODO: Two threads each trying to get a component type ID for T
-            // at the first time can race here. We'll either want to lock or
-            // do some kind of interlocked compare-exchange here to make it atomic
-            componentTypeId = Atom::GetNextComponentTypeId();
+            componentTypeId = _componentTypeIdFactory.GetNext();
         }
         return componentTypeId;
     }

--- a/include/NovelRT/Ecs/Graphics/DefaultRenderingSystem.h
+++ b/include/NovelRT/Ecs/Graphics/DefaultRenderingSystem.h
@@ -20,7 +20,8 @@ namespace NovelRT::Ecs::Graphics
     {
     private:
         inline static AtomFactory& _textureIdFactory = AtomFactoryDatabase::GetFactory("TextureId");
-        inline static AtomFactory& _ecsPrimitiveInfoConfigurationIdFactory = AtomFactoryDatabase::GetFactory("EcsPrimitiveInfoConfigurationId");
+        inline static AtomFactory& _ecsPrimitiveInfoConfigurationIdFactory =
+            AtomFactoryDatabase::GetFactory("EcsPrimitiveInfoConfigurationId");
 
         Utilities::Lazy<NovelRT::Graphics::GraphicsResourceManager> _resourceManager;
         std::shared_ptr<PluginManagement::IGraphicsPluginProvider> _graphicsPluginProvider;

--- a/include/NovelRT/Ecs/Graphics/DefaultRenderingSystem.h
+++ b/include/NovelRT/Ecs/Graphics/DefaultRenderingSystem.h
@@ -19,6 +19,9 @@ namespace NovelRT::Ecs::Graphics
     class DefaultRenderingSystem : public IEcsSystem
     {
     private:
+        inline static AtomFactory& _textureIdFactory = AtomFactoryDatabase::GetFactory("TextureId");
+        inline static AtomFactory& _ecsPrimitiveInfoConfigurationIdFactory = AtomFactoryDatabase::GetFactory("EcsPrimitiveInfoConfigurationId");
+
         Utilities::Lazy<NovelRT::Graphics::GraphicsResourceManager> _resourceManager;
         std::shared_ptr<PluginManagement::IGraphicsPluginProvider> _graphicsPluginProvider;
         std::shared_ptr<PluginManagement::IWindowingPluginProvider> _windowingPluginProvider;

--- a/include/NovelRT/Utilities/Event.h
+++ b/include/NovelRT/Utilities/Event.h
@@ -14,6 +14,7 @@ namespace NovelRT::Utilities
     private:
         Atom _id;
         std::function<void(TArgs...)> _function;
+        inline static AtomFactory& _eventIdFactory = AtomFactoryDatabase::GetFactory("EventHandler");
 
     public:
         EventHandler() : EventHandler(nullptr)
@@ -21,7 +22,7 @@ namespace NovelRT::Utilities
         }
 
         explicit EventHandler(const std::function<void(TArgs...)>& function)
-            : _id((function != nullptr) ? Atom::GetNextEventHandlerId() : Atom()), _function(function)
+            : _id((function != nullptr) ? _eventIdFactory.GetNext() : Atom()), _function(function)
         {
         }
 

--- a/src/NovelRT/Atom.cpp
+++ b/src/NovelRT/Atom.cpp
@@ -5,10 +5,10 @@
 #ifndef __TBB_PREVIEW_MUTEXES
 #define __TBB_PREVIEW_MUTEXES 1
 #endif
+#include <NovelRT/Exceptions/Exceptions.h>
+#include <mutex>
 #include <oneapi/tbb/mutex.h>
 #include <unordered_map>
-#include <mutex>
-#include <NovelRT/Exceptions/Exceptions.h>
 
 namespace NovelRT
 {
@@ -24,8 +24,7 @@ namespace NovelRT
     {
     }
 
-    AtomFactory::AtomFactory(Atom startingValue) noexcept :
-    _currentValue(startingValue), _moved(false)
+    AtomFactory::AtomFactory(Atom startingValue) noexcept : _currentValue(startingValue), _moved(false)
     {
     }
 
@@ -56,7 +55,8 @@ namespace NovelRT
     {
         if (_moved)
         {
-            throw Exceptions::InvalidOperationException("AtomFactory object has been moved. It is invalid to get the next atomic value from a factory in this state.");
+            throw Exceptions::InvalidOperationException("AtomFactory object has been moved. It is invalid to get the "
+                                                        "next atomic value from a factory in this state.");
         }
 
         auto value = ++_currentValue;
@@ -67,7 +67,8 @@ namespace NovelRT
     {
         if (_moved)
         {
-            throw Exceptions::InvalidOperationException("AtomFactory object has been moved. It is invalid to directly set the current atomic value from a factory in this state.");
+            throw Exceptions::InvalidOperationException("AtomFactory object has been moved. It is invalid to directly "
+                                                        "set the current atomic value from a factory in this state.");
         }
 
         _currentValue = value;

--- a/src/NovelRT/Ecs/Catalogue.cpp
+++ b/src/NovelRT/Ecs/Catalogue.cpp
@@ -15,7 +15,9 @@ namespace NovelRT::Ecs
 
     EntityId Catalogue::CreateEntity() noexcept
     {
-        EntityId returnId = Atom::GetNextEntityId();
+        static AtomFactory& _entityIdFactory = AtomFactoryDatabase::GetFactory("EntityId");
+
+        EntityId returnId = _entityIdFactory.GetNext();
         _createdEntitiesThisFrame.push_back(returnId);
         return returnId;
     }

--- a/src/NovelRT/Ecs/ComponentCache.cpp
+++ b/src/NovelRT/Ecs/ComponentCache.cpp
@@ -28,7 +28,9 @@ namespace NovelRT::Ecs
         const void* deleteInstructionState,
         const std::function<void(void*, const void*, size_t)>& componentUpdateLogic)
     {
-        ComponentTypeId returnId = Atom::GetNextComponentTypeId();
+        static AtomFactory& _componentTypeIdFactory = AtomFactoryDatabase::GetFactory("ComponentTypeId");
+
+        ComponentTypeId returnId = _componentTypeIdFactory.GetNext();
         std::shared_ptr<ComponentBufferMemoryContainer> ptr =
             CreateContainer(sizeOfDataType, deleteInstructionState, componentUpdateLogic);
         _bufferPrepEvent += [ptr](auto vec) { ptr->PrepContainerForFrame(vec); };

--- a/src/NovelRT/Ecs/Input/InputSystem.cpp
+++ b/src/NovelRT/Ecs/Input/InputSystem.cpp
@@ -58,8 +58,10 @@ namespace NovelRT::Ecs::Input
 
     void InputSystem::AddMapping(std::string name, std::string id)
     {
+        static AtomFactory& _entityIdFactory = AtomFactoryDatabase::GetFactory("EntityId");
+
         unused(_device->AddInputAction(name, id));
-        auto entityMappingId = NovelRT::Atom::GetNextEntityId();
+        auto entityMappingId = _entityIdFactory.GetNext();
         _inputMap.insert(std::pair<std::string, NovelRT::Atom>(name, entityMappingId));
         _logger.logDebug("Input Mapped: \"{}\" to {}", name, id);
     }

--- a/src/NovelRT/Ecs/SystemScheduler.cpp
+++ b/src/NovelRT/Ecs/SystemScheduler.cpp
@@ -75,7 +75,9 @@ namespace NovelRT::Ecs
 
     void SystemScheduler::RegisterSystem(std::function<void(Timing::Timestamp, Catalogue)> systemUpdatePtr) noexcept
     {
-        Atom id = Atom::GetNextSystemId();
+        static AtomFactory& systemIdFactory = AtomFactoryDatabase::GetFactory("SystemId");
+
+        Atom id = systemIdFactory.GetNext();
         _systems.emplace(id, systemUpdatePtr);
         _systemIds.emplace_back(id);
     }

--- a/tests/NovelRT.Tests/Ecs/EntityGraphViewTest.cpp
+++ b/tests/NovelRT.Tests/Ecs/EntityGraphViewTest.cpp
@@ -19,11 +19,13 @@ public:
 protected:
     void SetUp() override
     {
+        static NovelRT::AtomFactory& _entityIdFactory = NovelRT::AtomFactoryDatabase::GetFactory("EntityId");
+
         componentCache = ComponentCache(1);
         componentCache.RegisterComponentType(LinkedEntityListNodeComponent{false});
         componentCache.RegisterComponentType(EntityGraphComponent{false});
-        parentId = NovelRT::Atom::GetNextEntityId();
-        childId = NovelRT::Atom::GetNextEntityId();
+        parentId = _entityIdFactory.GetNext();
+        childId = _entityIdFactory.GetNext();
         entityCache = EntityCache(1);
         componentCache.GetComponentBuffer<EntityGraphComponent>().PushComponentUpdateInstruction(
             0, parentId, EntityGraphComponent{true, max, childId});

--- a/tests/NovelRT.Tests/Ecs/LinkedEntityListViewTest.cpp
+++ b/tests/NovelRT.Tests/Ecs/LinkedEntityListViewTest.cpp
@@ -18,9 +18,11 @@ public:
 protected:
     void SetUp() override
     {
+        static NovelRT::AtomFactory& _entityIdFactory = NovelRT::AtomFactoryDatabase::GetFactory("EntityId");
+
         componentCache = ComponentCache(1);
         componentCache.RegisterComponentType(LinkedEntityListNodeComponent{false});
-        rootListId = NovelRT::Atom::GetNextEntityId();
+        rootListId = _entityIdFactory.GetNext();
         componentCache.GetComponentBuffer<LinkedEntityListNodeComponent>().PushComponentUpdateInstruction(
             0, rootListId, LinkedEntityListNodeComponent());
         entityCache = EntityCache(1);

--- a/tests/NovelRT.Tests/Ecs/SystemSchedulerTest.cpp
+++ b/tests/NovelRT.Tests/Ecs/SystemSchedulerTest.cpp
@@ -19,6 +19,7 @@ public:
     std::function<void(Timestamp, Catalogue)> sysOne;
     std::function<void(Timestamp, Catalogue)> sysTwo;
     std::function<void(Timestamp, Catalogue)> sysThree;
+    inline static NovelRT::AtomFactory& entityIdFactory = NovelRT::AtomFactoryDatabase::GetFactory("EntityId");
 
 protected:
     void SetUp() override
@@ -71,7 +72,7 @@ TEST_F(SystemSchedulerTest, IndependentSystemsObtainValidCatalogue)
 {
     bool isEqual = false;
 
-    EntityId entity = Atom::GetNextEntityId();
+    EntityId entity = entityIdFactory.GetNext();
     scheduler->GetComponentCache().RegisterComponentType<int32_t>(-1);
     scheduler->GetComponentCache().GetComponentBuffer<int32_t>().PushComponentUpdateInstruction(0, entity, 10);
     scheduler->ExecuteIteration(Timestamp(0));
@@ -99,7 +100,7 @@ TEST_F(SystemSchedulerTest, IndependentSystemsCanHandleRemainderWithThreeThreads
     scheduler = new SystemScheduler(3);
     scheduler->SpinThreads();
 
-    EntityId entity = Atom::GetNextEntityId();
+    EntityId entity = entityIdFactory.GetNext();
 
     scheduler->GetComponentCache().RegisterComponentType<int32_t>(-1);
     scheduler->GetComponentCache().GetComponentBuffer<int32_t>().PushComponentUpdateInstruction(0, entity, 10);
@@ -160,7 +161,7 @@ TEST_F(SystemSchedulerTest, IndependentSystemsCanHandleRemainderWithThirtyTwoThr
     scheduler = new SystemScheduler(32);
     scheduler->SpinThreads();
 
-    EntityId entity = Atom::GetNextEntityId();
+    EntityId entity = entityIdFactory.GetNext();
 
     scheduler->GetComponentCache().RegisterComponentType<int32_t>(-1);
     scheduler->GetComponentCache().GetComponentBuffer<int32_t>().PushComponentUpdateInstruction(0, entity, 10);
@@ -216,7 +217,7 @@ TEST_F(SystemSchedulerTest, IndependentSystemsCanHandleRemainderWithThirtyTwoThr
 
 TEST_F(SystemSchedulerTest, IndependentSystemsCanHandleManySystems)
 {
-    EntityId entity = Atom::GetNextEntityId();
+    EntityId entity = entityIdFactory.GetNext();
 
     scheduler->GetComponentCache().RegisterComponentType<int32_t>(-1);
     scheduler->GetComponentCache().GetComponentBuffer<int32_t>().PushComponentUpdateInstruction(0, entity, 10);

--- a/tests/NovelRT.Tests/Interop/Ecs/NrtSystemSchedulerTest.cpp
+++ b/tests/NovelRT.Tests/Interop/Ecs/NrtSystemSchedulerTest.cpp
@@ -21,6 +21,7 @@ public:
     std::function<void(Timestamp, Catalogue)> sysOne;
     std::function<void(Timestamp, Catalogue)> sysTwo;
     std::function<void(Timestamp, Catalogue)> sysThree;
+    inline static NovelRT::AtomFactory& entityIdFactory = NovelRT::AtomFactoryDatabase::GetFactory("EntityId");
 
 protected:
     void SetUp() override
@@ -72,7 +73,7 @@ TEST_F(InteropSystemSchedulerTest, IndependentSystemsCanModifyValues)
 
 TEST_F(InteropSystemSchedulerTest, IndependentSystemsObtainValidCatalogue)
 {
-    EntityId entity = Atom::GetNextEntityId();
+    EntityId entity = entityIdFactory.GetNext();
 
     auto cache = Nrt_SystemScheduler_GetComponentCache(scheduler);
     reinterpret_cast<SystemScheduler*>(scheduler)->GetComponentCache().RegisterComponentType<int32_t>(-1);
@@ -122,7 +123,7 @@ TEST_F(InteropSystemSchedulerTest, IndependentSystemsCanHandleRemainderWithThree
     cppScheduler->RegisterSystem(sysThree);
     scheduler = reinterpret_cast<NrtSystemSchedulerHandle>(cppScheduler);
 
-    EntityId entity = Atom::GetNextEntityId();
+    EntityId entity = entityIdFactory.GetNext();
 
     auto cache = Nrt_SystemScheduler_GetComponentCache(scheduler);
     reinterpret_cast<SystemScheduler*>(scheduler)->GetComponentCache().RegisterComponentType<int32_t>(-1);
@@ -214,7 +215,7 @@ TEST_F(InteropSystemSchedulerTest, IndependentSystemsCanHandleRemainderWithThree
 
 TEST_F(InteropSystemSchedulerTest, IndependentSystemsCanHandleManySystems)
 {
-    EntityId entity = Atom::GetNextEntityId();
+    EntityId entity = entityIdFactory.GetNext();
 
     auto cache = Nrt_SystemScheduler_GetComponentCache(scheduler);
     reinterpret_cast<SystemScheduler*>(scheduler)->GetComponentCache().RegisterComponentType<int32_t>(-1);


### PR DESCRIPTION
This PR reworks our existing static factory methods for generating atomic IDs for things into an actual engine feature.

The main motivation behind this change is that the existing factory methods are restrictive, not even technically supposed to be exposed to the public API, and are just messy to maintain. As such I have just reworked it into a supported API.

I am unsure if I need this for the upcoming engine persistence features to work but from some of my very rough plans it might be a possibility - so future changes I make for persistence will be based off this just in case.

Resolves #249 - albeit in a different way than I had originally intended.