### PR TITLE
Changed cmake var used for builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WIN32)
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
 endif()
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 option(NOVELRT_BUILD_SAMPLES "Build NovelRT samples" ON)
 option(NOVELRT_BUILD_DOCUMENTATION "Build NovelRT documentation" ON)

--- a/doxygen/CMakeLists.txt
+++ b/doxygen/CMakeLists.txt
@@ -18,9 +18,9 @@ else()
 endif()
 
 set(DOCS_MAINPAGE
-        ${CMAKE_SOURCE_DIR}/README.md
-        ${CMAKE_SOURCE_DIR}/LICENCE.md
-        ${CMAKE_SOURCE_DIR}/CODE_OF_CONDUCT.md
+        ${PROJECT_SOURCE_DIR}/README.md
+        ${PROJECT_SOURCE_DIR}/LICENCE.md
+        ${PROJECT_SOURCE_DIR}/CODE_OF_CONDUCT.md
         )
 
 foreach(docFile ${DOCS_MAINPAGE})
@@ -67,5 +67,5 @@ doxygen_add_docs(Doxygen
         ${DOXYGEN_OUTPUT_DIRECTORY}/README.md
         ${DOXYGEN_OUTPUT_DIRECTORY}/CODE_OF_CONDUCT.md
         ${DOXYGEN_OUTPUT_DIRECTORY}/LICENCE.md
-        ${CMAKE_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/include
         )

--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -35,7 +35,7 @@ set_target_properties(Resources
 )
 
 install(
-  DIRECTORY ${CMAKE_SOURCE_DIR}/Resources/Shaders/
+  DIRECTORY ${PROJECT_SOURCE_DIR}/Resources/Shaders/
   DESTINATION bin/Resources/Shaders
   FILES_MATCHING PATTERN "*.spv"
 )

--- a/src/NovelRT.Interop/CMakeLists.txt
+++ b/src/NovelRT.Interop/CMakeLists.txt
@@ -54,7 +54,7 @@ set_property(TARGET Interop PROPERTY OUTPUT_NAME "$<IF:$<CONFIG:Release>,NovelRT
 target_compile_features(Interop PUBLIC cxx_std_17)
 target_include_directories(Interop
   PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 
@@ -106,7 +106,7 @@ install(
   RUNTIME DESTINATION bin
 )
 install(
-  DIRECTORY ${CMAKE_SOURCE_DIR}/include/NovelRT.Interop/
+  DIRECTORY ${PROJECT_SOURCE_DIR}/include/NovelRT.Interop/
   DESTINATION include/NovelRT.Interop
   FILES_MATCHING PATTERN "*.h"
 )

--- a/src/NovelRT/CMakeLists.txt
+++ b/src/NovelRT/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 target_compile_features(Engine PUBLIC cxx_std_17)
 target_include_directories(Engine
   PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${glm_SOURCE_DIR}>
     $<BUILD_INTERFACE:${GSL_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${stduuid_SOURCE_DIR}/include>
@@ -170,7 +170,7 @@ install(
 )
 #Workaround due to hierarchy destruction when installing by TARGETS
 install(
-  DIRECTORY ${CMAKE_SOURCE_DIR}/include/NovelRT/
+  DIRECTORY ${PROJECT_SOURCE_DIR}/include/NovelRT/
   DESTINATION include/NovelRT
   FILES_MATCHING PATTERN "*.h"
 )

--- a/tests/NovelRT.Tests/CMakeLists.txt
+++ b/tests/NovelRT.Tests/CMakeLists.txt
@@ -55,7 +55,7 @@ set(SOURCES
 )
 
 add_executable(Engine_Tests ${SOURCES})
-include(${CMAKE_SOURCE_DIR}/cmake/CopyBuildProducts.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/CopyBuildProducts.cmake)
 if(NOVELRT_BUILD_INTEROP)
   copy_build_products(Engine_Tests
     DEPENDENCY Engine


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Changes CMAKE_SOURCE_DIR to PROJECT_SOURCE_DIR in all CMakeLists.txt


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
Fixes #448 


**What is the current behavior?** (You can also link to an open issue here)
Build is OK


**What is the new behavior (if this is a feature change)?**
Build is still OK


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



**Other information**:
