### PR TITLE
Add GUID based asset loading.

### DIFF
--- a/include/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.h
@@ -21,11 +21,16 @@ namespace NovelRT::ResourceManagement::Desktop
 
     public:
         [[nodiscard]] TextureMetadata LoadTexture(std::filesystem::path filePath) final;
+        [[nodiscard]] TextureMetadata LoadTexture(uuids::uuid assetId) final;
         [[nodiscard]] ShaderMetadata LoadShaderSource(std::filesystem::path filePath) final;
+        [[nodiscard]] ShaderMetadata LoadShaderSource(uuids::uuid assetId) final;
         [[nodiscard]] BinaryPackage LoadPackage(std::filesystem::path filePath) final;
+        [[nodiscard]] BinaryPackage LoadPackage(uuids::uuid assetId) final;
         void SavePackage(std::filesystem::path filePath, const BinaryPackage& package) final;
         [[nodiscard]] AudioMetadata LoadAudioFrameData(std::filesystem::path filePath) final;
+        [[nodiscard]] AudioMetadata LoadAudioFrameData(uuids::uuid assetId) final;
         [[nodiscard]] StreamableAssetMetadata GetStreamToAsset(std::filesystem::path filePath) final;
+        [[nodiscard]] StreamableAssetMetadata GetStreamToAsset(uuids::uuid assetId) final;
         ~DesktopResourceLoader() final = default;
     };
 }

--- a/include/NovelRT/ResourceManagement/ResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/ResourceLoader.h
@@ -73,7 +73,7 @@ namespace NovelRT::ResourceManagement
          * @exception NovelRT::Exceptions::FileNotFoundException if there is no file at the specified location.
          */
         [[nodiscard]] virtual TextureMetadata LoadTexture(std::filesystem::path filePath) = 0;
-        
+
         [[nodiscard]] virtual TextureMetadata LoadTexture(uuids::uuid assetId) = 0;
 
         /**
@@ -87,21 +87,21 @@ namespace NovelRT::ResourceManagement
          * @exception NovelRT::Exceptions::FileNotFoundException if there is no file at the specified location.
          */
         [[nodiscard]] virtual ShaderMetadata LoadShaderSource(std::filesystem::path filePath) = 0;
-        
+
         [[nodiscard]] virtual ShaderMetadata LoadShaderSource(uuids::uuid assetId) = 0;
 
         [[nodiscard]] virtual BinaryPackage LoadPackage(std::filesystem::path fileName) = 0;
-        
+
         [[nodiscard]] virtual BinaryPackage LoadPackage(uuids::uuid assetId) = 0;
 
         virtual void SavePackage(std::filesystem::path filePath, const BinaryPackage& package) = 0;
 
         [[nodiscard]] virtual AudioMetadata LoadAudioFrameData(std::filesystem::path filePath) = 0;
-        
+
         [[nodiscard]] virtual AudioMetadata LoadAudioFrameData(uuids::uuid assetId) = 0;
 
         [[nodiscard]] virtual StreamableAssetMetadata GetStreamToAsset(std::filesystem::path filePath) = 0;
-        
+
         [[nodiscard]] virtual StreamableAssetMetadata GetStreamToAsset(uuids::uuid) = 0;
 
         virtual ~ResourceLoader() = default;

--- a/include/NovelRT/ResourceManagement/ResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/ResourceLoader.h
@@ -73,6 +73,8 @@ namespace NovelRT::ResourceManagement
          * @exception NovelRT::Exceptions::FileNotFoundException if there is no file at the specified location.
          */
         [[nodiscard]] virtual TextureMetadata LoadTexture(std::filesystem::path filePath) = 0;
+        
+        [[nodiscard]] virtual TextureMetadata LoadTexture(uuids::uuid assetId) = 0;
 
         /**
          * @brief Loads shader from a file on a given path.
@@ -85,14 +87,22 @@ namespace NovelRT::ResourceManagement
          * @exception NovelRT::Exceptions::FileNotFoundException if there is no file at the specified location.
          */
         [[nodiscard]] virtual ShaderMetadata LoadShaderSource(std::filesystem::path filePath) = 0;
