### PR TITLE
Added mechanism to type pun semi-safe

### DIFF
--- a/include/NovelRT/Maths/GeoMatrix4x4F.h
+++ b/include/NovelRT/Maths/GeoMatrix4x4F.h
@@ -72,8 +72,8 @@ namespace NovelRT::Maths
          */
         inline void Translate(Maths::GeoVector3F vector)
         {
-            *reinterpret_cast<glm::mat4*>(this) =
-                glm::translate(*reinterpret_cast<glm::mat4*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec3>(vector));
+            *reinterpret_cast<glm::mat4*>(this) = glm::translate(*reinterpret_cast<glm::mat4*>(this),
+                                                                 NovelRT::Utilities::Misc::BitCast<glm::vec3>(vector));
         }
 
         /**
@@ -84,8 +84,9 @@ namespace NovelRT::Maths
          */
         inline void Rotate(float angleInRadians, GeoVector3F rotationAngle = GeoVector3F(0.0f, 0.0f, -1.0f))
         {
-            *reinterpret_cast<glm::mat4*>(this) = glm::rotate(*reinterpret_cast<glm::mat4*>(this), angleInRadians,
-                                                              NovelRT::Utilities::Misc::BitCast<glm::vec3>(rotationAngle));
+            *reinterpret_cast<glm::mat4*>(this) =
+                glm::rotate(*reinterpret_cast<glm::mat4*>(this), angleInRadians,
+                            NovelRT::Utilities::Misc::BitCast<glm::vec3>(rotationAngle));
         }
 
         /**
@@ -106,8 +107,8 @@ namespace NovelRT::Maths
          */
         inline void Scale(GeoVector3F scaleValue)
         {
-            *reinterpret_cast<glm::mat4*>(this) =
-                glm::scale(*reinterpret_cast<glm::mat4*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec3>(scaleValue));
+            *reinterpret_cast<glm::mat4*>(this) = glm::scale(*reinterpret_cast<glm::mat4*>(this),
+                                                             NovelRT::Utilities::Misc::BitCast<glm::vec3>(scaleValue));
         }
 
         /**

--- a/include/NovelRT/Maths/GeoMatrix4x4F.h
+++ b/include/NovelRT/Maths/GeoMatrix4x4F.h
@@ -73,7 +73,7 @@ namespace NovelRT::Maths
         inline void Translate(Maths::GeoVector3F vector)
         {
             *reinterpret_cast<glm::mat4*>(this) =
-                glm::translate(*reinterpret_cast<glm::mat4*>(this), *reinterpret_cast<glm::vec3*>(&vector));
+                glm::translate(*reinterpret_cast<glm::mat4*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec3>(vector));
         }
 
         /**
@@ -85,7 +85,7 @@ namespace NovelRT::Maths
         inline void Rotate(float angleInRadians, GeoVector3F rotationAngle = GeoVector3F(0.0f, 0.0f, -1.0f))
         {
             *reinterpret_cast<glm::mat4*>(this) = glm::rotate(*reinterpret_cast<glm::mat4*>(this), angleInRadians,
-                                                              *reinterpret_cast<glm::vec3*>(&rotationAngle));
+                                                              NovelRT::Utilities::Misc::BitCast<glm::vec3>(rotationAngle));
         }
 
         /**
@@ -107,7 +107,7 @@ namespace NovelRT::Maths
         inline void Scale(GeoVector3F scaleValue)
         {
             *reinterpret_cast<glm::mat4*>(this) =
-                glm::scale(*reinterpret_cast<glm::mat4*>(this), *reinterpret_cast<glm::vec3*>(&scaleValue));
+                glm::scale(*reinterpret_cast<glm::mat4*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec3>(scaleValue));
         }
 
         /**
@@ -155,7 +155,7 @@ namespace NovelRT::Maths
          */
         inline bool operator==(GeoMatrix4x4F other) const noexcept
         {
-            return *reinterpret_cast<const glm::mat4*>(this) == *reinterpret_cast<const glm::mat4*>(&other);
+            return *reinterpret_cast<const glm::mat4*>(this) == NovelRT::Utilities::Misc::BitCast<glm::mat4>(other);
         }
 
         /**
@@ -167,7 +167,7 @@ namespace NovelRT::Maths
          */
         inline bool operator!=(GeoMatrix4x4F other) const noexcept
         {
-            return *reinterpret_cast<const glm::mat4*>(this) != *reinterpret_cast<const glm::mat4*>(&other);
+            return *reinterpret_cast<const glm::mat4*>(this) != NovelRT::Utilities::Misc::BitCast<glm::mat4>(other);
         }
 
         /**
@@ -211,7 +211,7 @@ namespace NovelRT::Maths
         inline GeoMatrix4x4F operator+(GeoMatrix4x4F other) const noexcept
         {
             return GeoMatrix4x4F(*reinterpret_cast<const glm::mat4*>(this) +
-                                 *reinterpret_cast<const glm::mat4*>(&other));
+                                 NovelRT::Utilities::Misc::BitCast<glm::mat4>(other));
         }
 
         /**
@@ -255,7 +255,7 @@ namespace NovelRT::Maths
         inline GeoMatrix4x4F operator-(GeoMatrix4x4F other) const noexcept
         {
             return GeoMatrix4x4F(*reinterpret_cast<const glm::mat4*>(this) -
-                                 *reinterpret_cast<const glm::mat4*>(&other));
+                                 NovelRT::Utilities::Misc::BitCast<glm::mat4>(other));
         }
 
         /**
@@ -299,7 +299,7 @@ namespace NovelRT::Maths
         inline GeoMatrix4x4F operator*(GeoMatrix4x4F other) const noexcept
         {
             return GeoMatrix4x4F(*reinterpret_cast<const glm::mat4*>(this) *
-                                 *reinterpret_cast<const glm::mat4*>(&other));
+                                 NovelRT::Utilities::Misc::BitCast<glm::mat4>(other));
         }
 
         /**
@@ -343,7 +343,7 @@ namespace NovelRT::Maths
          */
         inline GeoMatrix4x4F operator+=(GeoMatrix4x4F other) noexcept
         {
-            *reinterpret_cast<glm::mat4*>(this) += *reinterpret_cast<const glm::mat4*>(&other);
+            *reinterpret_cast<glm::mat4*>(this) += NovelRT::Utilities::Misc::BitCast<glm::mat4>(other);
             return *this;
         }
 
