### PR TITLE
Add fix for Wayland support in GLFW.

### DIFF
--- a/internal/glfw/CMakeLists.txt
+++ b/internal/glfw/CMakeLists.txt
@@ -22,7 +22,7 @@ set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
 
 if (UNIX AND NOT APPLE)
     message(STATUS "Linux detected, enabling Wayland support for GLFW.")
-    set(GLFW_BUILD_WAYLAND ON CACHE BOOL "" FORCE)
+    set(GLFW_USE_WAYLAND ON CACHE BOOL "" FORCE)
 endif()
 
 FetchContent_MakeAvailable(glfw)

--- a/internal/glfw/CMakeLists.txt
+++ b/internal/glfw/CMakeLists.txt
@@ -19,4 +19,10 @@ FetchContent_Declare(glfw
 set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+
+if (UNIX AND NOT APPLE)
+    message(STATUS "Linux detected, enabling Wayland support for GLFW.")
+    set(GLFW_BUILD_WAYLAND ON CACHE BOOL "" FORCE)
+endif()
+
 FetchContent_MakeAvailable(glfw)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change enables support for the Wayland windowing system inside our build of GLFW.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No issue to track for this bug.


**What is the current behavior?** (You can also link to an open issue here)
GLFW will compile for X11 only, causing wayland-only systems to fail.


**What is the new behavior (if this is a feature change)?**
Wayland-only systems should be able to use the GLFW windowing backend correctly.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
Documentation that directed this change can be found here: https://www.glfw.org/docs/latest/compile.html#compile_options_wayland