+        
+        [[nodiscard]] virtual ShaderMetadata LoadShaderSource(uuids::uuid assetId) = 0;
 
         [[nodiscard]] virtual BinaryPackage LoadPackage(std::filesystem::path fileName) = 0;
+        
+        [[nodiscard]] virtual BinaryPackage LoadPackage(uuids::uuid assetId) = 0;
 
         virtual void SavePackage(std::filesystem::path filePath, const BinaryPackage& package) = 0;
 
         [[nodiscard]] virtual AudioMetadata LoadAudioFrameData(std::filesystem::path filePath) = 0;
+        
+        [[nodiscard]] virtual AudioMetadata LoadAudioFrameData(uuids::uuid assetId) = 0;
 
         [[nodiscard]] virtual StreamableAssetMetadata GetStreamToAsset(std::filesystem::path filePath) = 0;
+        
+        [[nodiscard]] virtual StreamableAssetMetadata GetStreamToAsset(uuids::uuid) = 0;
 
         virtual ~ResourceLoader() = default;
     };

--- a/src/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.cpp
+++ b/src/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.cpp
@@ -221,6 +221,11 @@ namespace NovelRT::ResourceManagement::Desktop
                                RegisterAsset(relativePathForAssetDatabase)};
     }
 
+    TextureMetadata DesktopResourceLoader::LoadTexture(uuids::uuid assetId)
+    {
+        return LoadTexture(GetGuidsToFilePathsMap().at(assetId));
+    }
+
     ShaderMetadata DesktopResourceLoader::LoadShaderSource(std::filesystem::path filePath)
     {
         if (filePath.is_relative())
@@ -245,6 +250,11 @@ namespace NovelRT::ResourceManagement::Desktop
         auto relativePathForAssetDatabase = std::filesystem::relative(filePath, _resourcesRootDirectory);
 
         return ShaderMetadata{buffer, RegisterAsset(relativePathForAssetDatabase)};
+    }
+
+    ShaderMetadata DesktopResourceLoader::LoadShaderSource(uuids::uuid assetId)
+    {
+        return LoadShaderSource(GetGuidsToFilePathsMap().at(assetId));
     }
 
     BinaryPackage DesktopResourceLoader::LoadPackage(std::filesystem::path filePath)
@@ -291,6 +301,11 @@ namespace NovelRT::ResourceManagement::Desktop
         package.databaseHandle = RegisterAsset(relativePathForAssetDatabase);
 
         return package;
+    }
+
+    BinaryPackage DesktopResourceLoader::LoadPackage(uuids::uuid assetId)
+    {
+        return LoadPackage(GetGuidsToFilePathsMap().at(assetId));
     }
 
     void DesktopResourceLoader::SavePackage(std::filesystem::path filePath, const BinaryPackage& package)
@@ -373,6 +388,11 @@ namespace NovelRT::ResourceManagement::Desktop
         return AudioMetadata{data, info.channels, info.samplerate, databaseHandle};
     }
 
+    AudioMetadata DesktopResourceLoader::LoadAudioFrameData(uuids::uuid assetId)
+    {
+        return LoadAudioFrameData(GetGuidsToFilePathsMap().at(assetId));
+    }
+
     StreamableAssetMetadata DesktopResourceLoader::GetStreamToAsset(std::filesystem::path filePath)
     {
         if (filePath.is_relative())
@@ -388,5 +408,10 @@ namespace NovelRT::ResourceManagement::Desktop
         }
 
         return StreamableAssetMetadata{std::move(file), RegisterAsset(filePath)};
+    }
+
+    StreamableAssetMetadata DesktopResourceLoader::GetStreamToAsset(uuids::uuid assetId)
+    {
+        return GetStreamToAsset(GetGuidsToFilePathsMap().at(assetId));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds the ability to load assets based on GUIDs.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
You can only use file paths at present when we have GUID handles for previously tracked assets.


**What is the new behavior (if this is a feature change)?**
You are now able to use the GUID handles to get the assets.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
N/A