@@ -388,7 +388,7 @@ namespace NovelRT::Maths
          */
         inline GeoMatrix4x4F operator-=(GeoMatrix4x4F other) noexcept
         {
-            *reinterpret_cast<glm::mat4*>(this) -= *reinterpret_cast<const glm::mat4*>(&other);
+            *reinterpret_cast<glm::mat4*>(this) -= NovelRT::Utilities::Misc::BitCast<glm::mat4>(other);
             return *this;
         }
 
@@ -433,7 +433,7 @@ namespace NovelRT::Maths
          */
         inline GeoMatrix4x4F operator*=(GeoMatrix4x4F other) noexcept
         {
-            *reinterpret_cast<glm::mat4*>(this) *= *reinterpret_cast<const glm::mat4*>(&other);
+            *reinterpret_cast<glm::mat4*>(this) *= NovelRT::Utilities::Misc::BitCast<glm::mat4>(other);
             return *this;
         }
 
@@ -822,9 +822,9 @@ namespace NovelRT::Maths
          */
         static GeoMatrix4x4F CreateFromLookAt(GeoVector3F eye, GeoVector3F centre, GeoVector3F up)
         {
-            return GeoMatrix4x4F(glm::lookAt(*reinterpret_cast<glm::vec3*>(&eye),
-                                             *reinterpret_cast<glm::vec3*>(&centre),
-                                             *reinterpret_cast<glm::vec3*>(&up)));
+            return GeoMatrix4x4F(glm::lookAt(NovelRT::Utilities::Misc::BitCast<glm::vec3>(eye),
+                                             NovelRT::Utilities::Misc::BitCast<glm::vec3>(centre),
+                                             NovelRT::Utilities::Misc::BitCast<glm::vec3>(up)));
         }
     };
 }

