### PR TITLE
Bump Vulkan SDK version

### DIFF
--- a/scripts/novelrt-build.linux.Dockerfile
+++ b/scripts/novelrt-build.linux.Dockerfile
@@ -9,7 +9,7 @@ RUN apt update \
     && wget -q -O - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add - \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main" | tee /etc/apt/sources.list.d/kitware.list > /dev/null \
-    && wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.211-focal.list https://packages.lunarg.com/vulkan/1.3.211/lunarg-vulkan-1.3.211-focal.list \
+    && wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.231-focal.list https://packages.lunarg.com/vulkan/1.3.231/lunarg-vulkan-1.3.231-focal.list \
     && apt update \
     && apt install -y \
         clang \


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bumps Dockerfile to include Vulkan SDK 1.3.231


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
N/A - Assistance PR for Install Targets


**What is the current behavior?** (You can also link to an open issue here)
Vulkan 1.3.211 is included in Linux Dockerfile


**What is the new behavior (if this is a feature change)?**
Vulkan 1.3.231 will be included as version for Vulkan SDK


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
