### PR TITLE
Add Issue and Pull Request Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-**_Note: for support questions, please use the #engine-user-help channel in our [Discord](https://discord.com/invite/V7SgCkm) or [create a discussion](https://github.com/novelrt/NovelRT/discussions/new). This repository's issues are reserved for feature requests and bug reports._**
+**_Note: for support questions, please use the #engine-user-help channel in our [Discord](https://discord.novelrt.dev/) or [create a discussion](https://github.com/novelrt/NovelRT/discussions/new). This repository's issues are reserved for feature requests and bug reports._**
 
 **Describe the issue:**
 A clear and concise description of what the the current behaviour is.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Create a report to help us improve NovelRT
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**_Note: for support questions, please use the #engine-user-help channel in our [Discord](https://discord.com/invite/V7SgCkm) or [create a discussion](https://github.com/novelrt/NovelRT/discussions/new). This repository's issues are reserved for feature requests and bug reports._**
+
+**Describe the issue:**
+A clear and concise description of what the the current behaviour is.
+
+
+**Please provide the steps to reproduce if possible:**
+1. Clone the repo
+2. Switch to '...' branch
+3. Build with '...'
+4. Run '...'
+5. See error
+
+
+**Expected behaviour:**
+A clear and concise description of what you expected to happen.
+
+
+**Please tell us about your environment:**  
+  - Engine Version: [v0.00]
+  - Configuration: [Release | Debug | Other (please specify)]
+  - OS Version: [Windows 10 Version XXXX | Ubuntu 20.04 | macOS 12.0]
+  _If building from source_:
+  - Compiler Version: [ Clang 13 | AppleClang 13 | Visual Studio 2022 v17.3.0 ]
+  - Git fork/branch URL:
+
+
+**Additional context:**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-**_Note: for support questions, please use the #engine-user-help channel in our [Discord](https://discord.com/invite/V7SgCkm) or [create a discussion](https://github.com/novelrt/NovelRT/discussions/new). This repository's issues are reserved for feature requests and bug reports._**
+**_Note: for support questions, please use the #engine-user-help channel in our [Discord](https://discord.novelrt.dev/) or [create a discussion](https://github.com/novelrt/NovelRT/discussions/new). This repository's issues are reserved for feature requests and bug reports._**
 
 **What is the current behaviour?**
 A clear and concise description of what the current behaviour is.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+about: Suggest an idea for NovelRT
+title: ''
+labels: proposal
+assignees: ''
+
+---
+
+**_Note: for support questions, please use the #engine-user-help channel in our [Discord](https://discord.com/invite/V7SgCkm) or [create a discussion](https://github.com/novelrt/NovelRT/discussions/new). This repository's issues are reserved for feature requests and bug reports._**
+
+**What is the current behaviour?**
+A clear and concise description of what the current behaviour is.
+
+
+
+**What is the expected behaviour/change?**
+A clear and concise description of what you want to happen.
+
+
+
+**What is the motivation / use case for changing the behavior?**
+A clear and concise description as to why the change should occur.
+
+
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -24,8 +24,13 @@ A clear and concise description as to why the change should occur.
 
 
 
-**Describe alternatives you've considered**
+**Describe alternatives you've considered:**
 A clear and concise description of any alternative solutions or features you've considered.
+
+
+
+**Are there any potential roadblocks or challenges facing this change?**
+A clear and concise description of any issues that may prevent this change from being made, or that may need to be handled during implementation of this change.
 
 
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -34,5 +34,9 @@ A clear and concise description of any issues that may prevent this change from 
 
 
 
+**Are there any downsides to implementing this change?**
+A clear and concise description of any negative impacts that the change might bring about.
+
+
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+**Please check if the PR fulfills these requirements**
+- [ ] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Documentation has been added / updated (for bug fixes / features)
+
+
+**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+
+
+
+**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
+
+
+
+**What is the current behavior?** (You can also link to an open issue here)
+
+
+
+**What is the new behavior (if this is a feature change)?**
+
+
+
+**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
+
+
+
+**Other information**:


### PR DESCRIPTION
This should add the issue and pull request templates that we wanted as part of the Contributor PR #384

Essentially, any issues and PRs open _prior_ to this change will be okay, but we should expect as a whole that all future Issues go through the Bug Report / Feature Request issue types and the Pull Request template is populated when creating a PR.

Should possibly help with linking PRs to issues as well (maybe? hopefully? lol).