--- a/include/NovelRT/Maths/GeoVector2F.h
+++ b/include/NovelRT/Maths/GeoVector2F.h
@@ -181,7 +181,7 @@ namespace NovelRT::Maths
          */
         inline bool operator==(GeoVector2F other) const noexcept
         {
-            return *reinterpret_cast<const glm::vec2*>(this) == *reinterpret_cast<const glm::vec2*>(&other);
+            return *reinterpret_cast<const glm::vec2*>(this) == NovelRT::Utilities::Misc::BitCast<glm::vec2>(other);
         }
 
         /**
@@ -192,7 +192,7 @@ namespace NovelRT::Maths
          */
         inline bool operator!=(GeoVector2F other) const noexcept
         {
-            return *reinterpret_cast<const glm::vec2*>(this) != *reinterpret_cast<const glm::vec2*>(&other);
+            return *reinterpret_cast<const glm::vec2*>(this) != NovelRT::Utilities::Misc::BitCast<glm::vec2>(other);
         }
 
         /**
@@ -205,7 +205,7 @@ namespace NovelRT::Maths
         inline bool operator<(GeoVector2F other) const noexcept
         {
             return glm::any(
-                glm::lessThan(*reinterpret_cast<const glm::vec2*>(this), *reinterpret_cast<const glm::vec2*>(&other)));
+                glm::lessThan(*reinterpret_cast<const glm::vec2*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec2>(other)));
         }
 
         /**
@@ -219,7 +219,7 @@ namespace NovelRT::Maths
         inline bool operator<=(GeoVector2F other) const noexcept
         {
             return glm::any(glm::lessThanEqual(*reinterpret_cast<const glm::vec2*>(this),
-                                               *reinterpret_cast<const glm::vec2*>(&other)));
+                                               NovelRT::Utilities::Misc::BitCast<glm::vec2>(other)));
         }
 
         /**
@@ -232,7 +232,7 @@ namespace NovelRT::Maths
         inline bool operator>(GeoVector2F other) const noexcept
         {
             return glm::any(glm::greaterThan(*reinterpret_cast<const glm::vec2*>(this),
-                                             *reinterpret_cast<const glm::vec2*>(&other)));
+                                             NovelRT::Utilities::Misc::BitCast<glm::vec2>(other)));
         }
 
         /**
@@ -246,7 +246,7 @@ namespace NovelRT::Maths
         inline bool operator>=(GeoVector2F other) const noexcept
         {
             return glm::any(glm::greaterThanEqual(*reinterpret_cast<const glm::vec2*>(this),
-                                                  *reinterpret_cast<const glm::vec2*>(&other)));
+                                                  NovelRT::Utilities::Misc::BitCast<glm::vec2>(other)));
         }
 
         /**
@@ -281,7 +281,7 @@ namespace NovelRT::Maths
          */
         inline GeoVector2F operator+(GeoVector2F other) const noexcept
         {
-            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) + *reinterpret_cast<const glm::vec2*>(&other));
+            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) + NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
         }
 
         /**
@@ -316,7 +316,7 @@ namespace NovelRT::Maths
          */
         inline GeoVector2F operator-(GeoVector2F other) const noexcept
         {
-            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) - *reinterpret_cast<const glm::vec2*>(&other));
+            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) - NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
         }
 
         /**
@@ -351,7 +351,7 @@ namespace NovelRT::Maths
          */
         inline GeoVector2F operator*(GeoVector2F other) const noexcept
         {
-            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) * *reinterpret_cast<const glm::vec2*>(&other));
+            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) * NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
         }
 
         /**
@@ -386,7 +386,7 @@ namespace NovelRT::Maths
          */
         GeoVector2F operator/(GeoVector2F other) const noexcept
         {
-            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) / *reinterpret_cast<const glm::vec2*>(&other));
+            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) / NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
         }
 
         /**

--- a/include/NovelRT/Maths/GeoVector2F.h
+++ b/include/NovelRT/Maths/GeoVector2F.h
@@ -591,7 +591,7 @@ namespace NovelRT::Maths
         inline GeoVector2F& operator+=(GeoVector2F other) noexcept
         {
             *reinterpret_cast<glm::vec2*>(this) =
-                *reinterpret_cast<const glm::vec2*>(this) + *reinterpret_cast<const glm::vec2*>(&other);
+                *reinterpret_cast<const glm::vec2*>(this) + NovelRT::Utilities::Misc::BitCast<glm::vec2>(other);
             return *this;
         }
 

--- a/include/NovelRT/Maths/GeoVector2F.h
+++ b/include/NovelRT/Maths/GeoVector2F.h
@@ -629,7 +629,7 @@ namespace NovelRT::Maths
         inline GeoVector2F& operator-=(GeoVector2F other) noexcept
         {
             *reinterpret_cast<glm::vec2*>(this) =
-                *reinterpret_cast<const glm::vec2*>(this) - *reinterpret_cast<const glm::vec2*>(&other);
+                *reinterpret_cast<const glm::vec2*>(this) - NovelRT::Utilities::Misc::BitCast<glm::vec2>(other);
             return *this;
         }
 
@@ -667,7 +667,7 @@ namespace NovelRT::Maths
         inline GeoVector2F operator*=(GeoVector2F other) noexcept
         {
             *reinterpret_cast<glm::vec2*>(this) =
-                *reinterpret_cast<const glm::vec2*>(this) * *reinterpret_cast<const glm::vec2*>(&other);
+                *reinterpret_cast<const glm::vec2*>(this) * NovelRT::Utilities::Misc::BitCast<glm::vec2>(other);
             return *this;
         }
 
@@ -705,7 +705,7 @@ namespace NovelRT::Maths
         GeoVector2F operator/=(GeoVector2F other) noexcept
         {
             *reinterpret_cast<glm::vec2*>(this) =
-                *reinterpret_cast<const glm::vec2*>(this) / *reinterpret_cast<const glm::vec2*>(&other);
+                *reinterpret_cast<const glm::vec2*>(this) / NovelRT::Utilities::Misc::BitCast<glm::vec2>(other);
             return *this;
         }
 
@@ -905,10 +905,9 @@ namespace NovelRT::Maths
         void RotateToAngleAroundPointRad(float angleRotationValue, GeoVector2F point) noexcept
         {
             *reinterpret_cast<glm::vec2*>(this) =
-                glm::rotate((*reinterpret_cast<glm::vec2*>(this) = *reinterpret_cast<const glm::vec2*>(this) -
-                                                                   *reinterpret_cast<const glm::vec2*>(&point)),
+                glm::rotate((*reinterpret_cast<const glm::vec2*>(this) - NovelRT::Utilities::Misc::BitCast<glm::vec2>(point)),
                             angleRotationValue) +
-                *reinterpret_cast<const glm::vec2*>(&point);
+                NovelRT::Utilities::Misc::BitCast<glm::vec2>(point);
         }
 
         /**
@@ -923,8 +922,8 @@ namespace NovelRT::Maths
         bool EpsilonEquals(GeoVector2F other, GeoVector2F epsilonValue) const noexcept
         {
             return glm::all(glm::equal(*reinterpret_cast<const glm::vec2*>(this),
-                                       *reinterpret_cast<const glm::vec2*>(&other),
-                                       *reinterpret_cast<const glm::vec2*>(&epsilonValue)));
+                                       NovelRT::Utilities::Misc::BitCast<glm::vec2>(other),
+                                       NovelRT::Utilities::Misc::BitCast<glm::vec2>(epsilonValue)));
         }
 
         /**
@@ -952,7 +951,7 @@ namespace NovelRT::Maths
          */
         inline float Dot(GeoVector2F other) noexcept
         {
-            return glm::dot(*reinterpret_cast<const glm::vec2*>(this), *reinterpret_cast<const glm::vec2*>(&other));
+            return glm::dot(*reinterpret_cast<const glm::vec2*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
         }
 
         /**
@@ -989,7 +988,7 @@ namespace NovelRT::Maths
         inline float Distance(GeoVector2F other) noexcept
         {
             return glm::distance(*reinterpret_cast<const glm::vec2*>(this),
-                                 *reinterpret_cast<const glm::vec2*>(&other));
+                                 NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
         }
 
         /**

--- a/include/NovelRT/Maths/GeoVector2F.h
+++ b/include/NovelRT/Maths/GeoVector2F.h
@@ -204,8 +204,8 @@ namespace NovelRT::Maths
          */
         inline bool operator<(GeoVector2F other) const noexcept
         {
-            return glm::any(
-                glm::lessThan(*reinterpret_cast<const glm::vec2*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec2>(other)));
+            return glm::any(glm::lessThan(*reinterpret_cast<const glm::vec2*>(this),
+                                          NovelRT::Utilities::Misc::BitCast<glm::vec2>(other)));
         }
 
         /**
@@ -281,7 +281,8 @@ namespace NovelRT::Maths
          */
         inline GeoVector2F operator+(GeoVector2F other) const noexcept
         {
-            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) + NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
+            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) +
+                               NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
         }
 
         /**
@@ -316,7 +317,8 @@ namespace NovelRT::Maths
          */
         inline GeoVector2F operator-(GeoVector2F other) const noexcept
         {
-            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) - NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
+            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) -
+                               NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
         }
 
         /**
@@ -351,7 +353,8 @@ namespace NovelRT::Maths
          */
         inline GeoVector2F operator*(GeoVector2F other) const noexcept
         {
-            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) * NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
+            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) *
+                               NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
         }
 
         /**
@@ -386,7 +389,8 @@ namespace NovelRT::Maths
          */
         GeoVector2F operator/(GeoVector2F other) const noexcept
         {
-            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) / NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
+            return GeoVector2F(*reinterpret_cast<const glm::vec2*>(this) /
+                               NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
         }
 
         /**
@@ -904,10 +908,10 @@ namespace NovelRT::Maths
          */
         void RotateToAngleAroundPointRad(float angleRotationValue, GeoVector2F point) noexcept
         {
-            *reinterpret_cast<glm::vec2*>(this) =
-                glm::rotate((*reinterpret_cast<const glm::vec2*>(this) - NovelRT::Utilities::Misc::BitCast<glm::vec2>(point)),
-                            angleRotationValue) +
-                NovelRT::Utilities::Misc::BitCast<glm::vec2>(point);
+            *reinterpret_cast<glm::vec2*>(this) = glm::rotate(*reinterpret_cast<const glm::vec2*>(this) -
+                                                              NovelRT::Utilities::Misc::BitCast<glm::vec2>(point),
+                                                              angleRotationValue) +
+                                                  NovelRT::Utilities::Misc::BitCast<glm::vec2>(point);
         }
 
         /**
@@ -951,7 +955,8 @@ namespace NovelRT::Maths
          */
         inline float Dot(GeoVector2F other) noexcept
         {
-            return glm::dot(*reinterpret_cast<const glm::vec2*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
+            return glm::dot(*reinterpret_cast<const glm::vec2*>(this),
+                            NovelRT::Utilities::Misc::BitCast<glm::vec2>(other));
         }
 
         /**

--- a/include/NovelRT/Maths/GeoVector2F.h
+++ b/include/NovelRT/Maths/GeoVector2F.h
@@ -909,7 +909,7 @@ namespace NovelRT::Maths
         void RotateToAngleAroundPointRad(float angleRotationValue, GeoVector2F point) noexcept
         {
             *reinterpret_cast<glm::vec2*>(this) = glm::rotate(*reinterpret_cast<const glm::vec2*>(this) -
-                                                              NovelRT::Utilities::Misc::BitCast<glm::vec2>(point),
+                                                                  NovelRT::Utilities::Misc::BitCast<glm::vec2>(point),
                                                               angleRotationValue) +
                                                   NovelRT::Utilities::Misc::BitCast<glm::vec2>(point);
         }

--- a/include/NovelRT/Maths/GeoVector3F.h
+++ b/include/NovelRT/Maths/GeoVector3F.h
@@ -1054,7 +1054,7 @@ namespace NovelRT::Maths
          */
         inline float Dot(GeoVector3F other) noexcept
         {
-            return glm::dot(*reinterpret_cast<const glm::vec3*>(this), *reinterpret_cast<const glm::vec3*>(&other));
+            return glm::dot(*reinterpret_cast<const glm::vec3*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec3>(other));
         }
 
         /**
@@ -1104,7 +1104,7 @@ namespace NovelRT::Maths
          */
         inline GeoVector3F Cross(GeoVector3F other) noexcept
         {
-            return GeoVector3F(glm::cross(*reinterpret_cast<glm::vec3*>(this), *reinterpret_cast<glm::vec3*>(&other)));
+            return GeoVector3F(glm::cross(*reinterpret_cast<glm::vec3*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec3>(other)));
         }
 
         /**
@@ -1145,7 +1145,7 @@ namespace NovelRT::Maths
         inline float Distance(GeoVector3F other) noexcept
         {
             return glm::distance(*reinterpret_cast<const glm::vec3*>(this),
-                                 *reinterpret_cast<const glm::vec3*>(&other));
+                                 NovelRT::Utilities::Misc::BitCast<glm::vec3>(other));
         }
 
         /**

--- a/include/NovelRT/Maths/GeoVector3F.h
+++ b/include/NovelRT/Maths/GeoVector3F.h
@@ -1004,7 +1004,7 @@ namespace NovelRT::Maths
                                          const GeoVector3F& axis = GeoVector3F(0, 0, 1)) noexcept
         {
             *reinterpret_cast<glm::vec3*>(this) =
-                glm::rotate((*reinterpret_cast<const glm::vec3*>(this) - *reinterpret_cast<const glm::vec3*>(&point)),
+                glm::rotate(*reinterpret_cast<const glm::vec3*>(this) - *reinterpret_cast<const glm::vec3*>(&point),
                             angleRotationValue, *reinterpret_cast<const glm::vec3*>(&axis)) +
                 *reinterpret_cast<const glm::vec3*>(&point);
         }
@@ -1054,7 +1054,8 @@ namespace NovelRT::Maths
          */
         inline float Dot(GeoVector3F other) noexcept
         {
-            return glm::dot(*reinterpret_cast<const glm::vec3*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec3>(other));
+            return glm::dot(*reinterpret_cast<const glm::vec3*>(this),
+                            NovelRT::Utilities::Misc::BitCast<glm::vec3>(other));
         }
 
         /**
@@ -1104,7 +1105,8 @@ namespace NovelRT::Maths
          */
         inline GeoVector3F Cross(GeoVector3F other) noexcept
         {
-            return GeoVector3F(glm::cross(*reinterpret_cast<glm::vec3*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec3>(other)));
+            return GeoVector3F(
+                glm::cross(*reinterpret_cast<glm::vec3*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec3>(other)));
         }
 
         /**

--- a/include/NovelRT/Maths/GeoVector4F.h
+++ b/include/NovelRT/Maths/GeoVector4F.h
@@ -1109,7 +1109,7 @@ namespace NovelRT::Maths
                                          const GeoVector3F& axis = GeoVector3F(0, 0, 1)) noexcept
         {
             *reinterpret_cast<glm::vec4*>(this) =
-                glm::rotate((*reinterpret_cast<const glm::vec4*>(this) - *reinterpret_cast<const glm::vec4*>(&point)),
+                glm::rotate(*reinterpret_cast<const glm::vec4*>(this) - *reinterpret_cast<const glm::vec4*>(&point),
                             angleRotationValue, *reinterpret_cast<const glm::vec3*>(&axis)) +
                 *reinterpret_cast<const glm::vec4*>(&point);
         }
@@ -1160,7 +1160,8 @@ namespace NovelRT::Maths
          */
         inline float Dot(GeoVector4F other) noexcept
         {
-            return glm::dot(*reinterpret_cast<const glm::vec4*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec4>(other));
+            return glm::dot(*reinterpret_cast<const glm::vec4*>(this),
+                            NovelRT::Utilities::Misc::BitCast<glm::vec4>(other));
         }
 
         /**

--- a/include/NovelRT/Maths/GeoVector4F.h
+++ b/include/NovelRT/Maths/GeoVector4F.h
@@ -1160,7 +1160,7 @@ namespace NovelRT::Maths
          */
         inline float Dot(GeoVector4F other) noexcept
         {
-            return glm::dot(*reinterpret_cast<const glm::vec4*>(this), *reinterpret_cast<const glm::vec4*>(&other));
+            return glm::dot(*reinterpret_cast<const glm::vec4*>(this), NovelRT::Utilities::Misc::BitCast<glm::vec4>(other));
         }
 
         /**

--- a/include/NovelRT/Maths/Maths.h
+++ b/include/NovelRT/Maths/Maths.h
@@ -6,6 +6,7 @@
 
 // Maths dependencies
 #include <NovelRT/Exceptions/Exceptions.h>
+#include <NovelRT/Utilities/Misc.h>
 #include <array>
 #include <glm/glm.hpp>
 #include <glm/gtx/rotate_vector.hpp>

--- a/include/NovelRT/Utilities/Misc.h
+++ b/include/NovelRT/Utilities/Misc.h
@@ -6,7 +6,7 @@
 
 #ifdef __has_builtin
 #define _NOVELRT_UTILITIES_HAS_BUILTIN_BIT_CAST __has_builtin(__builtin_bit_cast)
-#else 
+#else
 #define _NOVELRT_UTILITIES_HAS_BUILTIN_BIT_CAST false
 #endif
 
@@ -23,7 +23,6 @@
 #endif
 
 #endif
-
 
 #define unused(x) (void)(x)
 
@@ -99,31 +98,41 @@ namespace NovelRT::Utilities
 
         /**
          * @brief Casts an object instance as an unrelated object of a different type.
-         * 
+         *
          * @details
-         * With this implementation types can only be casted to other types that are of equal size and that are trivially copyable.
-         * 
+         * With this implementation types can only be casted to other types that are of equal size and that are
+         * trivially copyable.
+         *
          * @tparam TTo The target type the instance should be casted to.
          * @tparam TFrom The original type of the object instance.
          * @returns The object instance as a TTo.
          */
         template<class TTo, class TFrom>
-        #if __cpp_lib_bit_cast
-        constexpr static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value) noexcept
+#if __cpp_lib_bit_cast
+        constexpr static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> &&
+                                              std::is_trivially_copyable_v<TFrom>,
+                                          TTo>
+        BitCast(const TFrom& value) noexcept
         {
             return std::bit_cast<TTo>(value);
         }
-        #elif _NOVELRT_UTILITIES_HAS_BUILTIN_BIT_CAST
-        constexpr static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value) noexcept
+#elif _NOVELRT_UTILITIES_HAS_BUILTIN_BIT_CAST
+        constexpr static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> &&
+                                              std::is_trivially_copyable_v<TFrom>,
+                                          TTo>
+        BitCast(const TFrom& value) noexcept
         {
             return __builtin_bit_cast(TTo, value);
         }
-        #else
-        inline static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value) noexcept
+#else
+        inline static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> &&
+                                           std::is_trivially_copyable_v<TFrom>,
+                                       TTo>
+        BitCast(const TFrom& value) noexcept
         {
             return *reinterpret_cast<const TTo*>(&value);
         }
-        #endif
+#endif
     };
 }
 

--- a/include/NovelRT/Utilities/Misc.h
+++ b/include/NovelRT/Utilities/Misc.h
@@ -118,25 +118,25 @@ namespace NovelRT::Utilities
          */
         template<class TTo, class TFrom>
         #if __cpp_lib_bit_cast
-        constexpr static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value)
+        constexpr static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value) noexcept
         {
             return std::bit_cast<TTo>(value);
         }
         #elif _NOVELRT_UTILITIES_HAS_BUILTIN_BIT_CAST
