### PR TITLE
Update "Build Docker Images" CI action

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,6 +1,7 @@
 name: Build Docker Images
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -13,14 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Build and push Linux docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           file: scripts/novelrt-build.linux.Dockerfile
-          tags:
-            - novelrt/novelrt-build:latest
+          tags: novelrt/novelrt-build:latest


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Updates the action to use v2 of the login action, v3 of the build image action, and corrects the tag as we are only specifying `latest`


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
Resolves #515 


**What is the current behavior?** (You can also link to an open issue here)
Action fails to start


**What is the new behavior (if this is a feature change)?**
Action should start and publish a new docker image successfully (as long as the Docker Hub secrets are properly assigned in the organization).


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
