### PR TITLE
fix(CI): Update macOS runners to macOS Big Sur

### DIFF
--- a/.github/workflows/build-system.yml
+++ b/.github/workflows/build-system.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         configuration: [RelWithDebInfo, Release]
-        os: [windows-latest, windows-2019, ubuntu-latest, macos-10.15]
+        os: [windows-latest, windows-2019, ubuntu-latest, macos-11]
         include:
         - os: ubuntu-latest
           container: novelrt/novelrt-build:latest
@@ -27,13 +27,13 @@ jobs:
           name: Windows - Visual Studio 2019
         - os: windows-latest
           name: Windows - Visual Studio 2022
-        - os: macos-10.15
-          name: macOS 10.15 - Apple-Clang 12
+        - os: macos-11
+          name: macOS 11 - Apple-Clang 12
           configuration: Debug
-        - os: macos-10.15
+        - os: macos-11
           name: macOS 10.15 - Apple-Clang 12
         exclude:
-        - os: macos-10.15
+        - os: macos-11
           configuration: RelWithDebInfo
 
     steps:

--- a/.github/workflows/build-system.yml
+++ b/.github/workflows/build-system.yml
@@ -28,10 +28,10 @@ jobs:
         - os: windows-latest
           name: Windows - Visual Studio 2022
         - os: macos-11
-          name: macOS 11 - Apple-Clang 12
+          name: macOS 11 - Apple-Clang 13
           configuration: Debug
         - os: macos-11
-          name: macOS 10.15 - Apple-Clang 12
+          name: macOS 11 - Apple-Clang 13
         exclude:
         - os: macos-11
           configuration: RelWithDebInfo


### PR DESCRIPTION
Self-titled - GH has deprecated the macOS Catalina environments and we've been hit with a few brownouts.
This will resolve them and stop other issues from occurring in CI.