-        constexpr static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value)
+        constexpr static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value) noexcept
         {
             return __builtin_bit_cast(TTo, value);
         }
         #else
         #if _NOVELRT_UTILITIES_IS_GCC
-        inline static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value)
+        inline static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value) noexcept
         {
             TTo result;
             memcpy(&result, &value, sizeof(result));
             return result;
         }
         #else
-        inline static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value)
+        inline static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value) noexcept
         {
             return *reinterpret_cast<const TTo*>(&value);
         }

--- a/include/NovelRT/Utilities/Misc.h
+++ b/include/NovelRT/Utilities/Misc.h
@@ -10,11 +10,6 @@
 #define _NOVELRT_UTILITIES_HAS_BUILTIN_BIT_CAST false
 #endif
 
-#if defined(__clang__) || defined(__INTEL_COMPILER)
-#elif defined(__GNUC__) || defined(__GNUG__)
-#define _NOVELRT_UTILITIES_IS_GCC true
-#endif
-
 #include <filesystem>
 #include <gsl/span>
 #include <type_traits>
@@ -25,10 +20,6 @@
 
 #if __cpp_lib_bit_cast
 #include <bit>
-#endif
-
-#if !_NOVELRT_UTILITIES_HAS_BUILTIN_BIT_CAST && _NOVELRT_UTILITIES_IS_GCC
-#include<cstring>
 #endif
 
 #endif
