### PR TITLE
Add eager asset DB loading.

### DIFF
--- a/include/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.h
@@ -14,12 +14,19 @@ namespace NovelRT::ResourceManagement::Desktop
     {
     private:
         LoggingService _logger;
+        bool _isAssetDBInitialised;
 
     protected:
         void WriteAssetDatabaseFile() final;
         void LoadAssetDatabaseFile() final;
 
     public:
+        [[nodiscard]] inline bool GetIsAssetDBInitialised() const noexcept final
+        {
+            return _isAssetDBInitialised;
+        }
+
+        void InitAssetDatabase() final;
         [[nodiscard]] TextureMetadata LoadTexture(std::filesystem::path filePath) final;
         [[nodiscard]] TextureMetadata LoadTexture(uuids::uuid assetId) final;
         [[nodiscard]] ShaderMetadata LoadShaderSource(std::filesystem::path filePath) final;

--- a/include/NovelRT/ResourceManagement/ResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/ResourceLoader.h
@@ -15,6 +15,7 @@ namespace NovelRT::ResourceManagement
         std::unique_ptr<std::ifstream> FileStream;
         uuids::uuid DatabaseHandle;
     };
+
     class ResourceLoader : public std::enable_shared_from_this<ResourceLoader>
     {
     private:
@@ -40,6 +41,8 @@ namespace NovelRT::ResourceManagement
         virtual void LoadAssetDatabaseFile() = 0;
 
         uuids::uuid RegisterAsset(const std::filesystem::path& filePath);
+        uuids::uuid RegisterAssetNoFileWrite(const std::filesystem::path& filePath);
+        void UnregisterAssetNoFileWrite(uuids::uuid assetId);
 
     public:
         [[nodiscard]] inline std::filesystem::path& ResourcesRootDirectory() noexcept
@@ -61,6 +64,10 @@ namespace NovelRT::ResourceManagement
         {
             return _filePathsToGuidsMap;
         }
+
+        [[nodiscard]] virtual bool GetIsAssetDBInitialised() const noexcept = 0;
+
+        virtual void InitAssetDatabase() = 0;
 
         /**
          * @brief Loads a texture from a file on a given path.

--- a/src/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.cpp
+++ b/src/NovelRT/ResourceManagement/Desktop/DesktopResourceLoader.cpp
@@ -81,7 +81,7 @@ namespace NovelRT::ResourceManagement::Desktop
 
         std::vector<uuids::uuid> filesToUnregister{};
 
-        for(auto [path, guid] : GetFilePathsToGuidsMap())
+        for (auto [path, guid] : GetFilePathsToGuidsMap())
         {
             if (std::filesystem::exists(path))
             {
@@ -89,14 +89,15 @@ namespace NovelRT::ResourceManagement::Desktop
             }
         }
 
-        for(const auto& guid : filesToUnregister)
+        for (const auto& guid : filesToUnregister)
         {
             UnregisterAssetNoFileWrite(guid);
         }
 
-        for(const auto& directoryEntry : std::filesystem::recursive_directory_iterator(filePath))
+        for (const auto& directoryEntry : std::filesystem::recursive_directory_iterator(filePath))
         {
-            if (!directoryEntry.is_regular_file() || directoryEntry.path().filename().string().find("AssetDB") != std::string::npos)
+            if (!directoryEntry.is_regular_file() ||
+                directoryEntry.path().filename().string().find("AssetDB") != std::string::npos)
             {
                 continue;
             }

--- a/src/NovelRT/ResourceManagement/Desktop/DesktopResourceManagementPluginProvider.cpp
+++ b/src/NovelRT/ResourceManagement/Desktop/DesktopResourceManagementPluginProvider.cpp
@@ -12,6 +12,11 @@ namespace NovelRT::ResourceManagement::Desktop
 
     DesktopResourceLoader* DesktopResourceManagementPluginProvider::GetResourceLoaderInternal()
     {
+        if (!_resourceLoader->GetIsAssetDBInitialised())
+        {
+            _resourceLoader->InitAssetDatabase();
+        }
+
         return _resourceLoader.get();
     }
 }

--- a/src/NovelRT/ResourceManagement/ResourceLoader.cpp
+++ b/src/NovelRT/ResourceManagement/ResourceLoader.cpp
@@ -7,6 +7,13 @@ namespace NovelRT::ResourceManagement
 {
     uuids::uuid ResourceLoader::RegisterAsset(const std::filesystem::path& filePath)
     {
+        auto returnValue = RegisterAssetNoFileWrite(filePath);
+        WriteAssetDatabaseFile();
+        return returnValue;
+    }
+
+    uuids::uuid ResourceLoader::RegisterAssetNoFileWrite(const std::filesystem::path& filePath)
+    {
         static std::random_device rd;
         static auto seed_data = std::array<int, std::mt19937::state_size>{};
         std::generate(std::begin(seed_data), std::end(seed_data), std::ref(rd));
@@ -39,8 +46,14 @@ namespace NovelRT::ResourceManagement
             pathGuidMap.emplace(filePath, guid);
         }
 
-        WriteAssetDatabaseFile();
-
         return it->second;
+    }
+
+    void NovelRT::ResourceManagement::ResourceLoader::UnregisterAssetNoFileWrite(uuids::uuid assetId)
+    {
+        auto path = _guidsToFilePathsMap.at(assetId);
+
+        _filePathsToGuidsMap.erase(path);
+        _guidsToFilePathsMap.erase(assetId);
     }
 }


### PR DESCRIPTION
…ame start.

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This introduces a required internal behavioural change for the resource loader that will, on first launch of a NovelRT game, ensure the asset DB is up to date and correct.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
The resource loader manages the asset DB lazily, which makes supporting certain APIs unfeasible.


**What is the new behavior (if this is a feature change)?**
The resource loader will now make sure the asset DB is loaded correctly on boot.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
N/A