### PR TITLE
Fixed MacOs Glfw SigAbort when creating a window

### DIFF
--- a/src/NovelRT/Windowing/Glfw/GlfwWindowingDevice.cpp
+++ b/src/NovelRT/Windowing/Glfw/GlfwWindowingDevice.cpp
@@ -49,10 +49,10 @@ namespace NovelRT::Windowing::Glfw
             throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", std::string(output));
         }
 
-        #ifndef __APPLE__
-            glfwSetWindowAttrib(window, GLFW_VISIBLE, GLFW_TRUE);
-        #endif
-        
+#ifndef __APPLE__
+        glfwSetWindowAttrib(window, GLFW_VISIBLE, GLFW_TRUE);
+#endif
+
         glfwSetWindowAttrib(window, GLFW_RESIZABLE, windowMode == NovelRT::Windowing::WindowMode::Windowed);
         glfwSetWindowUserPointer(window, this);
 
@@ -74,24 +74,18 @@ namespace NovelRT::Windowing::Glfw
         auto extensions = glfwGetRequiredInstanceExtensions(&extensionCount);
         if (extensionCount == 0)
         {
-           const char* output = nullptr;
-           glfwGetError(&output);
-           if(output != nullptr)
-           {
+            const char* output = nullptr;
+            glfwGetError(&output);
+            if (output != nullptr)
+            {
                 throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", std::string(output));
-           }
-           else
-           {
-               throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", "Attempting to fetch the required Vulkan extensions failed with a count of zero.");
-           }
-           else
-           {
-               throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", "Attempting to fetch the required Vulkan extensions failed with a count of zero.");
-           }
-           else
-           {
-               throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", "Attempting to fetch the required Vulkan extensions failed with a count of zero.");
-           }
+            }
+            else
+            {
+                throw Exceptions::InitialisationFailureException(
+                    "GLFW3 failed to initialise.",
+                    "Attempting to fetch the required Vulkan extensions failed with a count of zero.");
+            }
         }
 
         for (size_t i = 0; i < extensionCount; i++)

--- a/src/NovelRT/Windowing/Glfw/GlfwWindowingDevice.cpp
+++ b/src/NovelRT/Windowing/Glfw/GlfwWindowingDevice.cpp
@@ -80,6 +80,10 @@ namespace NovelRT::Windowing::Glfw
            {
                 throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", std::string(output));
            }
+           else
+           {
+               throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", "Attempting to fetch the required Vulkan extensions failed with a count of zero.");
+           }
         }
 
         for (size_t i = 0; i < extensionCount; i++)

--- a/src/NovelRT/Windowing/Glfw/GlfwWindowingDevice.cpp
+++ b/src/NovelRT/Windowing/Glfw/GlfwWindowingDevice.cpp
@@ -88,6 +88,10 @@ namespace NovelRT::Windowing::Glfw
            {
                throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", "Attempting to fetch the required Vulkan extensions failed with a count of zero.");
            }
+           else
+           {
+               throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", "Attempting to fetch the required Vulkan extensions failed with a count of zero.");
+           }
         }
 
         for (size_t i = 0; i < extensionCount; i++)

--- a/src/NovelRT/Windowing/Glfw/GlfwWindowingDevice.cpp
+++ b/src/NovelRT/Windowing/Glfw/GlfwWindowingDevice.cpp
@@ -84,6 +84,10 @@ namespace NovelRT::Windowing::Glfw
            {
                throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", "Attempting to fetch the required Vulkan extensions failed with a count of zero.");
            }
+           else
+           {
+               throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", "Attempting to fetch the required Vulkan extensions failed with a count of zero.");
+           }
         }
 
         for (size_t i = 0; i < extensionCount; i++)

--- a/src/NovelRT/Windowing/Glfw/GlfwWindowingDevice.cpp
+++ b/src/NovelRT/Windowing/Glfw/GlfwWindowingDevice.cpp
@@ -49,7 +49,10 @@ namespace NovelRT::Windowing::Glfw
             throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", std::string(output));
         }
 
-        glfwSetWindowAttrib(window, GLFW_VISIBLE, GLFW_TRUE);
+        #ifndef __APPLE__
+            glfwSetWindowAttrib(window, GLFW_VISIBLE, GLFW_TRUE);
+        #endif
+        
         glfwSetWindowAttrib(window, GLFW_RESIZABLE, windowMode == NovelRT::Windowing::WindowMode::Windowed);
         glfwSetWindowUserPointer(window, this);
 
@@ -71,9 +74,12 @@ namespace NovelRT::Windowing::Glfw
         auto extensions = glfwGetRequiredInstanceExtensions(&extensionCount);
         if (extensionCount == 0)
         {
-            const char* output = nullptr;
-            glfwGetError(&output);
-            throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", std::string(output));
+           const char* output = nullptr;
+           glfwGetError(&output);
+           if(output != nullptr)
+           {
+                throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", std::string(output));
+           }
         }
 
         for (size_t i = 0; i < extensionCount; i++)


### PR DESCRIPTION
Due to weirdness in the macOs system, when attempting to create a window it will return 0 extensions, which we had labeled as an error earlier. Now that we have fixed this issue we also ran into the problem of adding window attributes mac did not like. Added an ifdef and a nullptr check to solve the issues.
NOTE:: THIS DOES NOT SOLVE THE PROBLEM OF CONAN NOT PROVIDING A PROPER VULKAN LOADER FOR MACOS!!