### PR TITLE
Prepare logger for C++ 20

### DIFF
--- a/include/NovelRT/LoggingService.h
+++ b/include/NovelRT/LoggingService.h
@@ -60,19 +60,19 @@ namespace NovelRT
 
         template<typename I, typename... IRest> void logInfo(I current, IRest... next) const
         {
-            _logger->info(current, std::forward<IRest>(next)...);
+            _logger->info(fmt::runtime(current), std::forward<IRest>(next)...);
         }
         template<typename E, typename... ERest> void logError(E current, ERest... next) const
         {
-            _logger->error(current, std::forward<ERest>(next)...);
+            _logger->error(fmt::runtime(current), std::forward<ERest>(next)...);
         }
         template<typename W, typename... WRest> void logWarning(W current, WRest... next) const
         {
-            _logger->warn(current, std::forward<WRest>(next)...);
+            _logger->warn(fmt::runtime(current), std::forward<WRest>(next)...);
         }
         template<typename D, typename... DRest> void logDebug(D current, DRest... next) const
         {
-            _logger->debug(current, std::forward<DRest>(next)...);
+            _logger->debug(fmt::runtime(current), std::forward<DRest>(next)...);
         }
     };
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It wraps the first argument of the logging function in `fmt::runtime()` to avoid issues with how FMT expects things in C++ 20

**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**

It partially resolves https://github.com/novelrt/NovelRT/issues/500 (NovelRT/LoggingService).

**What is the current behavior?** (You can also link to an open issue here)

The logger builds on C++ 17, but fails to build on C++ 20.

**What is the new behavior (if this is a feature change)?**

The logger builds on C++ 17 and C++ 20.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

I don't think it causes any breakage

**Other information**:
