### PR TITLE
Make internal methods public in the Resourceloader

### DIFF
--- a/include/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.h
@@ -15,11 +15,9 @@ namespace NovelRT::ResourceManagement::Desktop
     private:
         LoggingService _logger;
 
-    protected:
-        [[nodiscard]] TextureMetadata LoadTexture(std::filesystem::path filePath) final;
-        [[nodiscard]] std::vector<uint8_t> LoadShaderSourceInternal(std::filesystem::path filePath) final;
-
     public:
+        [[nodiscard]] TextureMetadata LoadTextureFromFile(std::filesystem::path filePath) final;
+        [[nodiscard]] std::vector<uint8_t> LoadShaderSource(std::filesystem::path filePath) final;
         [[nodiscard]] BinaryPackage LoadPackage(std::filesystem::path filePath) final;
         void SavePackage(std::filesystem::path filePath, const BinaryPackage& package) final;
         ~DesktopResourceLoader() final = default;

--- a/include/NovelRT/ResourceManagement/ResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/ResourceLoader.h
@@ -15,11 +15,6 @@ namespace NovelRT::ResourceManagement
     protected:
         std::filesystem::path _resourcesRootDirectory = Utilities::Misc::getExecutableDirPath() / "Resources";
 
-        [[nodiscard]] virtual TextureMetadata LoadTexture(
-            std::filesystem::path filePath) = 0; // TODO: I've realised these should probably be overloads, not internal
-                                                 // methods. Monke brain. :(
-        [[nodiscard]] virtual std::vector<uint8_t> LoadShaderSourceInternal(std::filesystem::path filePath) = 0;
-
     public:
         [[nodiscard]] inline std::filesystem::path& ResourcesRootDirectory() noexcept
         {
@@ -31,16 +26,27 @@ namespace NovelRT::ResourceManagement
             return _resourcesRootDirectory;
         }
 
-        [[nodiscard]] inline TextureMetadata LoadTextureFromFile(const std::string& fileName)
-        {
-            return LoadTexture(_resourcesRootDirectory / "Images" /
-                               fileName); // TODO: This should probably either be textures or sprites, not image? Thonk.
-        }
+        /**
+         * @brief Loads texture from file on given path.
+         *
+         * Path can both be relative as well as absolute.
+         * When using relative path it will look in the Resources + Images directory
+         *
+         * @param filePath Relative or absolute path to the texture
+         * @return TextureMetadata of the file that was requested to load
+         */
+        [[nodiscard]] virtual TextureMetadata LoadTextureFromFile(std::filesystem::path filePath) = 0;
 
-        [[nodiscard]] inline std::vector<uint8_t> LoadShaderSource(const std::string& fileName)
-        {
-            return LoadShaderSourceInternal(_resourcesRootDirectory / "Shaders" / fileName);
-        }
+        /**
+         * @brief Loads shader from file on given path.
+         *
+         * Path can both be relative as well as absolute.
+         * When using relative path it will look in the Resources + Shaders directory
+         *
+         * @param filePath Relative or absolute path to the texture
+         * @return TextureMetadata of the file that was requested to load
+         */
+        [[nodiscard]] virtual std::vector<uint8_t> LoadShaderSource(std::filesystem::path filePath) = 0;
 
         [[nodiscard]] virtual BinaryPackage LoadPackage(std::filesystem::path fileName) = 0;
 

--- a/include/NovelRT/ResourceManagement/ResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/ResourceLoader.h
@@ -34,6 +34,7 @@ namespace NovelRT::ResourceManagement
          *
          * @param filePath Relative or absolute path to the texture.
          * @returns TextureMetadata The texture data contained in the file.
+         * @exception NovelRT::Exceptions::FileNotFoundException if there is no file at the specified location.
          */
         [[nodiscard]] virtual TextureMetadata LoadTextureFromFile(std::filesystem::path filePath) = 0;
 
@@ -45,6 +46,7 @@ namespace NovelRT::ResourceManagement
          *
          * @param filePath Relative or absolute path to the shader.
          * @returns std::vector<uint8_t> Shader data as a memory block that was contained in the file.
+         * @exception NovelRT::Exceptions::FileNotFoundException if there is no file at the specified location.
          */
         [[nodiscard]] virtual std::vector<uint8_t> LoadShaderSource(std::filesystem::path filePath) = 0;
 

--- a/include/NovelRT/ResourceManagement/ResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/ResourceLoader.h
@@ -27,24 +27,24 @@ namespace NovelRT::ResourceManagement
         }
 
         /**
-         * @brief Loads texture from file on given path.
+         * @brief Loads a texture from a file on a given path.
          *
-         * Path can both be relative as well as absolute.
-         * When using relative path it will look in the Resources + Images directory
+         * The path can be either relative or absolute.
+         * When using a relative path it will look in the Resources/Images directory.
          *
-         * @param filePath Relative or absolute path to the texture
-         * @return TextureMetadata of the file that was requested to load
+         * @param filePath Relative or absolute path to the texture.
+         * @returns TextureMetadata The texture data contained in the file.
          */
         [[nodiscard]] virtual TextureMetadata LoadTextureFromFile(std::filesystem::path filePath) = 0;
 
         /**
-         * @brief Loads shader from file on given path.
+         * @brief Loads shader from a file on a given path.
          *
-         * Path can both be relative as well as absolute.
-         * When using relative path it will look in the Resources + Shaders directory
+         * The path can be either relative or absolute.
+         * When using a relative path it will look in the Resources/Shaders directory.
          *
-         * @param filePath Relative or absolute path to the texture
-         * @return TextureMetadata of the file that was requested to load
+         * @param filePath Relative or absolute path to the shader.
+         * @returns std::vector<uint8_t> Shader data as a memory block that was contained in the file.
          */
         [[nodiscard]] virtual std::vector<uint8_t> LoadShaderSource(std::filesystem::path filePath) = 0;
 

--- a/src/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.cpp
+++ b/src/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.cpp
@@ -5,8 +5,13 @@
 
 namespace NovelRT::ResourceManagement::Desktop
 {
-    TextureMetadata DesktopResourceLoader::LoadTexture(std::filesystem::path filePath)
+    TextureMetadata DesktopResourceLoader::LoadTextureFromFile(std::filesystem::path filePath)
     {
+        if (filePath.is_relative())
+        {
+            filePath = _resourcesRootDirectory / "Images" / filePath;
+        }
+
         std::string filePathStr = filePath.string();
         FILE* cFile;
 #if defined(__STDC_LIB_EXT1__) || defined(_MSC_VER)
@@ -143,8 +148,13 @@ namespace NovelRT::ResourceManagement::Desktop
         return TextureMetadata{returnImage, data.width, data.height, finalLength};
     }
 
-    std::vector<uint8_t> DesktopResourceLoader::LoadShaderSourceInternal(std::filesystem::path filePath)
+    std::vector<uint8_t> DesktopResourceLoader::LoadShaderSource(std::filesystem::path filePath)
     {
+        if (filePath.is_relative())
+        {
+            filePath = _resourcesRootDirectory / "Shaders" / filePath;
+        }
+
         std::ifstream file(filePath.string(), std::ios::ate | std::ios::binary);
 
         if (!file.is_open())


### PR DESCRIPTION
This PR does a few things:

- Make internal methods public and rename them to not have a suffix anymore
- Remove the old public methods that would implicitly use a preset folder
- The implementation of the abstract methods now prefixes the default folder if somebody uses a relative path

This makes the UX cleaner by only having 1 method instead of an overload and with added documentation is clear and easy to use.

Would solve Issue #444 