### PR TITLE
Fixes #552: Doxygen generation appears to be wrong for some definitions

### DIFF
--- a/include/NovelRT/Input/Glfw/Input.Glfw.h
+++ b/include/NovelRT/Input/Glfw/Input.Glfw.h
@@ -5,7 +5,7 @@
 #define NOVELRT_INPUT_GLFW_H
 
 /**
- * @Brief The default GLFW3 implementation of the Input plugin API.
+ * @brief The default GLFW3 implementation of the Input plugin API.
  */
 namespace NovelRT::Input::Glfw
 {

--- a/include/NovelRT/Input/Input.h
+++ b/include/NovelRT/Input/Input.h
@@ -13,7 +13,7 @@
 #include <string>
 
 /**
- * @Brief The input plugin API.
+ * @brief The input plugin API.
  */
 namespace NovelRT::Input
 {

--- a/include/NovelRT/Windowing/Glfw/Windowing.Glfw.h
+++ b/include/NovelRT/Windowing/Glfw/Windowing.Glfw.h
@@ -5,7 +5,7 @@
 #define NOVELRT_WINDOWING_GLFW_H
 
 /**
- * @Brief The default GLFW3 implementation of the Windowing plugin API.
+ * @brief The default GLFW3 implementation of the Windowing plugin API.
  */
 namespace NovelRT::Windowing::Glfw
 {

--- a/include/NovelRT/Windowing/Windowing.h
+++ b/include/NovelRT/Windowing/Windowing.h
@@ -5,7 +5,7 @@
 #define NOVELRT_WINDOWING_H
 
 /**
- * @Brief The experimental windowing plugin API.
+ * @brief The experimental windowing plugin API.
  */
 namespace NovelRT::Windowing
 {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
This change fixes the brief tags that were appearing in the Doxygen documentation

**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
Fixes #552 

**What is the current behavior? (You can also link to an open issue here)**
Capitalised Doxygen @Brief tags are appearing in documentation

**What is the new behavior (if this is a feature change)?**
Capitalised Doxygen @Brief tags will no longer appear in the documentation titles

**Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**
No

**Other information:**
N/A