### PR TITLE
Feature/novelrt span alias

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ option(NOVELRT_BUILD_TESTS "Build NovelRT tests" ON)
 option(NOVELRT_BUILD_INTEROP "Build NovelRT's Interop library" ON)
 option(NOVELRT_VERBOSE_BUILD "Build NovelRT using verbose output" OFF)
 option(NOVELRT_INSTALL "Generate installation targets" ON)
+option(NOVELRT_USE_STD_SPAN "Alias \"NovelRT::Utilities::Misc:Span\" to \"std::span\" instead of \"gsl::span\"." OFF)
 
 set(NOVELRT_DOXYGEN_VERSION "1.8.17" CACHE STRING "Doxygen version")
 set(NOVELRT_FLAC_VERSION "1.3.4" CACHE STRING "FLAC version")
@@ -64,6 +65,14 @@ if(NOVELRT_BUILD_DOCUMENTATION)
   find_package(Doxygen ${NOVELRT_DOXYGEN_VERSION}
     COMPONENTS dot
   )
+endif()
+
+#
+# Alias "NovelRT::Utilities::Misc:Span" to "std::span" instead of "gsl::span".
+# If enabled, you need to make sure you current configuration supports "std::span".
+#
+if(NOVELRT_USE_STD_SPAN)
+  add_compile_definitions(NOVELRT_USE_STD_SPAN=true)
 endif()
 
 #

--- a/include/NovelRT/Audio/AudioService.h
+++ b/include/NovelRT/Audio/AudioService.h
@@ -32,7 +32,7 @@ namespace NovelRT::Audio
         SoundBank _soundStorage;
         SoundBank _bufferStorage;
 
-        ALuint BufferAudioFrameData(gsl::span<const int16_t> audioFrameData, int32_t channelCount, int32_t sampleRate);
+        ALuint BufferAudioFrameData(NovelRT::Utilities::Misc::Span<const int16_t> audioFrameData, int32_t channelCount, int32_t sampleRate);
         std::string GetALError();
 
     public:
@@ -42,7 +42,7 @@ namespace NovelRT::Audio
         ~AudioService();
 
         bool InitializeAudio();
-        std::vector<ALuint>::iterator LoadMusic(gsl::span<const int16_t> audioFrameData,
+        std::vector<ALuint>::iterator LoadMusic(NovelRT::Utilities::Misc::Span<const int16_t> audioFrameData,
                                                 int32_t channelCount,
                                                 int32_t sampleRate);
 
@@ -54,7 +54,7 @@ namespace NovelRT::Audio
         void StopMusic();
         void SetMusicVolume(float value);
         void CheckSources();
-        ALuint LoadSound(gsl::span<const int16_t> audioFrameData, int32_t channelCount, int32_t sampleRate);
+        ALuint LoadSound(NovelRT::Utilities::Misc::Span<const int16_t> audioFrameData, int32_t channelCount, int32_t sampleRate);
         void Unload(ALuint handle);
         void PlaySound(ALuint handle, int32_t loops);
         void StopSound(ALuint handle);

--- a/include/NovelRT/Audio/AudioService.h
+++ b/include/NovelRT/Audio/AudioService.h
@@ -32,7 +32,9 @@ namespace NovelRT::Audio
         SoundBank _soundStorage;
         SoundBank _bufferStorage;
 
-        ALuint BufferAudioFrameData(NovelRT::Utilities::Misc::Span<const int16_t> audioFrameData, int32_t channelCount, int32_t sampleRate);
+        ALuint BufferAudioFrameData(NovelRT::Utilities::Misc::Span<const int16_t> audioFrameData,
+                                    int32_t channelCount,
+                                    int32_t sampleRate);
         std::string GetALError();
 
     public:
@@ -54,7 +56,9 @@ namespace NovelRT::Audio
         void StopMusic();
         void SetMusicVolume(float value);
         void CheckSources();
-        ALuint LoadSound(NovelRT::Utilities::Misc::Span<const int16_t> audioFrameData, int32_t channelCount, int32_t sampleRate);
+        ALuint LoadSound(NovelRT::Utilities::Misc::Span<const int16_t> audioFrameData,
+                         int32_t channelCount,
+                         int32_t sampleRate);
         void Unload(ALuint handle);
         void PlaySound(ALuint handle, int32_t loops);
         void StopSound(ALuint handle);

--- a/include/NovelRT/Ecs/Ecs.h
+++ b/include/NovelRT/Ecs/Ecs.h
@@ -13,6 +13,7 @@
 #include "../Timing/Timestamp.h"
 #include "../Utilities/Event.h"
 #include "../Utilities/KeyValuePair.h"
+#include "../Utilities/Misc.h"
 #include "../PluginManagement/PluginManagement.h"
 #include "../Threading/Threading.h"
 #include <algorithm>

--- a/include/NovelRT/Ecs/Graphics/DefaultRenderingSystem.h
+++ b/include/NovelRT/Ecs/Graphics/DefaultRenderingSystem.h
@@ -91,11 +91,12 @@ namespace NovelRT::Ecs::Graphics
         [[nodiscard]] Threading::FutureResult<TextureInfo> GetOrLoadTexture(const std::string& spriteName);
 
         template<typename TSpanType>
-        [[nodiscard]] Threading::FutureResult<TextureInfo> LoadTextureDataRaw(const std::string& textureDataName,
-                                                                              NovelRT::Utilities::Misc::Span<TSpanType> textureDataSpan,
-                                                                              uint32_t width,
-                                                                              uint32_t height,
-                                                                              uuids::uuid textureAssetDataHandle)
+        [[nodiscard]] Threading::FutureResult<TextureInfo> LoadTextureDataRaw(
+            const std::string& textureDataName,
+            NovelRT::Utilities::Misc::Span<TSpanType> textureDataSpan,
+            uint32_t width,
+            uint32_t height,
+            uuids::uuid textureAssetDataHandle)
         {
             static_assert(std::is_trivially_copyable_v<TSpanType> &&
                           "The specified vertex struct must be trivially copyable.");
@@ -128,8 +129,9 @@ namespace NovelRT::Ecs::Graphics
         // TODO: in the future when we have mesh loading capabilities these will be replaced with similar mechanisms to
         // texture loading. End-users shouldn't need to manually hard-code the data.
         template<typename TSpanType>
-        [[nodiscard]] Threading::FutureResult<VertexInfo> LoadVertexDataRaw(const std::string& vertexDataName,
-                                                                            NovelRT::Utilities::Misc::Span<TSpanType> vertexDataSpan)
+        [[nodiscard]] Threading::FutureResult<VertexInfo> LoadVertexDataRaw(
+            const std::string& vertexDataName,
+            NovelRT::Utilities::Misc::Span<TSpanType> vertexDataSpan)
         {
             static_assert(std::is_trivially_copyable_v<TSpanType> &&
                           "The specified vertex struct must be trivially copyable.");

--- a/include/NovelRT/Ecs/Graphics/DefaultRenderingSystem.h
+++ b/include/NovelRT/Ecs/Graphics/DefaultRenderingSystem.h
@@ -92,7 +92,7 @@ namespace NovelRT::Ecs::Graphics
 
         template<typename TSpanType>
         [[nodiscard]] Threading::FutureResult<TextureInfo> LoadTextureDataRaw(const std::string& textureDataName,
-                                                                              gsl::span<TSpanType> textureDataSpan,
+                                                                              NovelRT::Utilities::Misc::Span<TSpanType> textureDataSpan,
                                                                               uint32_t width,
                                                                               uint32_t height,
                                                                               uuids::uuid textureAssetDataHandle)
@@ -129,7 +129,7 @@ namespace NovelRT::Ecs::Graphics
         // texture loading. End-users shouldn't need to manually hard-code the data.
         template<typename TSpanType>
         [[nodiscard]] Threading::FutureResult<VertexInfo> LoadVertexDataRaw(const std::string& vertexDataName,
-                                                                            gsl::span<TSpanType> vertexDataSpan)
+                                                                            NovelRT::Utilities::Misc::Span<TSpanType> vertexDataSpan)
         {
             static_assert(std::is_trivially_copyable_v<TSpanType> &&
                           "The specified vertex struct must be trivially copyable.");

--- a/include/NovelRT/Ecs/SparseSetMemoryContainer.h
+++ b/include/NovelRT/Ecs/SparseSetMemoryContainer.h
@@ -244,7 +244,8 @@ namespace NovelRT::Ecs
 
         [[nodiscard]] size_t Length() const noexcept;
 
-        void ResetAndWriteDenseData(NovelRT::Utilities::Misc::Span<const size_t> ids, NovelRT::Utilities::Misc::Span<const uint8_t> data);
+        void ResetAndWriteDenseData(NovelRT::Utilities::Misc::Span<const size_t> ids,
+                                    NovelRT::Utilities::Misc::Span<const uint8_t> data);
 
         void ResetAndWriteDenseData(const size_t* ids, size_t length, const uint8_t* data);
 

--- a/include/NovelRT/Ecs/SparseSetMemoryContainer.h
+++ b/include/NovelRT/Ecs/SparseSetMemoryContainer.h
@@ -244,7 +244,7 @@ namespace NovelRT::Ecs
 
         [[nodiscard]] size_t Length() const noexcept;
 
-        void ResetAndWriteDenseData(gsl::span<const size_t> ids, gsl::span<const uint8_t> data);
+        void ResetAndWriteDenseData(NovelRT::Utilities::Misc::Span<const size_t> ids, NovelRT::Utilities::Misc::Span<const uint8_t> data);
 
         void ResetAndWriteDenseData(const size_t* ids, size_t length, const uint8_t* data);
 

--- a/include/NovelRT/Graphics/Graphics.h
+++ b/include/NovelRT/Graphics/Graphics.h
@@ -17,7 +17,6 @@
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
-#include <gsl/span>
 #include <list>
 #include <memory>
 #include <mutex>

--- a/include/NovelRT/Graphics/GraphicsDevice.h
+++ b/include/NovelRT/Graphics/GraphicsDevice.h
@@ -48,7 +48,7 @@ namespace NovelRT::Graphics
 
         [[nodiscard]] virtual size_t GetContextIndex() const noexcept = 0;
 
-        [[nodiscard]] virtual gsl::span<std::shared_ptr<GraphicsContext>> GetContexts() = 0;
+        [[nodiscard]] virtual NovelRT::Utilities::Misc::Span<std::shared_ptr<GraphicsContext>> GetContexts() = 0;
 
         [[nodiscard]] inline std::shared_ptr<GraphicsContext> GetCurrentContext()
         {
@@ -78,8 +78,8 @@ namespace NovelRT::Graphics
         [[nodiscard]] virtual std::shared_ptr<GraphicsPipelineSignature> CreatePipelineSignature(
             GraphicsPipelineBlendFactor srcBlendFactor,
             GraphicsPipelineBlendFactor dstBlendFactor,
-            gsl::span<GraphicsPipelineInput> inputs,
-            gsl::span<GraphicsPipelineResource> resources) = 0;
+            NovelRT::Utilities::Misc::Span<GraphicsPipelineInput> inputs,
+            NovelRT::Utilities::Misc::Span<GraphicsPipelineResource> resources) = 0;
 
         [[nodiscard]] virtual std::shared_ptr<GraphicsPrimitive> CreatePrimitive(
             std::shared_ptr<GraphicsPipeline> pipeline,
@@ -87,11 +87,11 @@ namespace NovelRT::Graphics
             uint32_t vertexBufferStride,
             GraphicsMemoryRegion<GraphicsResource>& indexBufferRegion,
             uint32_t indexBufferStride,
-            gsl::span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions) = 0;
+            NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions) = 0;
 
         [[nodiscard]] virtual std::shared_ptr<ShaderProgram> CreateShaderProgram(std::string entryPointName,
                                                                                  ShaderProgramKind kind,
-                                                                                 gsl::span<uint8_t> byteData) = 0;
+                                                                                 NovelRT::Utilities::Misc::Span<uint8_t> byteData) = 0;
 
         virtual void PresentFrame() = 0;
         virtual void Signal(std::shared_ptr<GraphicsFence> fence) = 0;

--- a/include/NovelRT/Graphics/GraphicsDevice.h
+++ b/include/NovelRT/Graphics/GraphicsDevice.h
@@ -89,9 +89,10 @@ namespace NovelRT::Graphics
             uint32_t indexBufferStride,
             NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions) = 0;
 