@@ -128,19 +119,10 @@ namespace NovelRT::Utilities
             return __builtin_bit_cast(TTo, value);
         }
         #else
-        #if _NOVELRT_UTILITIES_IS_GCC
-        inline static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value) noexcept
-        {
-            TTo result;
-            memcpy(&result, &value, sizeof(result));
-            return result;
-        }
-        #else
         inline static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value) noexcept
         {
             return *reinterpret_cast<const TTo*>(&value);
         }
-        #endif
         #endif
     };
 }

--- a/include/NovelRT/Utilities/Misc.h
+++ b/include/NovelRT/Utilities/Misc.h
@@ -106,6 +106,16 @@ namespace NovelRT::Utilities
             return returnVec;
         }
 
+        /**
+         * @brief Casts an object instance as an unrelated object of a different type.
+         * 
+         * @details
+         * With this implementation types can only be casted to other types that are of equal size and that are trivially copyable.
+         * 
+         * @tparam TTo The target type the instance should be casted to.
+         * @tparam TFrom The original type of the object instance.
+         * @returns The object instance as a TTo.
+         */
         template<class TTo, class TFrom>
         #if __cpp_lib_bit_cast
         constexpr static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value)

--- a/include/NovelRT/Utilities/Misc.h
+++ b/include/NovelRT/Utilities/Misc.h
@@ -138,7 +138,7 @@ namespace NovelRT::Utilities
         #else
         inline static std::enable_if_t<sizeof(TTo) == sizeof(TFrom) && std::is_trivially_copyable_v<TTo> && std::is_trivially_copyable_v<TFrom>, TTo> BitCast(const TFrom& value)
         {
-            return *reinterpret_cast<const TTo*>(value);
+            return *reinterpret_cast<const TTo*>(&value);
         }
         #endif
         #endif

