### PR TITLE
Fix C++20 template resolution for MSVC in C++20 mode.

### DIFF
--- a/include/NovelRT/Graphics/IGraphicsMemoryRegionCollection.h
+++ b/include/NovelRT/Graphics/IGraphicsMemoryRegionCollection.h
@@ -227,7 +227,7 @@ namespace NovelRT::Graphics
 
                 _regions->clear();
 
-                GraphicsMemoryRegion<TSelf> region(1, _collection, GetDevice(), false, 0, size);
+                GraphicsMemoryRegion<TSelf> region(1, _collection, this->GetDevice(), false, 0, size);
                 _regions->emplace_front(region);
                 auto iterator = _regions->begin();
                 _freeRegionsBySize->clear();
@@ -599,20 +599,20 @@ namespace NovelRT::Graphics
 
                 UnregisterFreeRegion(regionNode);
 
-                region = GraphicsMemoryRegion<TSelf>(alignment, _collection, GetDevice(), true, offset, size);
+                region = GraphicsMemoryRegion<TSelf>(alignment, _collection, this->GetDevice(), true, offset, size);
 
                 if (paddingEnd != 0)
                 {
                     auto iterator = _regions->insert(
                         std::next(regionNode),
-                        GraphicsMemoryRegion<TSelf>(1, _collection, GetDevice(), false, offset + size, paddingEnd));
+                        GraphicsMemoryRegion<TSelf>(1, _collection, this->GetDevice(), false, offset + size, paddingEnd));
                     RegisterFreeRegion(iterator);
                 }
 
                 if (paddingBegin != 0)
                 {
                     auto iterator =
-                        _regions->insert(regionNode, GraphicsMemoryRegion<TSelf>(1, _collection, GetDevice(), false,
+                        _regions->insert(regionNode, GraphicsMemoryRegion<TSelf>(1, _collection, this->GetDevice(), false,
                                                                                  offset - paddingBegin, paddingBegin));
                     RegisterFreeRegion(iterator);
                 }

--- a/include/NovelRT/Graphics/IGraphicsMemoryRegionCollection.h
+++ b/include/NovelRT/Graphics/IGraphicsMemoryRegionCollection.h
@@ -603,17 +603,17 @@ namespace NovelRT::Graphics
 
                 if (paddingEnd != 0)
                 {
-                    auto iterator = _regions->insert(
-                        std::next(regionNode),
-                        GraphicsMemoryRegion<TSelf>(1, _collection, this->GetDevice(), false, offset + size, paddingEnd));
+                    auto iterator = _regions->insert(std::next(regionNode),
+                                                     GraphicsMemoryRegion<TSelf>(1, _collection, this->GetDevice(),
+                                                                                 false, offset + size, paddingEnd));
                     RegisterFreeRegion(iterator);
                 }
 
                 if (paddingBegin != 0)
                 {
-                    auto iterator =
-                        _regions->insert(regionNode, GraphicsMemoryRegion<TSelf>(1, _collection, this->GetDevice(), false,
-                                                                                 offset - paddingBegin, paddingBegin));
+                    auto iterator = _regions->insert(
+                        regionNode, GraphicsMemoryRegion<TSelf>(1, _collection, this->GetDevice(), false,
+                                                                offset - paddingBegin, paddingBegin));
                     RegisterFreeRegion(iterator);
                 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces an MSVC-specific C++20 fix - it appears MSVC has a bug in template resolution when in C++20 mode, this seems to resolve it.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
N/A


**What is the current behavior?** (You can also link to an open issue here)
C++20 fails to build becuase it thinks we are calling instance methods in static contexts when we aren't.


**What is the new behavior (if this is a feature change)?**
C++20 resolves the template correctly and so can build on MSVC.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
C++17 should be fine, so no.


**Other information**:
N/A