-        [[nodiscard]] virtual std::shared_ptr<ShaderProgram> CreateShaderProgram(std::string entryPointName,
-                                                                                 ShaderProgramKind kind,
-                                                                                 NovelRT::Utilities::Misc::Span<uint8_t> byteData) = 0;
+        [[nodiscard]] virtual std::shared_ptr<ShaderProgram> CreateShaderProgram(
+            std::string entryPointName,
+            ShaderProgramKind kind,
+            NovelRT::Utilities::Misc::Span<uint8_t> byteData) = 0;
 
         virtual void PresentFrame() = 0;
         virtual void Signal(std::shared_ptr<GraphicsFence> fence) = 0;

--- a/include/NovelRT/Graphics/GraphicsMemoryBlockCollection.h
+++ b/include/NovelRT/Graphics/GraphicsMemoryBlockCollection.h
@@ -91,9 +91,9 @@ namespace NovelRT::Graphics
         [[nodiscard]] bool TryAllocate(size_t size,
                                        size_t alignment,
                                        GraphicsMemoryRegionAllocationFlags flags,
-                                       gsl::span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions);
+                                       NovelRT::Utilities::Misc::Span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions);
 
-        [[nodiscard]] bool TryAllocate(size_t size, gsl::span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions);
+        [[nodiscard]] bool TryAllocate(size_t size, NovelRT::Utilities::Misc::Span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions);
 
         void Free(const GraphicsMemoryRegion<GraphicsMemoryBlock>& region);
 

--- a/include/NovelRT/Graphics/GraphicsMemoryBlockCollection.h
+++ b/include/NovelRT/Graphics/GraphicsMemoryBlockCollection.h
@@ -88,12 +88,15 @@ namespace NovelRT::Graphics
 
         [[nodiscard]] bool TryAllocate(size_t size, GraphicsMemoryRegion<GraphicsMemoryBlock>& outRegion);
 
-        [[nodiscard]] bool TryAllocate(size_t size,
-                                       size_t alignment,
-                                       GraphicsMemoryRegionAllocationFlags flags,
-                                       NovelRT::Utilities::Misc::Span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions);
+        [[nodiscard]] bool TryAllocate(
+            size_t size,
+            size_t alignment,
+            GraphicsMemoryRegionAllocationFlags flags,
+            NovelRT::Utilities::Misc::Span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions);
 
-        [[nodiscard]] bool TryAllocate(size_t size, NovelRT::Utilities::Misc::Span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions);
+        [[nodiscard]] bool TryAllocate(
+            size_t size,
+            NovelRT::Utilities::Misc::Span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions);
 
         void Free(const GraphicsMemoryRegion<GraphicsMemoryBlock>& region);
 

--- a/include/NovelRT/Graphics/GraphicsPipelineInput.h
+++ b/include/NovelRT/Graphics/GraphicsPipelineInput.h
@@ -16,9 +16,9 @@ namespace NovelRT::Graphics
         std::vector<GraphicsPipelineInputElement> _elements;
 
     public:
-        explicit GraphicsPipelineInput(gsl::span<const GraphicsPipelineInputElement> elements) noexcept;
+        explicit GraphicsPipelineInput(NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement> elements) noexcept;
 
-        [[nodiscard]] gsl::span<const GraphicsPipelineInputElement> GetElements() const noexcept;
+        [[nodiscard]] NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement> GetElements() const noexcept;
     };
 }
 

--- a/include/NovelRT/Graphics/GraphicsPipelineInput.h
+++ b/include/NovelRT/Graphics/GraphicsPipelineInput.h
@@ -16,7 +16,8 @@ namespace NovelRT::Graphics
         std::vector<GraphicsPipelineInputElement> _elements;
 
     public:
-        explicit GraphicsPipelineInput(NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement> elements) noexcept;
+        explicit GraphicsPipelineInput(
+            NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement> elements) noexcept;
 
         [[nodiscard]] NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement> GetElements() const noexcept;
     };

--- a/include/NovelRT/Graphics/GraphicsPipelineSignature.h
+++ b/include/NovelRT/Graphics/GraphicsPipelineSignature.h
@@ -22,11 +22,11 @@ namespace NovelRT::Graphics
         GraphicsPipelineSignature(std::shared_ptr<GraphicsDevice> device,
                                   GraphicsPipelineBlendFactor srcBlendFactor,
                                   GraphicsPipelineBlendFactor dstBlendFactor,
-                                  gsl::span<const GraphicsPipelineInput> inputs,
-                                  gsl::span<const GraphicsPipelineResource> resources) noexcept;
+                                  NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs,
+                                  NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource> resources) noexcept;
 
-        [[nodiscard]] gsl::span<const GraphicsPipelineInput> GetInputs() const noexcept;
-        [[nodiscard]] gsl::span<const GraphicsPipelineResource> GetResources() const noexcept;
+        [[nodiscard]] NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> GetInputs() const noexcept;
+        [[nodiscard]] NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource> GetResources() const noexcept;
 
         [[nodiscard]] inline GraphicsPipelineBlendFactor GetSrcBlendFactor() const noexcept
         {

--- a/include/NovelRT/Graphics/GraphicsPrimitive.h
+++ b/include/NovelRT/Graphics/GraphicsPrimitive.h
@@ -21,13 +21,14 @@ namespace NovelRT::Graphics
         uint32_t _indexBufferStride;
 
     public:
-        GraphicsPrimitive(const std::shared_ptr<GraphicsDevice>& device,
-                          std::shared_ptr<GraphicsPipeline> pipeline,
-                          GraphicsMemoryRegion<GraphicsResource> vertexBufferRegion,
-                          uint32_t vertexBufferStride,
-                          GraphicsMemoryRegion<GraphicsResource> indexBufferRegion,
-                          uint32_t indexBufferStride,
-                          NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions)
+        GraphicsPrimitive(
+            const std::shared_ptr<GraphicsDevice>& device,
+            std::shared_ptr<GraphicsPipeline> pipeline,
+            GraphicsMemoryRegion<GraphicsResource> vertexBufferRegion,
+            uint32_t vertexBufferStride,
+            GraphicsMemoryRegion<GraphicsResource> indexBufferRegion,
+            uint32_t indexBufferStride,
+            NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions)
             : GraphicsDeviceObject(std::weak_ptr<GraphicsDevice>(device)),
               _pipeline(std::move(pipeline)),
               _vertexBufferRegion(std::move(vertexBufferRegion)),
@@ -79,11 +80,11 @@ namespace NovelRT::Graphics
             return _indexBufferStride;
         }
 
-        [[nodiscard]] inline NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> GetInputResourceRegions()
-            const noexcept
+        [[nodiscard]] inline NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>>
+        GetInputResourceRegions() const noexcept
         {
-            return NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>>(&(*_inputResourceRegions.begin()),
-                                                                           _inputResourceRegions.size());
+            return NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>>(
+                &(*_inputResourceRegions.begin()), _inputResourceRegions.size());
         }
 
         [[nodiscard]] inline std::shared_ptr<GraphicsPipeline> GetPipeline() const noexcept

--- a/include/NovelRT/Graphics/GraphicsPrimitive.h
+++ b/include/NovelRT/Graphics/GraphicsPrimitive.h
@@ -27,7 +27,7 @@ namespace NovelRT::Graphics
                           uint32_t vertexBufferStride,
                           GraphicsMemoryRegion<GraphicsResource> indexBufferRegion,
                           uint32_t indexBufferStride,
-                          gsl::span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions)
+                          NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions)
             : GraphicsDeviceObject(std::weak_ptr<GraphicsDevice>(device)),
               _pipeline(std::move(pipeline)),
               _vertexBufferRegion(std::move(vertexBufferRegion)),
@@ -79,10 +79,10 @@ namespace NovelRT::Graphics
             return _indexBufferStride;
         }
 
-        [[nodiscard]] inline gsl::span<const GraphicsMemoryRegion<GraphicsResource>> GetInputResourceRegions()
+        [[nodiscard]] inline NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> GetInputResourceRegions()
             const noexcept
         {
-            return gsl::span<const GraphicsMemoryRegion<GraphicsResource>>(&(*_inputResourceRegions.begin()),
+            return NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>>(&(*_inputResourceRegions.begin()),
                                                                            _inputResourceRegions.size());
         }
 

--- a/include/NovelRT/Graphics/GraphicsResourceManager.h
+++ b/include/NovelRT/Graphics/GraphicsResourceManager.h
@@ -47,7 +47,7 @@ namespace NovelRT::Graphics
         void PrepForFrameWithContextIndex(size_t newContextIndex);
 
         template<typename TData>
-        [[nodiscard]] GraphicsMemoryRegion<GraphicsResource> LoadVertexData(gsl::span<TData> data, size_t alignment = 0)
+        [[nodiscard]] GraphicsMemoryRegion<GraphicsResource> LoadVertexData(NovelRT::Utilities::Misc::Span<TData> data, size_t alignment = 0)
         {
             return LoadVertexDataUntyped(&(*data.begin()), sizeof(TData), data.size(), alignment);
         }
@@ -58,7 +58,7 @@ namespace NovelRT::Graphics
                                                                                    size_t alignment = 16);
 
         template<typename TData>
