### PR TITLE
Fix genex issue for Windows and Linux

### DIFF
--- a/samples/AudioEcsSample/CMakeLists.txt
+++ b/samples/AudioEcsSample/CMakeLists.txt
@@ -4,7 +4,7 @@ set(SOURCES
 
 if(APPLE)
   add_executable(AudioEcsSample MACOSX_BUNDLE ${NOVELCHAN_ICON} ${SOURCES})
-  set_target_properties(AudioEcsSample 
+  set_target_properties(AudioEcsSample
     PROPERTIES
       BUNDLE True
       MACOSX_BUNDLE_GUI_IDENTIFIER dev.novelrt.samples.AudioEcsSample
@@ -24,7 +24,7 @@ target_link_libraries(AudioEcsSample
 
 copy_build_products(AudioEcsSample
   DEPENDENCY Resources
-  TARGET_LOCATION $<IF:$<BOOL:APPLE>,$<TARGET_FILE_DIR:AudioEcsSample>/../Resources,$<TARGET_FILE_DIR:AudioEcsSample>/Resources>
+  TARGET_LOCATION $<IF:$<BOOL:${APPLE}>,$<TARGET_FILE_DIR:AudioEcsSample>/../Resources,$<TARGET_FILE_DIR:AudioEcsSample>/Resources>
 )
 
 if(APPLE)

--- a/samples/EcsPipeline/CMakeLists.txt
+++ b/samples/EcsPipeline/CMakeLists.txt
@@ -4,7 +4,7 @@ set(SOURCES
 
 if(APPLE)
   add_executable(EcsPipeline MACOSX_BUNDLE ${NOVELCHAN_ICON} ${SOURCES})
-  set_target_properties(EcsPipeline 
+  set_target_properties(EcsPipeline
     PROPERTIES
       BUNDLE True
       MACOSX_BUNDLE_GUI_IDENTIFIER dev.novelrt.samples.EcsPipeline
@@ -23,7 +23,7 @@ target_link_libraries(EcsPipeline
 
 copy_build_products(EcsPipeline
   DEPENDENCY Resources
-  TARGET_LOCATION $<IF:$<BOOL:APPLE>,$<TARGET_FILE_DIR:EcsPipeline>/../Resources,$<TARGET_FILE_DIR:EcsPipeline>/Resources>
+  TARGET_LOCATION $<IF:$<BOOL:${APPLE}>,$<TARGET_FILE_DIR:EcsPipeline>/../Resources,$<TARGET_FILE_DIR:EcsPipeline>/Resources>
 )
 
 if(APPLE)

--- a/samples/Experimental/VulkanRender/CMakeLists.txt
+++ b/samples/Experimental/VulkanRender/CMakeLists.txt
@@ -4,7 +4,7 @@ set(SOURCES
 
 if(APPLE)
   add_executable(VulkanRender MACOSX_BUNDLE ${NOVELCHAN_ICON} ${SOURCES})
-  set_target_properties(VulkanRender 
+  set_target_properties(VulkanRender
     PROPERTIES
       BUNDLE True
       MACOSX_BUNDLE_GUI_IDENTIFIER dev.novelrt.samples.VulkanRender
@@ -23,7 +23,7 @@ target_link_libraries(VulkanRender
 
 copy_build_products(VulkanRender
   DEPENDENCY Resources
-  TARGET_LOCATION $<IF:$<BOOL:APPLE>,$<TARGET_FILE_DIR:VulkanRender>/../Resources,$<TARGET_FILE_DIR:VulkanRender>/Resources>
+  TARGET_LOCATION $<IF:$<BOOL:${APPLE}>,$<TARGET_FILE_DIR:VulkanRender>/../Resources,$<TARGET_FILE_DIR:VulkanRender>/Resources>
 )
 
 if(APPLE)

--- a/samples/FabulistTest/CMakeLists.txt
+++ b/samples/FabulistTest/CMakeLists.txt
@@ -4,7 +4,7 @@ set(SOURCES
 
 if(APPLE)
   add_executable(FabulistTest MACOSX_BUNDLE ${NOVELCHAN_ICON} ${SOURCES})
-  set_target_properties(FabulistTest 
+  set_target_properties(FabulistTest
     PROPERTIES
       BUNDLE True
       MACOSX_BUNDLE_GUI_IDENTIFIER dev.novelrt.samples.FabulistTest
@@ -23,7 +23,7 @@ target_link_libraries(FabulistTest
 
 copy_build_products(FabulistTest
   DEPENDENCY Resources
-  TARGET_LOCATION $<IF:$<BOOL:APPLE>,$<TARGET_FILE_DIR:FabulistTest>/../Resources,$<TARGET_FILE_DIR:FabulistTest>/Resources>
+  TARGET_LOCATION $<IF:$<BOOL:${APPLE}>,$<TARGET_FILE_DIR:FabulistTest>/../Resources,$<TARGET_FILE_DIR:FabulistTest>/Resources>
 )
 
 if(APPLE)

--- a/samples/InputEcsSample/CMakeLists.txt
+++ b/samples/InputEcsSample/CMakeLists.txt
@@ -4,7 +4,7 @@ set(SOURCES
 
 if(APPLE)
   add_executable(InputEcsSample MACOSX_BUNDLE ${NOVELCHAN_ICON} ${SOURCES})
-  set_target_properties(InputEcsSample 
+  set_target_properties(InputEcsSample
     PROPERTIES
       BUNDLE True
       MACOSX_BUNDLE_GUI_IDENTIFIER dev.novelrt.samples.InputEcsSample
@@ -23,7 +23,7 @@ target_link_libraries(InputEcsSample
 
 copy_build_products(InputEcsSample
   DEPENDENCY Resources
-  TARGET_LOCATION $<IF:$<BOOL:APPLE>,$<TARGET_FILE_DIR:InputEcsSample>/../Resources,$<TARGET_FILE_DIR:InputEcsSample>/Resources>
+  TARGET_LOCATION $<IF:$<BOOL:${APPLE}>,$<TARGET_FILE_DIR:InputEcsSample>/../Resources,$<TARGET_FILE_DIR:InputEcsSample>/Resources>
 )
 
 if(APPLE)

--- a/samples/PersistenceSample/CMakeLists.txt
+++ b/samples/PersistenceSample/CMakeLists.txt
@@ -4,7 +4,7 @@ set(SOURCES
 
 if(APPLE)
   add_executable(PersistenceSample MACOSX_BUNDLE ${NOVELCHAN_ICON} ${SOURCES})
-  set_target_properties(PersistenceSample 
+  set_target_properties(PersistenceSample
     PROPERTIES
       BUNDLE True
       MACOSX_BUNDLE_GUI_IDENTIFIER dev.novelrt.samples.PersistenceSample
@@ -23,7 +23,7 @@ target_link_libraries(PersistenceSample
 
 copy_build_products(PersistenceSample
   DEPENDENCY Resources
-  TARGET_LOCATION $<IF:$<BOOL:APPLE>,$<TARGET_FILE_DIR:PersistenceSample>/../Resources,$<TARGET_FILE_DIR:PersistenceSample>/Resources>
+  TARGET_LOCATION $<IF:$<BOOL:${APPLE}>,$<TARGET_FILE_DIR:PersistenceSample>/../Resources,$<TARGET_FILE_DIR:PersistenceSample>/Resources>
 )
 
 if(APPLE)

--- a/samples/UIEventExample/CMakeLists.txt
+++ b/samples/UIEventExample/CMakeLists.txt
@@ -4,7 +4,7 @@ set(SOURCES
 
 if(APPLE)
   add_executable(UIEventExample MACOSX_BUNDLE ${NOVELCHAN_ICON} ${SOURCES})
-  set_target_properties(UIEventExample 
+  set_target_properties(UIEventExample
     PROPERTIES
       BUNDLE True
       MACOSX_BUNDLE_GUI_IDENTIFIER dev.novelrt.samples.UIEventExample
@@ -23,7 +23,7 @@ target_link_libraries(UIEventExample
 
 copy_build_products(UIEventExample
   DEPENDENCY Resources
-  TARGET_LOCATION $<IF:$<BOOL:APPLE>,$<TARGET_FILE_DIR:UIEventExample>/../Resources,$<TARGET_FILE_DIR:UIEventExample>/Resources>
+  TARGET_LOCATION $<IF:$<BOOL:${APPLE}>,$<TARGET_FILE_DIR:UIEventExample>/../Resources,$<TARGET_FILE_DIR:UIEventExample>/Resources>
 )
 
 if(APPLE)

--- a/src/NovelRT/CMakeLists.txt
+++ b/src/NovelRT/CMakeLists.txt
@@ -171,7 +171,7 @@ target_link_libraries(Engine
     Opus::opus
     Ogg::ogg
     $<$<CXX_COMPILER_ID:MSVC>:Winmm>
-    $<$<BOOL:APPLE>:${COREFOUNDATION}>
+    $<$<BOOL:${APPLE}>:${COREFOUNDATION}>
 )
 
 if(NOVELRT_INSTALL)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes bug that caused Resource files to produce in the wrong folder for Linux and Win32 deployments


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
Nope


**What is the current behavior?** (You can also link to an open issue here)
The generator expression causes Resources folder to be produced inline with the individual samples' parent folders instead of inside them.


**What is the new behavior (if this is a feature change)?**
The folder correctly produces _inside_ the samples' folders


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope


**Other information**:
N/A