### PR TITLE
Add basic registered streamable asset management.

### DIFF
--- a/include/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.h
@@ -17,14 +17,15 @@ namespace NovelRT::ResourceManagement::Desktop
 
     protected:
         void WriteAssetDatabaseFile() final;
-        void LoadAssetDatabaseFile() override;
+        void LoadAssetDatabaseFile() final;
 
     public:
         [[nodiscard]] TextureMetadata LoadTexture(std::filesystem::path filePath) final;
         [[nodiscard]] ShaderMetadata LoadShaderSource(std::filesystem::path filePath) final;
         [[nodiscard]] BinaryPackage LoadPackage(std::filesystem::path filePath) final;
         void SavePackage(std::filesystem::path filePath, const BinaryPackage& package) final;
-        [[nodiscard]] AudioMetadata LoadAudioFrameData(std::filesystem::path filePath) override;
+        [[nodiscard]] AudioMetadata LoadAudioFrameData(std::filesystem::path filePath) final;
+        [[nodiscard]] StreamableAssetMetadata GetStreamToAsset(std::filesystem::path filePath) final;
         ~DesktopResourceLoader() final = default;
     };
 }

--- a/include/NovelRT/ResourceManagement/ResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/ResourceLoader.h
@@ -10,6 +10,11 @@
 
 namespace NovelRT::ResourceManagement
 {
+    struct StreamableAssetMetadata
+    {
+        std::unique_ptr<std::ifstream> FileStream;
+        uuids::uuid DatabaseHandle;
+    };
     class ResourceLoader : public std::enable_shared_from_this<ResourceLoader>
     {
     private:
@@ -86,6 +91,8 @@ namespace NovelRT::ResourceManagement
         virtual void SavePackage(std::filesystem::path filePath, const BinaryPackage& package) = 0;
 
         [[nodiscard]] virtual AudioMetadata LoadAudioFrameData(std::filesystem::path filePath) = 0;
+
+        [[nodiscard]] virtual StreamableAssetMetadata GetStreamToAsset(std::filesystem::path filePath) = 0;
 
         virtual ~ResourceLoader() = default;
     };

--- a/src/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.cpp
+++ b/src/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.cpp
@@ -205,13 +205,14 @@ namespace NovelRT::ResourceManagement::Desktop
             returnImage.emplace_back(rawImage[i]);
         }
 
-        if (data.colourType != PNG_COLOR_TYPE_RGBA)
-        {
-            throw std::runtime_error("reeeeeeee");
-        }
-
         delete[] rawImage;
         delete[] data.rowPointers;
+
+        if (data.colourType != PNG_COLOR_TYPE_RGBA)
+        {
+            throw Exceptions::NotSupportedException("Colour type is in an unsupported format.");
+        }
+
         png_destroy_read_struct(&png, &info, nullptr);
 
         auto relativePathForAssetDatabase = std::filesystem::relative(filePath, _resourcesRootDirectory);
@@ -370,5 +371,22 @@ namespace NovelRT::ResourceManagement::Desktop
         uuids::uuid databaseHandle = RegisterAsset(relativePathForAssetDatabase);
 
         return AudioMetadata{data, info.channels, info.samplerate, databaseHandle};
+    }
+
+    StreamableAssetMetadata DesktopResourceLoader::GetStreamToAsset(std::filesystem::path filePath)
+    {
+        if (filePath.is_relative())
+        {
+            filePath = _resourcesRootDirectory / filePath;
+        }
+
+        auto file = std::make_unique<std::ifstream>(filePath.string());
+
+        if (!file->is_open())
+        {
+            throw NovelRT::Exceptions::FileNotFoundException(filePath.string());
+        }
+
+        return StreamableAssetMetadata {std::move(file), RegisterAsset(filePath)};
     }
 }

--- a/src/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.cpp
+++ b/src/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.cpp
@@ -387,6 +387,6 @@ namespace NovelRT::ResourceManagement::Desktop
             throw NovelRT::Exceptions::FileNotFoundException(filePath.string());
         }
 
-        return StreamableAssetMetadata {std::move(file), RegisterAsset(filePath)};
+        return StreamableAssetMetadata{std::move(file), RegisterAsset(filePath)};
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This adds a new basic file loading API for assets.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
There is no API that has this functionality.


**What is the new behavior (if this is a feature change)?**
The resource loader can now provide assets, untyped, as a stream.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
This is required as part of the Fabulist MVP changes since Fabulist works with streams.