-        [[nodiscard]] GraphicsMemoryRegion<GraphicsResource> LoadIndexData(gsl::span<TData> data, size_t alignment = 0)
+        [[nodiscard]] GraphicsMemoryRegion<GraphicsResource> LoadIndexData(NovelRT::Utilities::Misc::Span<TData> data, size_t alignment = 0)
         {
             return LoadIndexDataUntyped(&(*data.begin()), sizeof(TData), data.size(), alignment);
         }

--- a/include/NovelRT/Graphics/GraphicsResourceManager.h
+++ b/include/NovelRT/Graphics/GraphicsResourceManager.h
@@ -47,7 +47,8 @@ namespace NovelRT::Graphics
         void PrepForFrameWithContextIndex(size_t newContextIndex);
 
         template<typename TData>
-        [[nodiscard]] GraphicsMemoryRegion<GraphicsResource> LoadVertexData(NovelRT::Utilities::Misc::Span<TData> data, size_t alignment = 0)
+        [[nodiscard]] GraphicsMemoryRegion<GraphicsResource> LoadVertexData(NovelRT::Utilities::Misc::Span<TData> data,
+                                                                            size_t alignment = 0)
         {
             return LoadVertexDataUntyped(&(*data.begin()), sizeof(TData), data.size(), alignment);
         }
@@ -58,7 +59,8 @@ namespace NovelRT::Graphics
                                                                                    size_t alignment = 16);
 
         template<typename TData>
-        [[nodiscard]] GraphicsMemoryRegion<GraphicsResource> LoadIndexData(NovelRT::Utilities::Misc::Span<TData> data, size_t alignment = 0)
+        [[nodiscard]] GraphicsMemoryRegion<GraphicsResource> LoadIndexData(NovelRT::Utilities::Misc::Span<TData> data,
+                                                                           size_t alignment = 0)
         {
             return LoadIndexDataUntyped(&(*data.begin()), sizeof(TData), data.size(), alignment);
         }

--- a/include/NovelRT/Graphics/IGraphicsMemoryRegionCollection.h
+++ b/include/NovelRT/Graphics/IGraphicsMemoryRegionCollection.h
@@ -301,7 +301,7 @@ namespace NovelRT::Graphics
 
                 if (GetTotalFreeRegionSize() >= sizeWithMargins)
                 {
-                    gsl::span<typename std::list<GraphicsMemoryRegion<TSelf>>::iterator> freeRegionsBySizeSpan(
+                    NovelRT::Utilities::Misc::Span<typename std::list<GraphicsMemoryRegion<TSelf>>::iterator> freeRegionsBySizeSpan(
                         *_freeRegionsBySize);
                     size_t freeRegionsBySizeLength = freeRegionsBySizeSpan.size();
 
@@ -429,7 +429,7 @@ namespace NovelRT::Graphics
 
             [[nodiscard]] size_t BinarySearchFirstRegionNodeWithSizeNotLessThan(size_t size) const noexcept
             {
-                gsl::span<const typename std::list<GraphicsMemoryRegion<TSelf>>::iterator> freeRegionsBySizeSpan(
+                NovelRT::Utilities::Misc::Span<const typename std::list<GraphicsMemoryRegion<TSelf>>::iterator> freeRegionsBySizeSpan(
                     &(*_freeRegionsBySize->begin()), _freeRegionsBySize->size());
 
                 size_t index = 0;

--- a/include/NovelRT/Graphics/IGraphicsMemoryRegionCollection.h
+++ b/include/NovelRT/Graphics/IGraphicsMemoryRegionCollection.h
@@ -301,8 +301,8 @@ namespace NovelRT::Graphics
 
                 if (GetTotalFreeRegionSize() >= sizeWithMargins)
                 {
-                    NovelRT::Utilities::Misc::Span<typename std::list<GraphicsMemoryRegion<TSelf>>::iterator> freeRegionsBySizeSpan(
-                        *_freeRegionsBySize);
+                    NovelRT::Utilities::Misc::Span<typename std::list<GraphicsMemoryRegion<TSelf>>::iterator>
+                        freeRegionsBySizeSpan(*_freeRegionsBySize);
                     size_t freeRegionsBySizeLength = freeRegionsBySizeSpan.size();
 
                     if (freeRegionsBySizeLength > 0)
@@ -429,8 +429,8 @@ namespace NovelRT::Graphics
 
             [[nodiscard]] size_t BinarySearchFirstRegionNodeWithSizeNotLessThan(size_t size) const noexcept
             {
-                NovelRT::Utilities::Misc::Span<const typename std::list<GraphicsMemoryRegion<TSelf>>::iterator> freeRegionsBySizeSpan(
-                    &(*_freeRegionsBySize->begin()), _freeRegionsBySize->size());
+                NovelRT::Utilities::Misc::Span<const typename std::list<GraphicsMemoryRegion<TSelf>>::iterator>
+                    freeRegionsBySizeSpan(&(*_freeRegionsBySize->begin()), _freeRegionsBySize->size());
 
                 size_t index = 0;
                 size_t endIndex = freeRegionsBySizeSpan.size();

--- a/include/NovelRT/Graphics/ShaderProgram.h
+++ b/include/NovelRT/Graphics/ShaderProgram.h
@@ -31,7 +31,7 @@ namespace NovelRT::Graphics
             return _kind;
         }
 
-        [[nodiscard]] virtual gsl::span<const uint8_t> GetBytecode() const noexcept = 0;
+        [[nodiscard]] virtual NovelRT::Utilities::Misc::Span<const uint8_t> GetBytecode() const noexcept = 0;
     };
 }
 

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.h
@@ -98,8 +98,8 @@ namespace NovelRT::Graphics::Vulkan
 
         [[nodiscard]] inline NovelRT::Utilities::Misc::Span<std::shared_ptr<GraphicsContext>> GetContexts() final
         {
-            return NovelRT::Utilities::Misc::Span<std::shared_ptr<GraphicsContext>>(&(*_contextPtrs.getActual().begin()),
-                                                               _contextPtrs.getActual().size());
+            return NovelRT::Utilities::Misc::Span<std::shared_ptr<GraphicsContext>>(
+                &(*_contextPtrs.getActual().begin()), _contextPtrs.getActual().size());
         }
 
         [[nodiscard]] std::shared_ptr<VulkanGraphicsContext> GetCurrentContext()
@@ -117,9 +117,10 @@ namespace NovelRT::Graphics::Vulkan
             return std::dynamic_pointer_cast<VulkanGraphicsSurfaceContext>(GraphicsDevice::GetSurfaceContext());
         }
 
-        [[nodiscard]] std::shared_ptr<ShaderProgram> CreateShaderProgram(std::string entryPointName,
-                                                                         ShaderProgramKind kind,
-                                                                         NovelRT::Utilities::Misc::Span<uint8_t> byteData) final;
+        [[nodiscard]] std::shared_ptr<ShaderProgram> CreateShaderProgram(
+            std::string entryPointName,
+            ShaderProgramKind kind,
+            NovelRT::Utilities::Misc::Span<uint8_t> byteData) final;
 
         [[nodiscard]] std::shared_ptr<GraphicsPipeline> CreatePipeline(
             std::shared_ptr<GraphicsPipelineSignature> signature,

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.h
@@ -79,7 +79,7 @@ namespace NovelRT::Graphics::Vulkan
             uint32_t vertexBufferStride,
             GraphicsMemoryRegion<GraphicsResource>& indexBufferRegion,
             uint32_t indexBufferStride,
-            gsl::span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions) final;
+            NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions) final;
 
         [[nodiscard]] std::shared_ptr<VulkanGraphicsPrimitive> CreateVulkanPrimitive(
             std::shared_ptr<VulkanGraphicsPipeline> pipeline,
@@ -87,7 +87,7 @@ namespace NovelRT::Graphics::Vulkan
             uint32_t vertexBufferStride,
             GraphicsMemoryRegion<GraphicsResource>& indexBufferRegion,
             uint32_t indexBufferStride,
-            gsl::span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions);
+            NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions);
 
         void PresentFrame() final;
 
@@ -96,9 +96,9 @@ namespace NovelRT::Graphics::Vulkan
 
         void WaitForIdle() final;
 
-        [[nodiscard]] inline gsl::span<std::shared_ptr<GraphicsContext>> GetContexts() final
+        [[nodiscard]] inline NovelRT::Utilities::Misc::Span<std::shared_ptr<GraphicsContext>> GetContexts() final
         {
-            return gsl::span<std::shared_ptr<GraphicsContext>>(&(*_contextPtrs.getActual().begin()),
+            return NovelRT::Utilities::Misc::Span<std::shared_ptr<GraphicsContext>>(&(*_contextPtrs.getActual().begin()),
                                                                _contextPtrs.getActual().size());
         }
 
@@ -119,7 +119,7 @@ namespace NovelRT::Graphics::Vulkan
 
         [[nodiscard]] std::shared_ptr<ShaderProgram> CreateShaderProgram(std::string entryPointName,
                                                                          ShaderProgramKind kind,
-                                                                         gsl::span<uint8_t> byteData) final;
+                                                                         NovelRT::Utilities::Misc::Span<uint8_t> byteData) final;
 
         [[nodiscard]] std::shared_ptr<GraphicsPipeline> CreatePipeline(
             std::shared_ptr<GraphicsPipelineSignature> signature,
@@ -129,8 +129,8 @@ namespace NovelRT::Graphics::Vulkan
         [[nodiscard]] std::shared_ptr<GraphicsPipelineSignature> CreatePipelineSignature(
             GraphicsPipelineBlendFactor srcBlendFactor,
             GraphicsPipelineBlendFactor dstBlendFactor,
-            gsl::span<GraphicsPipelineInput> inputs,
-            gsl::span<GraphicsPipelineResource> resources) final;
+            NovelRT::Utilities::Misc::Span<GraphicsPipelineInput> inputs,
+            NovelRT::Utilities::Misc::Span<GraphicsPipelineResource> resources) final;
 
         [[nodiscard]] inline VkSwapchainKHR GetVulkanSwapchain()
         {

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsPipeline.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsPipeline.h
@@ -15,7 +15,8 @@ namespace NovelRT::Graphics::Vulkan
     private:
         NovelRT::Utilities::Lazy<VkPipeline> _vulkanPipeline;
         [[nodiscard]] VkPipeline CreateVulkanPipeline();
-        [[nodiscard]] size_t GetInputElementsCount(NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs) const noexcept;
+        [[nodiscard]] size_t GetInputElementsCount(
+            NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs) const noexcept;
         [[nodiscard]] VkFormat GetInputElementFormat(std::type_index index) const noexcept;
 
     public:

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsPipeline.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsPipeline.h
@@ -15,7 +15,7 @@ namespace NovelRT::Graphics::Vulkan
     private:
         NovelRT::Utilities::Lazy<VkPipeline> _vulkanPipeline;
         [[nodiscard]] VkPipeline CreateVulkanPipeline();
-        [[nodiscard]] size_t GetInputElementsCount(gsl::span<const GraphicsPipelineInput> inputs) const noexcept;
+        [[nodiscard]] size_t GetInputElementsCount(NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs) const noexcept;
         [[nodiscard]] VkFormat GetInputElementFormat(std::type_index index) const noexcept;
 
     public:

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsPipelineSignature.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsPipelineSignature.h
@@ -30,11 +30,12 @@ namespace NovelRT::Graphics::Vulkan
             ShaderProgramVisibility shaderVisibility) const noexcept;
 
     public:
