### PR TITLE
Fix a Vulkan race condition between the swapchain and command buffer

### DIFF
--- a/src/NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.cpp
+++ b/src/NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.cpp
@@ -351,6 +351,7 @@ namespace NovelRT::Graphics::Vulkan
             throw std::runtime_error("Failed to acquire next VkImage! Reason: " +
                                      std::to_string(acquireNextImageResult));
         }
+        presentCompletionGraphicsFence->Wait();
 
         if (!_isAttachedToResizeEvent)
         {
@@ -525,6 +526,7 @@ namespace NovelRT::Graphics::Vulkan
             throw std::runtime_error("Failed to acquire next VkImage! Reason: " +
                                      std::to_string(acquireNextImageResult));
         }
+        presentCompletionGraphicsFence->Wait();
 
         _contextIndex = contextIndex;
     }


### PR DESCRIPTION
There was a race condition between `vkAcquireNextImageKHR` and `vkQueueSubmit` where the image may not have been "acquired" (and therefore may still be in use by the device) before new draws were made to it.

This is a minimal fix to ensure that the race doesn't exist. Ideally we eventually change these waits to happen in the "correct" places (e.g. the `presentCompletionGraphicsFence` should be waited just before `vkQueueSubmit` and `executeGraphicsFence` should be waited just before `vkQueuePresentKHR`). Optionally this could be done using the semaphores instead of full fences.