### PR TITLE
Static link from-source build of libpng via FetchContent.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,7 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 
+### generic cache folders e.g. neovim ###
+.cache/*
+
 # End of https://www.gitignore.io/api/c++,cmake,clion

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,6 +8,7 @@ class NovelRTConan(ConanFile):
     description = "A cross-platform 2D game engine accompanied by a strong toolset for visual novels."
     settings = "os", "compiler", "build_type", "arch"
     requires = [
+        ("zlib/1.2.12"),
         ("freetype/2.10.1"),
         ("libsndfile/1.0.30"),
         ("openal/1.21.1"),

--- a/internal/CMakeLists.txt
+++ b/internal/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(glfw)
 add_subdirectory(glm)
 add_subdirectory(GSL)
 add_subdirectory(jsoncons)
+add_subdirectory(libpng)
 add_subdirectory(spdlog)
 
 if(NOVELRT_BUILD_TESTS)

--- a/internal/libpng/CMakeLists.txt
+++ b/internal/libpng/CMakeLists.txt
@@ -1,0 +1,21 @@
+include(FetchContent)
+
+FIND_PACKAGE(ZLIB)
+
+FetchContent_Declare(libpng
+        URL https://github.com/glennrp/libpng/archive/refs/tags/v1.6.35.zip 
+        URL_HASH SHA512=65df0c2befa06d0b9ec0c6395a73987fb071754610d328b94ce01a6b8f7161c71ce97ddf0e0a8e28c2e50019a103368c4b4f0b63bd8cd75e168b32f940922d96 
+
+        PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+        TMP_DIR "${CMAKE_CURRENT_BINARY_DIR}/tmp"
+        STAMP_DIR "${CMAKE_CURRENT_BINARY_DIR}/stamp"
+        DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/dl"
+        SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/src"
+        SUBBUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/build"
+        BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/bin"
+        INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/inst"
+        LOG_DIR "${CMAKE_CURRENT_BINARY_DIR}/log"
+)
+
+set(PNG_SHARED OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(libpng)

--- a/internal/libpng/CMakeLists.txt
+++ b/internal/libpng/CMakeLists.txt
@@ -19,3 +19,5 @@ FetchContent_Declare(libpng
 
 set(PNG_SHARED OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(libpng)
+
+set_propert(TARGET png_static PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/internal/libpng/CMakeLists.txt
+++ b/internal/libpng/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(FetchContent)
 
-FIND_PACKAGE(ZLIB)
+FIND_PACKAGE(ZLIB REQUIRED)
 
 FetchContent_Declare(libpng
         URL https://github.com/glennrp/libpng/archive/refs/tags/v1.6.35.zip 

--- a/internal/libpng/CMakeLists.txt
+++ b/internal/libpng/CMakeLists.txt
@@ -20,4 +20,4 @@ FetchContent_Declare(libpng
 set(PNG_SHARED OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(libpng)
 
-set_propert(TARGET png_static PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET png_static PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/src/NovelRT/CMakeLists.txt
+++ b/src/NovelRT/CMakeLists.txt
@@ -4,7 +4,6 @@ find_package(Freetype ${NOVELRT_FREETYPE_VERSION} REQUIRED)
 find_package(Ogg ${NOVELRT_OGG_VERSION} REQUIRED)
 find_package(OpenAL ${NOVELRT_OPENAL_VERSION} REQUIRED)
 find_package(Opus ${NOVELRT_Opus_VERSION} REQUIRED)
-find_package(PNG ${NOVELRT_PNG_VERSION} REQUIRED)
 find_package(SndFile ${NOVELRT_SNDFILE_VERISON} REQUIRED)
 find_package(TBB ${NOVELRT_ONETBB_VERSION} REQUIRED)
 find_package(Vorbis ${NOVELRT_VORBIS_VERSION} REQUIRED)
@@ -148,7 +147,7 @@ target_link_libraries(Engine
     Ogg::Ogg
     OpenAL::OpenAL
     Opus::Opus
-    PNG::PNG
+    png_static
     SndFile::SndFile
     spdlog
     TBB::TBB


### PR DESCRIPTION
This resolves libpng being a conan dependency. However I have had to temporarily add zlib to the conanfile.py because the zlib cmakelists is actually a spawn of satan and I couldn't get it to work in time for this PR - so the list of dependencies to knock off the conanfile hasn't actually changed.