-        VulkanGraphicsPipelineSignature(std::shared_ptr<VulkanGraphicsDevice> device,
-                                        GraphicsPipelineBlendFactor srcBlendFactor,
-                                        GraphicsPipelineBlendFactor dstBlendFactor,
-                                        NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs,
-                                        NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource> resources) noexcept;
+        VulkanGraphicsPipelineSignature(
+            std::shared_ptr<VulkanGraphicsDevice> device,
+            GraphicsPipelineBlendFactor srcBlendFactor,
+            GraphicsPipelineBlendFactor dstBlendFactor,
+            NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs,
+            NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource> resources) noexcept;
 
         [[nodiscard]] inline std::shared_ptr<VulkanGraphicsDevice> GetDevice() const
         {

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsPipelineSignature.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsPipelineSignature.h
@@ -33,8 +33,8 @@ namespace NovelRT::Graphics::Vulkan
         VulkanGraphicsPipelineSignature(std::shared_ptr<VulkanGraphicsDevice> device,
                                         GraphicsPipelineBlendFactor srcBlendFactor,
                                         GraphicsPipelineBlendFactor dstBlendFactor,
-                                        gsl::span<const GraphicsPipelineInput> inputs,
-                                        gsl::span<const GraphicsPipelineResource> resources) noexcept;
+                                        NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs,
+                                        NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource> resources) noexcept;
 
         [[nodiscard]] inline std::shared_ptr<VulkanGraphicsDevice> GetDevice() const
         {
@@ -61,7 +61,7 @@ namespace NovelRT::Graphics::Vulkan
             return _vulkanPipelineLayout.getActual();
         }
 
-        void DestroyDescriptorSets(gsl::span<VkDescriptorSet> vulkanDescriptorSets);
+        void DestroyDescriptorSets(NovelRT::Utilities::Misc::Span<VkDescriptorSet> vulkanDescriptorSets);
 
         ~VulkanGraphicsPipelineSignature() final;
     };

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsPrimitive.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsPrimitive.h
@@ -22,7 +22,7 @@ namespace NovelRT::Graphics::Vulkan
                                 uint32_t vertexBufferStride,
                                 GraphicsMemoryRegion<GraphicsResource> indexBufferView,
                                 uint32_t indexBufferStride,
-                                gsl::span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions = {})
+                                NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions = {})
             : GraphicsPrimitive(std::move(device),
                                 std::move(pipeline),
                                 std::move(vertexBufferView),

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsPrimitive.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsPrimitive.h
@@ -16,13 +16,14 @@ namespace NovelRT::Graphics::Vulkan
         Threading::VolatileState _state;
 
     public:
-        VulkanGraphicsPrimitive(std::shared_ptr<VulkanGraphicsDevice> device,
-                                std::shared_ptr<VulkanGraphicsPipeline> pipeline,
-                                GraphicsMemoryRegion<GraphicsResource> vertexBufferView,
-                                uint32_t vertexBufferStride,
-                                GraphicsMemoryRegion<GraphicsResource> indexBufferView,
-                                uint32_t indexBufferStride,
-                                NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions = {})
+        VulkanGraphicsPrimitive(
+            std::shared_ptr<VulkanGraphicsDevice> device,
+            std::shared_ptr<VulkanGraphicsPipeline> pipeline,
+            GraphicsMemoryRegion<GraphicsResource> vertexBufferView,
+            uint32_t vertexBufferStride,
+            GraphicsMemoryRegion<GraphicsResource> indexBufferView,
+            uint32_t indexBufferStride,
+            NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions = {})
             : GraphicsPrimitive(std::move(device),
                                 std::move(pipeline),
                                 std::move(vertexBufferView),

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsProvider.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsProvider.h
@@ -55,9 +55,9 @@ namespace NovelRT::Graphics::Vulkan
             return _vulkanInstance;
         }
 
-        [[nodiscard]] inline gsl::span<const std::string> GetValidationLayers() const noexcept
+        [[nodiscard]] inline NovelRT::Utilities::Misc::Span<const std::string> GetValidationLayers() const noexcept
         {
-            return gsl::span<const std::string>(&(*_finalValidationLayerSet.begin()), _finalValidationLayerSet.size());
+            return NovelRT::Utilities::Misc::Span<const std::string>(&(*_finalValidationLayerSet.begin()), _finalValidationLayerSet.size());
         }
 
         std::vector<std::shared_ptr<GraphicsAdapter>>::iterator begin() noexcept final;

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsProvider.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsProvider.h
@@ -57,7 +57,8 @@ namespace NovelRT::Graphics::Vulkan
 
         [[nodiscard]] inline NovelRT::Utilities::Misc::Span<const std::string> GetValidationLayers() const noexcept
         {
-            return NovelRT::Utilities::Misc::Span<const std::string>(&(*_finalValidationLayerSet.begin()), _finalValidationLayerSet.size());
+            return NovelRT::Utilities::Misc::Span<const std::string>(&(*_finalValidationLayerSet.begin()),
+                                                                     _finalValidationLayerSet.size());
         }
 
         std::vector<std::shared_ptr<GraphicsAdapter>>::iterator begin() noexcept final;

--- a/include/NovelRT/Graphics/Vulkan/VulkanShaderProgram.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanShaderProgram.h
@@ -23,9 +23,9 @@ namespace NovelRT::Graphics::Vulkan
         VulkanShaderProgram(std::shared_ptr<VulkanGraphicsDevice> device,
                             std::string entryPointName,
                             ShaderProgramKind kind,
-                            gsl::span<uint8_t> bytecode) noexcept;
+                            NovelRT::Utilities::Misc::Span<uint8_t> bytecode) noexcept;
 
-        [[nodiscard]] gsl::span<const uint8_t> GetBytecode() const noexcept final;
+        [[nodiscard]] NovelRT::Utilities::Misc::Span<const uint8_t> GetBytecode() const noexcept final;
         [[nodiscard]] VkShaderModule GetShaderModule();
 
         ~VulkanShaderProgram() override;

--- a/include/NovelRT/Input/Glfw/GlfwInputDevice.h
+++ b/include/NovelRT/Input/Glfw/GlfwInputDevice.h
@@ -31,7 +31,7 @@ namespace NovelRT::Input::Glfw
                                                   const std::string& keyIdentifier) final;
         [[nodiscard]] NovelKey& GetAvailableKey(const std::string& keyRequested) final;
         [[nodiscard]] NovelRT::Maths::GeoVector2F GetMousePosition() noexcept final;
-        [[nodiscard]] gsl::span<InputAction> GetAllMappings() noexcept final;
+        [[nodiscard]] NovelRT::Utilities::Misc::Span<InputAction> GetAllMappings() noexcept final;
 
         ~GlfwInputDevice() final;
     };

--- a/include/NovelRT/Input/IInputDevice.h
+++ b/include/NovelRT/Input/IInputDevice.h
@@ -28,7 +28,7 @@ namespace NovelRT::Input
                                                           const std::string& keyIdentifier) = 0;
         [[nodiscard]] virtual NovelKey& GetAvailableKey(const std::string& keyRequested) = 0;
         [[nodiscard]] virtual NovelRT::Maths::GeoVector2F GetMousePosition() = 0;
-        [[nodiscard]] virtual gsl::span<InputAction> GetAllMappings() = 0;
+        [[nodiscard]] virtual NovelRT::Utilities::Misc::Span<InputAction> GetAllMappings() = 0;
 
         virtual ~IInputDevice() = default;
     };

--- a/include/NovelRT/Input/Input.h
+++ b/include/NovelRT/Input/Input.h
@@ -8,7 +8,7 @@
 #include "NovelRT/LoggingService.h"
 #include "NovelRT/Maths/Maths.h"
 #include "NovelRT/Timing/Timestamp.h"
-#include <gsl/span>
+#include "NovelRT/Utilities/Misc.h"
 #include <map>
 #include <string>
 

--- a/include/NovelRT/Persistence/Chapter.h
+++ b/include/NovelRT/Persistence/Chapter.h
@@ -18,7 +18,8 @@ namespace NovelRT::Persistence
     public:
         Chapter() noexcept;
 
-        explicit Chapter(NovelRT::Utilities::Misc::Span<std::shared_ptr<Ecs::ComponentBufferMemoryContainer>> componentCacheData) noexcept;
+        explicit Chapter(NovelRT::Utilities::Misc::Span<std::shared_ptr<Ecs::ComponentBufferMemoryContainer>>
+                             componentCacheData) noexcept;
 
         void ToEcsInstance(Ecs::ComponentCache& componentCache, Ecs::EntityCache& entityCache) const;
 

--- a/include/NovelRT/Persistence/Chapter.h
+++ b/include/NovelRT/Persistence/Chapter.h
@@ -18,7 +18,7 @@ namespace NovelRT::Persistence
     public:
         Chapter() noexcept;
 
-        explicit Chapter(gsl::span<std::shared_ptr<Ecs::ComponentBufferMemoryContainer>> componentCacheData) noexcept;
+        explicit Chapter(NovelRT::Utilities::Misc::Span<std::shared_ptr<Ecs::ComponentBufferMemoryContainer>> componentCacheData) noexcept;
 
         void ToEcsInstance(Ecs::ComponentCache& componentCache, Ecs::EntityCache& entityCache) const;
 

