### PR TITLE
Interim fix for Vulkan versioning

### DIFF
--- a/samples/AudioEcsSample/CMakeLists.txt
+++ b/samples/AudioEcsSample/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOVELRT_VULKAN_SDK)
-  find_dependency(Vulkan REQUIRED)
+  find_package(Vulkan REQUIRED)
 endif()
 
 set(SOURCES

--- a/samples/AudioEcsSample/CMakeLists.txt
+++ b/samples/AudioEcsSample/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOVELRT_VULKAN_SDK)
-  find_package(Vulkan REQUIRED)
+  find_package(Vulkan ${NOVELRT_VULKAN_VERSION} REQUIRED)
 endif()
 
 set(SOURCES

--- a/samples/EcsPipeline/CMakeLists.txt
+++ b/samples/EcsPipeline/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOVELRT_VULKAN_SDK)
-  find_dependency(Vulkan REQUIRED)
+  find_package(Vulkan ${NOVELRT_VULKAN_VERSION} REQUIRED)
 endif()
 
 set(SOURCES

--- a/samples/Experimental/VulkanRender/CMakeLists.txt
+++ b/samples/Experimental/VulkanRender/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOVELRT_VULKAN_SDK)
-  find_dependency(Vulkan REQUIRED)
+  find_package(Vulkan ${NOVELRT_VULKAN_VERSION} REQUIRED)
 endif()
 
 set(SOURCES

--- a/samples/FabulistTest/CMakeLists.txt
+++ b/samples/FabulistTest/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOVELRT_VULKAN_SDK)
-  find_dependency(Vulkan REQUIRED)
+  find_package(Vulkan ${NOVELRT_VULKAN_VERSION} REQUIRED)
 endif()
 set(SOURCES
   main.cpp

--- a/samples/InputEcsSample/CMakeLists.txt
+++ b/samples/InputEcsSample/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOVELRT_VULKAN_SDK)
-  find_dependency(Vulkan REQUIRED)
+  find_package(Vulkan ${NOVELRT_VULKAN_VERSION} REQUIRED)
 endif()
 
 set(SOURCES

--- a/samples/PersistenceSample/CMakeLists.txt
+++ b/samples/PersistenceSample/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOVELRT_VULKAN_SDK)
-  find_dependency(Vulkan REQUIRED)
+  find_package(Vulkan ${NOVELRT_VULKAN_VERSION} REQUIRED)
 endif()
 
 set(SOURCES

--- a/samples/UIEventExample/CMakeLists.txt
+++ b/samples/UIEventExample/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOVELRT_VULKAN_SDK)
-  find_dependency(Vulkan REQUIRED)
+  find_package(Vulkan ${NOVELRT_VULKAN_VERSION} REQUIRED)
 endif()
 
 set(SOURCES

--- a/src/NovelRT.Interop/CMakeLists.txt
+++ b/src/NovelRT.Interop/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOVELRT_VULKAN_SDK)
-  find_dependency(Vulkan REQUIRED)
+  find_package(Vulkan ${NOVELRT_VULKAN_VERSION} REQUIRED)
 endif()
 
 set(SOURCES

--- a/src/NovelRT/CMakeLists.txt
+++ b/src/NovelRT/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(NOVELRT_VULKAN_SDK)
-  include(CMakeFindDependencyMacro)
-  find_dependency(Vulkan REQUIRED)
+  #include(CMakeFindDependencyMacro)
+  find_package(Vulkan ${NOVELRT_VULKAN_VERSION} REQUIRED)
 endif()
 
 if(NOT DEFINED NOVELRT_LIB_SUFFIX)

--- a/src/NovelRT/CMakeLists.txt
+++ b/src/NovelRT/CMakeLists.txt
@@ -1,5 +1,4 @@
 if(NOVELRT_VULKAN_SDK)
-  #include(CMakeFindDependencyMacro)
   find_package(Vulkan ${NOVELRT_VULKAN_VERSION} REQUIRED)
 endif()
 

--- a/tests/NovelRT.Tests/CMakeLists.txt
+++ b/tests/NovelRT.Tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(GoogleTest)
 if(NOVELRT_VULKAN_SDK)
-  find_dependency(Vulkan REQUIRED)
+  find_package(Vulkan ${NOVELRT_VULKAN_VERSION} REQUIRED)
 endif()
 
 set(SOURCES


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes version handling for Vulkan SDK


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
Resolves #520



**What is the current behavior?** (You can also link to an open issue here)
Builds with any Vulkan version that is compatible with usage


**What is the new behavior (if this is a feature change)?**
Should fail to configure if Vulkan version is not identified as 1.3.211 or higher (and API compatible as far as CMake can tell)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