--- a/tests/NovelRT.Tests/CMakeLists.txt
+++ b/tests/NovelRT.Tests/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SOURCES
 
   Timing/TimestampTest.cpp
 
+  Utilities/BitCastTest.cpp
   Utilities/BitflagsTest.cpp
   Utilities/EventTest.cpp
 

--- a/tests/NovelRT.Tests/Utilities/BitCastTest.cpp
+++ b/tests/NovelRT.Tests/Utilities/BitCastTest.cpp
@@ -1,0 +1,75 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT License (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <NovelRT/NovelRT.h>
+#include <gtest/gtest.h>
+
+using namespace NovelRT;
+using namespace NovelRT::Utilities;
+using namespace NovelRT::Maths;
+
+TEST(BitCastTest, CastGlmVec2ToNovelRTGeoVector2F)
+{
+    float x = 1.0f, y = 2.0f;
+    glm::vec2 glmVec2 = glm::vec2{x, y};
+    GeoVector2F nrtVec2 = Misc::BitCast<GeoVector2F>(glmVec2);
+
+    EXPECT_FLOAT_EQ(nrtVec2.x, x);
+    EXPECT_FLOAT_EQ(nrtVec2.y, y);
+}
+
+TEST(BitCastTest, CastGlmVec3ToNovelRTGeoVector3F)
+{
+    float x = 1.0f, y = 2.0f, z = 3.0f;
+    glm::vec3 glmVec3 = glm::vec3{x, y, z};
+    GeoVector3F nrtVec3 = Misc::BitCast<GeoVector3F>(glmVec3);
+
+    EXPECT_FLOAT_EQ(nrtVec3.x, x);
+    EXPECT_FLOAT_EQ(nrtVec3.y, y);
+    EXPECT_FLOAT_EQ(nrtVec3.z, z);
+}
+
+TEST(BitCastTest, CastGlmVec4ToNovelRTGeoVector4F)
+{
+    float x = 1.0f, y = 2.0f, z = 3.0f, w = 4.0f;
+    glm::vec4 glmVec4 = glm::vec4{x, y, z, w};
+    GeoVector4F nrtVec4 = Misc::BitCast<GeoVector4F>(glmVec4);
+
+    EXPECT_FLOAT_EQ(nrtVec4.x, x);
+    EXPECT_FLOAT_EQ(nrtVec4.y, y);
+    EXPECT_FLOAT_EQ(nrtVec4.z, z);
+    EXPECT_FLOAT_EQ(nrtVec4.w, w);
+}
+
+TEST(BitCastTest, CastGlmMat4ToNovelRTGeoMatrix4x4)
+{
+    float x1 = 1.0f, y1 = 0.0f, z1 = 0.0f, w1 = 0.0f;
+    float x2 = 0.0f, y2 = 1.0f, z2 = 0.0f, w2 = 0.0f;
+    float x3 = 0.0f, y3 = 0.0f, z3 = 1.0f, w3 = 0.0f;
+    float x4 = 0.0f, y4 = 0.0f, z4 = 0.0f, w4 = 1.0f;
+    glm::mat4 glmMat4 = glm::mat4{x1, y1, z1, w1,
+                                  x2, y2, z2, w2,
+                                  x3, y3, z3, w3,
+                                  x4, y4, z4, w4};
+    GeoMatrix4x4F nrtMat4x4 = Misc::BitCast<GeoMatrix4x4F>(glmMat4);
+
+    EXPECT_FLOAT_EQ(nrtMat4x4.x.x, x1);
+    EXPECT_FLOAT_EQ(nrtMat4x4.x.y, y1);
+    EXPECT_FLOAT_EQ(nrtMat4x4.x.z, z1);
+    EXPECT_FLOAT_EQ(nrtMat4x4.x.w, w1);
+
+    EXPECT_FLOAT_EQ(nrtMat4x4.y.x, x2);
+    EXPECT_FLOAT_EQ(nrtMat4x4.y.y, y2);
+    EXPECT_FLOAT_EQ(nrtMat4x4.y.z, z2);
+    EXPECT_FLOAT_EQ(nrtMat4x4.y.w, w2);
+
+    EXPECT_FLOAT_EQ(nrtMat4x4.z.x, x3);
+    EXPECT_FLOAT_EQ(nrtMat4x4.z.y, y3);
+    EXPECT_FLOAT_EQ(nrtMat4x4.z.z, z3);
+    EXPECT_FLOAT_EQ(nrtMat4x4.z.w, w3);
+
+    EXPECT_FLOAT_EQ(nrtMat4x4.w.x, x4);
+    EXPECT_FLOAT_EQ(nrtMat4x4.w.y, y4);
+    EXPECT_FLOAT_EQ(nrtMat4x4.w.z, z4);
+    EXPECT_FLOAT_EQ(nrtMat4x4.w.w, w4);
+}

--- a/tests/NovelRT.Tests/Utilities/BitCastTest.cpp
+++ b/tests/NovelRT.Tests/Utilities/BitCastTest.cpp
@@ -47,10 +47,7 @@ TEST(BitCastTest, CastGlmMat4ToNovelRTGeoMatrix4x4)
     float x2 = 0.0f, y2 = 1.0f, z2 = 0.0f, w2 = 0.0f;
     float x3 = 0.0f, y3 = 0.0f, z3 = 1.0f, w3 = 0.0f;
     float x4 = 0.0f, y4 = 0.0f, z4 = 0.0f, w4 = 1.0f;
-    glm::mat4 glmMat4 = glm::mat4{x1, y1, z1, w1,
-                                  x2, y2, z2, w2,
-                                  x3, y3, z3, w3,
-                                  x4, y4, z4, w4};
+    glm::mat4 glmMat4 = glm::mat4{x1, y1, z1, w1, x2, y2, z2, w2, x3, y3, z3, w3, x4, y4, z4, w4};
     GeoMatrix4x4F nrtMat4x4 = Misc::BitCast<GeoMatrix4x4F>(glmMat4);
 
     EXPECT_FLOAT_EQ(nrtMat4x4.x.x, x1);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR aims to solve the type punning issues of https://github.com/novelrt/NovelRT/issues/402. I am not certain if that will be enough to get GCC support up and running.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
This PR 


**What is the current behavior?** (You can also link to an open issue here)
NovelRT fails to build with GCC.

**What is the new behavior (if this is a feature change)?**
NovelRT no longer fails to build with GCC due to type punning issues.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
This should not introduce a breaking change to the API or behavior.


**Other information**:

this handles most cases, as long as C++ 17 is used and the macros don't cry.

in C++ 20 std::bit_set is used.
some compilers support it in earlier C++ versions as a sort of compiler intrinsic, if one is available it might use it. if the compiler has not implemented std::bit_set yet or a built in implementation cannot be found, it will fallback on memcpy for GNU based compilers except clang and icc, these use reinterpret_cast as fallback.

the list of gnu exceptions is a tricky one to pin down and this is my current best attempt.