--- a/include/NovelRT/Persistence/Graphics/RenderingComponentPersistenceRule.h
+++ b/include/NovelRT/Persistence/Graphics/RenderingComponentPersistenceRule.h
@@ -25,10 +25,10 @@ namespace NovelRT::Persistence::Graphics
         }
 
         [[nodiscard]] std::vector<uint8_t> ExecuteSerialiseModification(
-            gsl::span<const uint8_t> component) const noexcept final;
+            NovelRT::Utilities::Misc::Span<const uint8_t> component) const noexcept final;
 
         [[nodiscard]] std::vector<uint8_t> ExecuteDeserialiseModification(
-            gsl::span<const uint8_t> component) const noexcept final;
+            NovelRT::Utilities::Misc::Span<const uint8_t> component) const noexcept final;
     };
 }
 

--- a/include/NovelRT/Persistence/ICustomSerialisationRule.h
+++ b/include/NovelRT/Persistence/ICustomSerialisationRule.h
@@ -17,9 +17,9 @@ namespace NovelRT::Persistence
 
         [[nodiscard]] virtual size_t GetSerialisedSize() const noexcept = 0;
         [[nodiscard]] virtual std::vector<uint8_t> ExecuteSerialiseModification(
-            gsl::span<const uint8_t> component) const noexcept = 0;
+            NovelRT::Utilities::Misc::Span<const uint8_t> component) const noexcept = 0;
         [[nodiscard]] virtual std::vector<uint8_t> ExecuteDeserialiseModification(
-            gsl::span<const uint8_t> component) const noexcept = 0;
+            NovelRT::Utilities::Misc::Span<const uint8_t> component) const noexcept = 0;
     };
 }
 #endif // NOVELRT_PERSISTENCE_ICUSTOMSERIALISATIONRULE_H

--- a/include/NovelRT/Persistence/Persistable.h
+++ b/include/NovelRT/Persistence/Persistable.h
@@ -14,12 +14,12 @@ namespace NovelRT::Persistence
     {
     protected:
         void ApplySerialisationRule(const std::string& serialisedName,
-                                    gsl::span<const uint8_t> componentData,
-                                    gsl::span<uint8_t> writeToData) const;
+                                    NovelRT::Utilities::Misc::Span<const uint8_t> componentData,
+                                    NovelRT::Utilities::Misc::Span<uint8_t> writeToData) const;
 
         void ApplyDeserialisationRule(const std::string& serialisedName,
-                                      gsl::span<const uint8_t> serialisedData,
-                                      gsl::span<uint8_t> writeToData) const;
+                                      NovelRT::Utilities::Misc::Span<const uint8_t> serialisedData,
+                                      NovelRT::Utilities::Misc::Span<uint8_t> writeToData) const;
 
     public:
         [[nodiscard]] static std::unordered_map<std::string, std::unique_ptr<ICustomSerialisationRule>>&

--- a/include/NovelRT/Persistence/Persistence.h
+++ b/include/NovelRT/Persistence/Persistence.h
@@ -7,7 +7,7 @@
 // Persistence dependencies
 #include "../Ecs/Ecs.h"
 #include "../ResourceManagement/ResourceManagement.h"
-#include <gsl/span>
+#include "../Utilities/Misc.h"
 #include <map>
 #include <sstream>
 #include <string>

--- a/include/NovelRT/Utilities/Misc.h
+++ b/include/NovelRT/Utilities/Misc.h
@@ -11,18 +11,23 @@
 #endif
 
 #include <filesystem>
-#include <gsl/span>
 #include <type_traits>
 #include <vector>
 
 #if __has_include(<version>)
 #include <version>
+#endif
 
 #if __cpp_lib_bit_cast
 #include <bit>
 #endif
 
-#endif
+#ifdef NOVELRT_USE_STD_SPAN
+#include <span>
+#else
+#include <gsl/span>
+#endif // NOVELRT_USE_STD_SPAN
+
 
 #define unused(x) (void)(x)
 
@@ -39,6 +44,13 @@ namespace NovelRT::Utilities
         static inline const char* CONSOLE_LOG_AUDIO = "Audio";
         static inline const char* CONSOLE_LOG_INPUT = "Input";
         static inline const char* CONSOLE_LOG_WINDOWING = "WindowManager";
+
+        template<class T>
+#ifdef NOVELRT_USE_STD_SPAN
+        using Span = std::span<T>;
+#else
+        using Span = gsl::span<T>;
+#endif
 
         /**
          * @brief Gets the path to the executable.

--- a/include/NovelRT/Utilities/Misc.h
+++ b/include/NovelRT/Utilities/Misc.h
@@ -28,7 +28,6 @@
 #include <gsl/span>
 #endif // NOVELRT_USE_STD_SPAN
 
-
 #define unused(x) (void)(x)
 
 namespace NovelRT::Utilities

--- a/include/NovelRT/Utilities/Misc.h
+++ b/include/NovelRT/Utilities/Misc.h
@@ -71,7 +71,7 @@ namespace NovelRT::Utilities
         }
 
         [[nodiscard]] static std::vector<const char*> GetStringSpanAsCharPtrVector(
-            const gsl::span<const std::string>& target) noexcept
+            const NovelRT::Utilities::Misc::Span<const std::string>& target) noexcept
         {
             size_t extensionLength = target.size();
             std::vector<const char*> targetPtrs{};

--- a/include/NovelRT/Utilities/Misc.h
+++ b/include/NovelRT/Utilities/Misc.h
@@ -22,7 +22,7 @@
 #include <bit>
 #endif
 
-#ifdef NOVELRT_USE_STD_SPAN
+#if NOVELRT_USE_STD_SPAN
 #include <span>
 #else
 #include <gsl/span>

--- a/samples/PersistenceSample/main.cpp
+++ b/samples/PersistenceSample/main.cpp
@@ -52,7 +52,7 @@ int main()
             return sizeof(CopyStruct);
         }
 
-        std::vector<uint8_t> ExecuteSerialiseModification(gsl::span<const uint8_t> component) const noexcept final
+        std::vector<uint8_t> ExecuteSerialiseModification(NovelRT::Utilities::Misc::Span<const uint8_t> component) const noexcept final
         {
             TestStruct componentStruct = *reinterpret_cast<const TestStruct*>(component.data());
 
@@ -66,7 +66,7 @@ int main()
             return data;
         }
 
-        std::vector<uint8_t> ExecuteDeserialiseModification(gsl::span<const uint8_t> component) const noexcept final
+        std::vector<uint8_t> ExecuteDeserialiseModification(NovelRT::Utilities::Misc::Span<const uint8_t> component) const noexcept final
         {
             auto dataPtr = reinterpret_cast<const CopyStruct*>(component.data());
 

--- a/samples/PersistenceSample/main.cpp
+++ b/samples/PersistenceSample/main.cpp
@@ -52,7 +52,8 @@ int main()
             return sizeof(CopyStruct);
         }
 
-        std::vector<uint8_t> ExecuteSerialiseModification(NovelRT::Utilities::Misc::Span<const uint8_t> component) const noexcept final
+        std::vector<uint8_t> ExecuteSerialiseModification(
+            NovelRT::Utilities::Misc::Span<const uint8_t> component) const noexcept final
         {
             TestStruct componentStruct = *reinterpret_cast<const TestStruct*>(component.data());
 
@@ -66,7 +67,8 @@ int main()
             return data;
         }
 
-        std::vector<uint8_t> ExecuteDeserialiseModification(NovelRT::Utilities::Misc::Span<const uint8_t> component) const noexcept final
+        std::vector<uint8_t> ExecuteDeserialiseModification(
+            NovelRT::Utilities::Misc::Span<const uint8_t> component) const noexcept final
         {
             auto dataPtr = reinterpret_cast<const CopyStruct*>(component.data());
 

--- a/src/NovelRT/Audio/AudioService.cpp
+++ b/src/NovelRT/Audio/AudioService.cpp
@@ -328,7 +328,9 @@ namespace NovelRT::Audio
         }
     }
 
-    ALuint AudioService::LoadSound(NovelRT::Utilities::Misc::Span<const int16_t> audioFrameData, int32_t channelCount, int32_t sampleRate)
+    ALuint AudioService::LoadSound(NovelRT::Utilities::Misc::Span<const int16_t> audioFrameData,
+                                   int32_t channelCount,
+                                   int32_t sampleRate)
     {
         if (!isInitialised)
         {

--- a/src/NovelRT/Audio/AudioService.cpp
+++ b/src/NovelRT/Audio/AudioService.cpp
@@ -58,7 +58,7 @@ namespace NovelRT::Audio
         return isInitialised;
     }
 
-    ALuint AudioService::BufferAudioFrameData(gsl::span<const int16_t> audioFrameData,
+    ALuint AudioService::BufferAudioFrameData(NovelRT::Utilities::Misc::Span<const int16_t> audioFrameData,
                                               int32_t channelCount,
                                               int32_t sampleRate)
     {
@@ -79,7 +79,7 @@ namespace NovelRT::Audio
       If it is called on the main thread, please do all loading of audio files at the start of
       the engine (after NovelRunner has been created).
     */
-    std::vector<ALuint>::iterator AudioService::LoadMusic(gsl::span<const int16_t> audioFrameData,
+    std::vector<ALuint>::iterator AudioService::LoadMusic(NovelRT::Utilities::Misc::Span<const int16_t> audioFrameData,
                                                           int32_t channelCount,
                                                           int32_t sampleRate)
     {
@@ -328,7 +328,7 @@ namespace NovelRT::Audio
         }
     }
 
-    ALuint AudioService::LoadSound(gsl::span<const int16_t> audioFrameData, int32_t channelCount, int32_t sampleRate)
+    ALuint AudioService::LoadSound(NovelRT::Utilities::Misc::Span<const int16_t> audioFrameData, int32_t channelCount, int32_t sampleRate)
     {
         if (!isInitialised)
         {

--- a/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
+++ b/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
@@ -196,7 +196,7 @@ namespace NovelRT::Ecs
         return _dense.size();
     }
 
-    void SparseSetMemoryContainer::ResetAndWriteDenseData(gsl::span<const size_t> ids, gsl::span<const uint8_t> data)
+    void SparseSetMemoryContainer::ResetAndWriteDenseData(NovelRT::Utilities::Misc::Span<const size_t> ids, NovelRT::Utilities::Misc::Span<const uint8_t> data)
     {
         _dense.clear();
         _dense.resize(ids.size());
@@ -221,8 +221,8 @@ namespace NovelRT::Ecs
 
     void SparseSetMemoryContainer::ResetAndWriteDenseData(const size_t* ids, size_t length, const uint8_t* data)
     {
-        ResetAndWriteDenseData(gsl::span<const size_t>(ids, length),
-                               gsl::span<const uint8_t>(data, length * GetSizeOfDataTypeInBytes()));
+        ResetAndWriteDenseData(NovelRT::Utilities::Misc::Span<const size_t>(ids, length),
+                               NovelRT::Utilities::Misc::Span<const uint8_t>(data, length * GetSizeOfDataTypeInBytes()));
     }
 
     SparseSetMemoryContainer::ByteIteratorView SparseSetMemoryContainer::operator[](size_t key) noexcept

--- a/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
+++ b/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
@@ -196,7 +196,8 @@ namespace NovelRT::Ecs
         return _dense.size();
     }
 
-    void SparseSetMemoryContainer::ResetAndWriteDenseData(NovelRT::Utilities::Misc::Span<const size_t> ids, NovelRT::Utilities::Misc::Span<const uint8_t> data)
+    void SparseSetMemoryContainer::ResetAndWriteDenseData(NovelRT::Utilities::Misc::Span<const size_t> ids,
+                                                          NovelRT::Utilities::Misc::Span<const uint8_t> data)
     {
         _dense.clear();
         _dense.resize(ids.size());
@@ -221,8 +222,9 @@ namespace NovelRT::Ecs
 
     void SparseSetMemoryContainer::ResetAndWriteDenseData(const size_t* ids, size_t length, const uint8_t* data)
     {
-        ResetAndWriteDenseData(NovelRT::Utilities::Misc::Span<const size_t>(ids, length),
-                               NovelRT::Utilities::Misc::Span<const uint8_t>(data, length * GetSizeOfDataTypeInBytes()));
+        ResetAndWriteDenseData(
+            NovelRT::Utilities::Misc::Span<const size_t>(ids, length),
+            NovelRT::Utilities::Misc::Span<const uint8_t>(data, length * GetSizeOfDataTypeInBytes()));
     }
 
     SparseSetMemoryContainer::ByteIteratorView SparseSetMemoryContainer::operator[](size_t key) noexcept

--- a/src/NovelRT/Graphics/GraphicsMemoryBlockCollection.cpp
+++ b/src/NovelRT/Graphics/GraphicsMemoryBlockCollection.cpp
@@ -56,7 +56,8 @@ namespace NovelRT::Graphics
     size_t GraphicsMemoryBlockCollection::GetLargestSharedBlockSize() const noexcept
     {
         size_t result = 0;
-        NovelRT::Utilities::Misc::Span<const std::shared_ptr<GraphicsMemoryBlock>> blocks(&(*_blocks.begin()), _blocks.size());
+        NovelRT::Utilities::Misc::Span<const std::shared_ptr<GraphicsMemoryBlock>> blocks(&(*_blocks.begin()),
+                                                                                          _blocks.size());
         size_t maximumSharedBlockSize = GetMaximumSharedBlockSize();
 
         for (size_t i = blocks.size(); i-- != 0;)
@@ -82,7 +83,8 @@ namespace NovelRT::Graphics
         // Bubble sort only until first swap. This is called after
         // freeing a region and will result in eventual consistency.
 
-        NovelRT::Utilities::Misc::Span<std::shared_ptr<GraphicsMemoryBlock>> blocks(&(*_blocks.begin()), _blocks.size());
+        NovelRT::Utilities::Misc::Span<std::shared_ptr<GraphicsMemoryBlock>> blocks(&(*_blocks.begin()),
+                                                                                    _blocks.size());
 
         if (blocks.size() >= 2)
         {
@@ -148,7 +150,8 @@ namespace NovelRT::Graphics
         size_t maximumSharedBlockSize = GetMaximumSharedBlockSize();
         size_t sizeWithMargins = size + (2 * _allocator->GetSettings().MinimumAllocatedRegionMarginSize.value_or(0));
 
-        NovelRT::Utilities::Misc::Span<std::shared_ptr<GraphicsMemoryBlock>> blocks(&(*_blocks.begin()), _blocks.size());
+        NovelRT::Utilities::Misc::Span<std::shared_ptr<GraphicsMemoryBlock>> blocks(&(*_blocks.begin()),
+                                                                                    _blocks.size());
         size_t blocksLength = blocks.size();
 
         size_t availableMemory = (budget.GetEstimatedUsage() < budget.GetEstimatedBudget())
@@ -356,10 +359,11 @@ namespace NovelRT::Graphics
         return TryAllocate(size, 1, GraphicsMemoryRegionAllocationFlags::None, outRegion);
     }
 
-    bool GraphicsMemoryBlockCollection::TryAllocate(size_t size,
-                                                    size_t alignment,
-                                                    GraphicsMemoryRegionAllocationFlags flags,
-                                                    NovelRT::Utilities::Misc::Span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions)
+    bool GraphicsMemoryBlockCollection::TryAllocate(
+        size_t size,
+        size_t alignment,
+        GraphicsMemoryRegionAllocationFlags flags,
+        NovelRT::Utilities::Misc::Span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions)
     {
         bool succeeded = true;
         size_t index;
@@ -391,8 +395,9 @@ namespace NovelRT::Graphics
         return succeeded;
     }
 
-    bool GraphicsMemoryBlockCollection::TryAllocate(size_t size,
-                                                    NovelRT::Utilities::Misc::Span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions)
+    bool GraphicsMemoryBlockCollection::TryAllocate(
+        size_t size,
+        NovelRT::Utilities::Misc::Span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions)
     {
         return TryAllocate(size, 1, GraphicsMemoryRegionAllocationFlags::None, regions);
     }

--- a/src/NovelRT/Graphics/GraphicsMemoryBlockCollection.cpp
+++ b/src/NovelRT/Graphics/GraphicsMemoryBlockCollection.cpp
@@ -56,7 +56,7 @@ namespace NovelRT::Graphics
     size_t GraphicsMemoryBlockCollection::GetLargestSharedBlockSize() const noexcept
     {
         size_t result = 0;
-        gsl::span<const std::shared_ptr<GraphicsMemoryBlock>> blocks(&(*_blocks.begin()), _blocks.size());
+        NovelRT::Utilities::Misc::Span<const std::shared_ptr<GraphicsMemoryBlock>> blocks(&(*_blocks.begin()), _blocks.size());
         size_t maximumSharedBlockSize = GetMaximumSharedBlockSize();
 
         for (size_t i = blocks.size(); i-- != 0;)
@@ -82,7 +82,7 @@ namespace NovelRT::Graphics
         // Bubble sort only until first swap. This is called after
         // freeing a region and will result in eventual consistency.
 
-        gsl::span<std::shared_ptr<GraphicsMemoryBlock>> blocks(&(*_blocks.begin()), _blocks.size());
+        NovelRT::Utilities::Misc::Span<std::shared_ptr<GraphicsMemoryBlock>> blocks(&(*_blocks.begin()), _blocks.size());
 
         if (blocks.size() >= 2)
         {
@@ -148,7 +148,7 @@ namespace NovelRT::Graphics
         size_t maximumSharedBlockSize = GetMaximumSharedBlockSize();
         size_t sizeWithMargins = size + (2 * _allocator->GetSettings().MinimumAllocatedRegionMarginSize.value_or(0));
 
-        gsl::span<std::shared_ptr<GraphicsMemoryBlock>> blocks(&(*_blocks.begin()), _blocks.size());
+        NovelRT::Utilities::Misc::Span<std::shared_ptr<GraphicsMemoryBlock>> blocks(&(*_blocks.begin()), _blocks.size());
         size_t blocksLength = blocks.size();
 
         size_t availableMemory = (budget.GetEstimatedUsage() < budget.GetEstimatedBudget())
@@ -359,7 +359,7 @@ namespace NovelRT::Graphics
     bool GraphicsMemoryBlockCollection::TryAllocate(size_t size,
                                                     size_t alignment,
                                                     GraphicsMemoryRegionAllocationFlags flags,
-                                                    gsl::span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions)
+                                                    NovelRT::Utilities::Misc::Span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions)
     {
         bool succeeded = true;
         size_t index;
@@ -392,7 +392,7 @@ namespace NovelRT::Graphics
     }
 
     bool GraphicsMemoryBlockCollection::TryAllocate(size_t size,
-                                                    gsl::span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions)
+                                                    NovelRT::Utilities::Misc::Span<GraphicsMemoryRegion<GraphicsMemoryBlock>> regions)
     {
         return TryAllocate(size, 1, GraphicsMemoryRegionAllocationFlags::None, regions);
     }

--- a/src/NovelRT/Graphics/GraphicsPipelineInput.cpp
+++ b/src/NovelRT/Graphics/GraphicsPipelineInput.cpp
@@ -5,13 +5,13 @@
 
 namespace NovelRT::Graphics
 {
-    GraphicsPipelineInput::GraphicsPipelineInput(gsl::span<const GraphicsPipelineInputElement> elements) noexcept
+    GraphicsPipelineInput::GraphicsPipelineInput(NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement> elements) noexcept
         : _elements(std::vector<GraphicsPipelineInputElement>(elements.begin(), elements.end()))
     {
     }
 
-    gsl::span<const GraphicsPipelineInputElement> GraphicsPipelineInput::GetElements() const noexcept
+    NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement> GraphicsPipelineInput::GetElements() const noexcept
     {
-        return gsl::span<const GraphicsPipelineInputElement>(&(*_elements.begin()), _elements.size());
+        return NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement>(&(*_elements.begin()), _elements.size());
     }
 } // namespace NovelRT::Graphics

--- a/src/NovelRT/Graphics/GraphicsPipelineInput.cpp
+++ b/src/NovelRT/Graphics/GraphicsPipelineInput.cpp
@@ -5,13 +5,16 @@
 
 namespace NovelRT::Graphics
 {
-    GraphicsPipelineInput::GraphicsPipelineInput(NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement> elements) noexcept
+    GraphicsPipelineInput::GraphicsPipelineInput(
+        NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement> elements) noexcept
         : _elements(std::vector<GraphicsPipelineInputElement>(elements.begin(), elements.end()))
     {
     }
 
-    NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement> GraphicsPipelineInput::GetElements() const noexcept
+    NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement> GraphicsPipelineInput::GetElements()
+        const noexcept
     {
-        return NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement>(&(*_elements.begin()), _elements.size());
+        return NovelRT::Utilities::Misc::Span<const GraphicsPipelineInputElement>(&(*_elements.begin()),
+                                                                                  _elements.size());
     }
 } // namespace NovelRT::Graphics

--- a/src/NovelRT/Graphics/GraphicsPipelineSignature.cpp
+++ b/src/NovelRT/Graphics/GraphicsPipelineSignature.cpp
@@ -9,8 +9,8 @@ namespace NovelRT::Graphics
     GraphicsPipelineSignature::GraphicsPipelineSignature(std::shared_ptr<GraphicsDevice> device,
                                                          GraphicsPipelineBlendFactor srcBlendFactor,
                                                          GraphicsPipelineBlendFactor dstBlendFactor,
-                                                         gsl::span<const GraphicsPipelineInput> inputs,
-                                                         gsl::span<const GraphicsPipelineResource> resources) noexcept
+                                                         NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs,
+                                                         NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource> resources) noexcept
         : GraphicsDeviceObject(std::move(device)),
           _srcBlendFactor(srcBlendFactor),
           _dstBlendFactor(dstBlendFactor),
@@ -19,12 +19,12 @@ namespace NovelRT::Graphics
     {
     }
 
-    gsl::span<const GraphicsPipelineInput> GraphicsPipelineSignature::GetInputs() const noexcept
+    NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> GraphicsPipelineSignature::GetInputs() const noexcept
     {
-        return gsl::span<const GraphicsPipelineInput>(&(*_inputs.begin()), _inputs.size());
+        return NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput>(&(*_inputs.begin()), _inputs.size());
     }
-    gsl::span<const GraphicsPipelineResource> GraphicsPipelineSignature::GetResources() const noexcept
+    NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource> GraphicsPipelineSignature::GetResources() const noexcept
     {
-        return gsl::span<const GraphicsPipelineResource>(&(*_resources.begin()), _resources.size());
+        return NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource>(&(*_resources.begin()), _resources.size());
     }
 } // namespace NovelRT::Graphics

--- a/src/NovelRT/Graphics/GraphicsPipelineSignature.cpp
+++ b/src/NovelRT/Graphics/GraphicsPipelineSignature.cpp
@@ -6,11 +6,12 @@
 namespace NovelRT::Graphics
 {
 
-    GraphicsPipelineSignature::GraphicsPipelineSignature(std::shared_ptr<GraphicsDevice> device,
-                                                         GraphicsPipelineBlendFactor srcBlendFactor,
-                                                         GraphicsPipelineBlendFactor dstBlendFactor,
-                                                         NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs,
-                                                         NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource> resources) noexcept
+    GraphicsPipelineSignature::GraphicsPipelineSignature(
+        std::shared_ptr<GraphicsDevice> device,
+        GraphicsPipelineBlendFactor srcBlendFactor,
+        GraphicsPipelineBlendFactor dstBlendFactor,
+        NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs,
+        NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource> resources) noexcept
         : GraphicsDeviceObject(std::move(device)),
           _srcBlendFactor(srcBlendFactor),
           _dstBlendFactor(dstBlendFactor),
@@ -23,8 +24,10 @@ namespace NovelRT::Graphics
     {
         return NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput>(&(*_inputs.begin()), _inputs.size());
     }
-    NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource> GraphicsPipelineSignature::GetResources() const noexcept
+    NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource> GraphicsPipelineSignature::GetResources()
+        const noexcept
     {
-        return NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource>(&(*_resources.begin()), _resources.size());
+        return NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource>(&(*_resources.begin()),
+                                                                              _resources.size());
     }
 } // namespace NovelRT::Graphics

--- a/src/NovelRT/Graphics/Vulkan/VulkanGraphicsContext.cpp
+++ b/src/NovelRT/Graphics/Vulkan/VulkanGraphicsContext.cpp
@@ -378,7 +378,7 @@ namespace NovelRT::Graphics::Vulkan
 
         if (vulkanDescriptorSet != VK_NULL_HANDLE)
         {
-            gsl::span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions =
+            NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions =
                 primitive->GetInputResourceRegions();
             size_t inputResourceRegionsLength = inputResourceRegions.size();
 

--- a/src/NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.cpp
+++ b/src/NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.cpp
@@ -382,9 +382,10 @@ namespace NovelRT::Graphics::Vulkan
         _logger.logInfoLine("Vulkan logical device version 1.2 successfully torn down.");
     }
 
-    std::shared_ptr<ShaderProgram> VulkanGraphicsDevice::CreateShaderProgram(std::string entryPointName,
-                                                                             ShaderProgramKind kind,
-                                                                             NovelRT::Utilities::Misc::Span<uint8_t> byteData)
+    std::shared_ptr<ShaderProgram> VulkanGraphicsDevice::CreateShaderProgram(
+        std::string entryPointName,
+        ShaderProgramKind kind,
+        NovelRT::Utilities::Misc::Span<uint8_t> byteData)
     {
         return std::shared_ptr<ShaderProgram>(
             new VulkanShaderProgram(std::static_pointer_cast<VulkanGraphicsDevice>(shared_from_this()),

--- a/src/NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.cpp
+++ b/src/NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.cpp
@@ -384,7 +384,7 @@ namespace NovelRT::Graphics::Vulkan
 
     std::shared_ptr<ShaderProgram> VulkanGraphicsDevice::CreateShaderProgram(std::string entryPointName,
                                                                              ShaderProgramKind kind,
-                                                                             gsl::span<uint8_t> byteData)
+                                                                             NovelRT::Utilities::Misc::Span<uint8_t> byteData)
     {
         return std::shared_ptr<ShaderProgram>(
             new VulkanShaderProgram(std::static_pointer_cast<VulkanGraphicsDevice>(shared_from_this()),
@@ -411,8 +411,8 @@ namespace NovelRT::Graphics::Vulkan
     std::shared_ptr<GraphicsPipelineSignature> VulkanGraphicsDevice::CreatePipelineSignature(
         GraphicsPipelineBlendFactor srcBlendFactor,
         GraphicsPipelineBlendFactor dstBlendFactor,
-        gsl::span<GraphicsPipelineInput> inputs,
-        gsl::span<GraphicsPipelineResource> resources)
+        NovelRT::Utilities::Misc::Span<GraphicsPipelineInput> inputs,
+        NovelRT::Utilities::Misc::Span<GraphicsPipelineResource> resources)
     {
         return std::static_pointer_cast<GraphicsPipelineSignature>(std::make_shared<VulkanGraphicsPipelineSignature>(
             std::dynamic_pointer_cast<VulkanGraphicsDevice>(shared_from_this()), srcBlendFactor, dstBlendFactor, inputs,
@@ -473,7 +473,7 @@ namespace NovelRT::Graphics::Vulkan
         uint32_t vertexBufferStride,
         GraphicsMemoryRegion<GraphicsResource>& indexBufferRegion,
         uint32_t indexBufferStride,
-        gsl::span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions)
+        NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions)
     {
         return std::static_pointer_cast<GraphicsPrimitive>(
             CreateVulkanPrimitive(std::dynamic_pointer_cast<VulkanGraphicsPipeline>(pipeline), vertexBufferRegion,
@@ -486,7 +486,7 @@ namespace NovelRT::Graphics::Vulkan
         uint32_t vertexBufferStride,
         GraphicsMemoryRegion<GraphicsResource>& indexBufferRegion,
         uint32_t indexBufferStride,
-        gsl::span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions)
+        NovelRT::Utilities::Misc::Span<const GraphicsMemoryRegion<GraphicsResource>> inputResourceRegions)
     {
         return std::make_shared<VulkanGraphicsPrimitive>(
             std::dynamic_pointer_cast<VulkanGraphicsDevice>(shared_from_this()), pipeline, vertexBufferRegion,

--- a/src/NovelRT/Graphics/Vulkan/VulkanGraphicsPipeline.cpp
+++ b/src/NovelRT/Graphics/Vulkan/VulkanGraphicsPipeline.cpp
@@ -191,7 +191,8 @@ namespace NovelRT::Graphics::Vulkan
         return vulkanPipeline;
     }
 
-    size_t VulkanGraphicsPipeline::GetInputElementsCount(NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs) const noexcept
+    size_t VulkanGraphicsPipeline::GetInputElementsCount(
+        NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs) const noexcept
     {
         size_t returnCount = 0;
 

--- a/src/NovelRT/Graphics/Vulkan/VulkanGraphicsPipeline.cpp
+++ b/src/NovelRT/Graphics/Vulkan/VulkanGraphicsPipeline.cpp
@@ -191,7 +191,7 @@ namespace NovelRT::Graphics::Vulkan
         return vulkanPipeline;
     }
 
-    size_t VulkanGraphicsPipeline::GetInputElementsCount(gsl::span<const GraphicsPipelineInput> inputs) const noexcept
+    size_t VulkanGraphicsPipeline::GetInputElementsCount(NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs) const noexcept
     {
         size_t returnCount = 0;
 

--- a/src/NovelRT/Graphics/Vulkan/VulkanGraphicsPipelineSignature.cpp
+++ b/src/NovelRT/Graphics/Vulkan/VulkanGraphicsPipelineSignature.cpp
@@ -248,7 +248,7 @@ namespace NovelRT::Graphics::Vulkan
         }
     }
 
-    void VulkanGraphicsPipelineSignature::DestroyDescriptorSets(gsl::span<VkDescriptorSet> vulkanDescriptorSets)
+    void VulkanGraphicsPipelineSignature::DestroyDescriptorSets(NovelRT::Utilities::Misc::Span<VkDescriptorSet> vulkanDescriptorSets)
     {
         vkFreeDescriptorSets(std::static_pointer_cast<VulkanGraphicsDevice>(GetDevice())->GetVulkanDevice(),
                              _vulkanDescriptorPool.getActual(), static_cast<int32_t>(vulkanDescriptorSets.size()),
@@ -279,8 +279,8 @@ namespace NovelRT::Graphics::Vulkan
         std::shared_ptr<VulkanGraphicsDevice> device,
         GraphicsPipelineBlendFactor srcBlendFactor,
         GraphicsPipelineBlendFactor dstBlendFactor,
-        gsl::span<const GraphicsPipelineInput> inputs,
-        gsl::span<const GraphicsPipelineResource> resources) noexcept
+        NovelRT::Utilities::Misc::Span<const GraphicsPipelineInput> inputs,
+        NovelRT::Utilities::Misc::Span<const GraphicsPipelineResource> resources) noexcept
         : GraphicsPipelineSignature(std::move(device), srcBlendFactor, dstBlendFactor, inputs, resources),
           _vulkanDescriptorPool([&]() { return CreateDescriptorPool(); }),
           _vulkanDescriptorSetLayout([&]() { return CreateDescriptorSetLayout(); }),

--- a/src/NovelRT/Graphics/Vulkan/VulkanGraphicsPipelineSignature.cpp
+++ b/src/NovelRT/Graphics/Vulkan/VulkanGraphicsPipelineSignature.cpp
@@ -248,7 +248,8 @@ namespace NovelRT::Graphics::Vulkan
         }
     }
 
-    void VulkanGraphicsPipelineSignature::DestroyDescriptorSets(NovelRT::Utilities::Misc::Span<VkDescriptorSet> vulkanDescriptorSets)
+    void VulkanGraphicsPipelineSignature::DestroyDescriptorSets(
+        NovelRT::Utilities::Misc::Span<VkDescriptorSet> vulkanDescriptorSets)
     {
         vkFreeDescriptorSets(std::static_pointer_cast<VulkanGraphicsDevice>(GetDevice())->GetVulkanDevice(),
                              _vulkanDescriptorPool.getActual(), static_cast<int32_t>(vulkanDescriptorSets.size()),

--- a/src/NovelRT/Graphics/Vulkan/VulkanShaderProgram.cpp
+++ b/src/NovelRT/Graphics/Vulkan/VulkanShaderProgram.cpp
@@ -8,7 +8,7 @@ namespace NovelRT::Graphics::Vulkan
     VulkanShaderProgram::VulkanShaderProgram(std::shared_ptr<VulkanGraphicsDevice> device,
                                              std::string entryPointName,
                                              ShaderProgramKind kind,
-                                             gsl::span<uint8_t> bytecode) noexcept
+                                             NovelRT::Utilities::Misc::Span<uint8_t> bytecode) noexcept
         : ShaderProgram(device, std::move(entryPointName), kind),
           _shaderModule(NovelRT::Utilities::Lazy<VkShaderModule>(
               std::function<VkShaderModule()>([this]() { return CreateShaderModule(); }))),
@@ -44,9 +44,9 @@ namespace NovelRT::Graphics::Vulkan
                               _shaderModule.getActual(), nullptr);
     }
 
-    gsl::span<const uint8_t> VulkanShaderProgram::GetBytecode() const noexcept
+    NovelRT::Utilities::Misc::Span<const uint8_t> VulkanShaderProgram::GetBytecode() const noexcept
     {
-        return gsl::span<const uint8_t>(&(*_bytecode.begin()), _bytecode.size());
+        return NovelRT::Utilities::Misc::Span<const uint8_t>(&(*_bytecode.begin()), _bytecode.size());
     }
 
     VkShaderModule VulkanShaderProgram::GetShaderModule()

--- a/src/NovelRT/Input/Glfw/GlfwInputDevice.cpp
+++ b/src/NovelRT/Input/Glfw/GlfwInputDevice.cpp
@@ -340,7 +340,7 @@ namespace NovelRT::Input::Glfw
         throw NovelRT::Exceptions::KeyNotFoundException("Unavailable input key requested from input service.");
     }
 
-    gsl::span<InputAction> GlfwInputDevice::GetAllMappings() noexcept
+    NovelRT::Utilities::Misc::Span<InputAction> GlfwInputDevice::GetAllMappings() noexcept
     {
         return _mappedActions;
     }

--- a/src/NovelRT/Persistence/Chapter.cpp
+++ b/src/NovelRT/Persistence/Chapter.cpp
@@ -9,7 +9,8 @@ namespace NovelRT::Persistence
     {
     }
 
-    Chapter::Chapter(NovelRT::Utilities::Misc::Span<std::shared_ptr<Ecs::ComponentBufferMemoryContainer>> componentCacheData) noexcept
+    Chapter::Chapter(NovelRT::Utilities::Misc::Span<std::shared_ptr<Ecs::ComponentBufferMemoryContainer>>
+                         componentCacheData) noexcept
         : _componentCacheData{}
     {
         for (auto&& buffer : componentCacheData)
@@ -140,11 +141,12 @@ namespace NovelRT::Persistence
                 else
                 {
                     componentJumpValue = componentMetadata.sizeOfSerialisedDataInBytes;
-                    ApplySerialisationRule(
-                        dataPair.first,
-                        NovelRT::Utilities::Misc::Span<const uint8_t>(reinterpret_cast<const uint8_t*>(dataView.GetDataHandle()),
-                                                 dataPair.second.GetSizeOfDataTypeInBytes()),
-                        NovelRT::Utilities::Misc::Span<uint8_t>(componentPtr, componentMetadata.sizeOfSerialisedDataInBytes));
+                    ApplySerialisationRule(dataPair.first,
+                                           NovelRT::Utilities::Misc::Span<const uint8_t>(
+                                               reinterpret_cast<const uint8_t*>(dataView.GetDataHandle()),
+                                               dataPair.second.GetSizeOfDataTypeInBytes()),
+                                           NovelRT::Utilities::Misc::Span<uint8_t>(
+                                               componentPtr, componentMetadata.sizeOfSerialisedDataInBytes));
                 }
 
                 entityPtr++;
@@ -230,9 +232,10 @@ namespace NovelRT::Persistence
                 {
                     ApplyDeserialisationRule(
                         pair.first,
-                        NovelRT::Utilities::Misc::Span<const uint8_t>(serialisedDataPtr, pair.second.sizeOfSerialisedDataInBytes),
+                        NovelRT::Utilities::Misc::Span<const uint8_t>(serialisedDataPtr,
+                                                                      pair.second.sizeOfSerialisedDataInBytes),
                         NovelRT::Utilities::Misc::Span<uint8_t>(reinterpret_cast<uint8_t*>(bufferDataPtr),
-                                           pair.second.sizeOfComponentInBytes));
+                                                                pair.second.sizeOfComponentInBytes));
                     bufferDataPtr += pair.second.sizeOfComponentInBytes;
                     serialisedDataPtr += pair.second.sizeOfSerialisedDataInBytes;
                 }

--- a/src/NovelRT/Persistence/Chapter.cpp
+++ b/src/NovelRT/Persistence/Chapter.cpp
@@ -9,7 +9,7 @@ namespace NovelRT::Persistence
     {
     }
 
-    Chapter::Chapter(gsl::span<std::shared_ptr<Ecs::ComponentBufferMemoryContainer>> componentCacheData) noexcept
+    Chapter::Chapter(NovelRT::Utilities::Misc::Span<std::shared_ptr<Ecs::ComponentBufferMemoryContainer>> componentCacheData) noexcept
         : _componentCacheData{}
     {
         for (auto&& buffer : componentCacheData)
@@ -142,9 +142,9 @@ namespace NovelRT::Persistence
                     componentJumpValue = componentMetadata.sizeOfSerialisedDataInBytes;
                     ApplySerialisationRule(
                         dataPair.first,
-                        gsl::span<const uint8_t>(reinterpret_cast<const uint8_t*>(dataView.GetDataHandle()),
+                        NovelRT::Utilities::Misc::Span<const uint8_t>(reinterpret_cast<const uint8_t*>(dataView.GetDataHandle()),
                                                  dataPair.second.GetSizeOfDataTypeInBytes()),
-                        gsl::span<uint8_t>(componentPtr, componentMetadata.sizeOfSerialisedDataInBytes));
+                        NovelRT::Utilities::Misc::Span<uint8_t>(componentPtr, componentMetadata.sizeOfSerialisedDataInBytes));
                 }
 
                 entityPtr++;
@@ -230,8 +230,8 @@ namespace NovelRT::Persistence
                 {
                     ApplyDeserialisationRule(
                         pair.first,
-                        gsl::span<const uint8_t>(serialisedDataPtr, pair.second.sizeOfSerialisedDataInBytes),
-                        gsl::span<uint8_t>(reinterpret_cast<uint8_t*>(bufferDataPtr),
+                        NovelRT::Utilities::Misc::Span<const uint8_t>(serialisedDataPtr, pair.second.sizeOfSerialisedDataInBytes),
+                        NovelRT::Utilities::Misc::Span<uint8_t>(reinterpret_cast<uint8_t*>(bufferDataPtr),
                                            pair.second.sizeOfComponentInBytes));
                     bufferDataPtr += pair.second.sizeOfComponentInBytes;
                     serialisedDataPtr += pair.second.sizeOfSerialisedDataInBytes;

--- a/src/NovelRT/Persistence/Graphics/RenderingComponentPersistenceRule.cpp
+++ b/src/NovelRT/Persistence/Graphics/RenderingComponentPersistenceRule.cpp
@@ -12,7 +12,7 @@ namespace NovelRT::Persistence::Graphics
     }
 
     std::vector<uint8_t> RenderingComponentPersistenceRule::ExecuteSerialiseModification(
-        gsl::span<const uint8_t> component) const noexcept
+        NovelRT::Utilities::Misc::Span<const uint8_t> component) const noexcept
     {
         const Ecs::Graphics::RenderComponent* ptr =
             reinterpret_cast<const Ecs::Graphics::RenderComponent*>(component.data());
@@ -32,7 +32,7 @@ namespace NovelRT::Persistence::Graphics
     }
 
     std::vector<uint8_t> RenderingComponentPersistenceRule::ExecuteDeserialiseModification(
-        gsl::span<const uint8_t> component) const noexcept
+        NovelRT::Utilities::Misc::Span<const uint8_t> component) const noexcept
     {
         const uuids::uuid* guids = reinterpret_cast<const uuids::uuid*>(component.data());
 

--- a/src/NovelRT/Persistence/Persistable.cpp
+++ b/src/NovelRT/Persistence/Persistable.cpp
@@ -20,8 +20,8 @@ namespace NovelRT::Persistence
     }
 
     void Persistable::ApplySerialisationRule(const std::string& serialisedName,
-                                             gsl::span<const uint8_t> componentData,
-                                             gsl::span<uint8_t> writeToData) const
+                                             NovelRT::Utilities::Misc::Span<const uint8_t> componentData,
+                                             NovelRT::Utilities::Misc::Span<uint8_t> writeToData) const
     {
         auto& serialisationRules = GetSerialisationRules();
         auto it = serialisationRules.find(serialisedName);
@@ -36,8 +36,8 @@ namespace NovelRT::Persistence
     }
 
     void Persistable::ApplyDeserialisationRule(const std::string& serialisedName,
-                                               gsl::span<const uint8_t> serialisedData,
-                                               gsl::span<uint8_t> writeToData) const
+                                               NovelRT::Utilities::Misc::Span<const uint8_t> serialisedData,
+                                               NovelRT::Utilities::Misc::Span<uint8_t> writeToData) const
     {
         auto& serialisationRules = GetSerialisationRules();
         auto it = serialisationRules.find(serialisedName);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces `NovelRT::Utilities::Misc::Span` as alias to `gsl::span` and `std::span` according to https://github.com/novelrt/NovelRT/issues/532

**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
https://github.com/novelrt/NovelRT/issues/532


**What is the current behavior?** (You can also link to an open issue here)
Currently across the NovelRT engine `gsl::span` is used directly


**What is the new behavior (if this is a feature change)?**
NovelRT will continue to use `gsl::span` by default, but through an aliased. Through defining `NOVELRT_USE_STD_SPAN` it will attempt to use C++ 20's `std::span` instead.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
This PR does not introduce any breaking changes, as `NovelRT::Utilities::Misc::Span` will still use `gsl::span` by default. In order to make use of `std::span`, developers will first have to opt-in. 


**Other information**:
This PR currently only makes changes for C++, it might be possible to create an option in CMake to have it be easier to use.