### PR TITLE
Add new asset ID and file location querying APIs.

### DIFF
--- a/include/NovelRT/ResourceManagement/ResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/ResourceLoader.h
@@ -111,9 +111,11 @@ namespace NovelRT::ResourceManagement
 
         [[nodiscard]] virtual StreamableAssetMetadata GetStreamToAsset(uuids::uuid) = 0;
 
-        [[nodiscard]] std::optional<uuids::uuid> TryGetAssetIdBasedOnFilePath(const std::filesystem::path& pathToAsset) const noexcept;
-        
-        [[nodiscard]] std::optional<std::filesystem::path> TryGetFilePathBasedOnAssetId(uuids::uuid assetId) const noexcept;
+        [[nodiscard]] std::optional<uuids::uuid> TryGetAssetIdBasedOnFilePath(
+            const std::filesystem::path& pathToAsset) const noexcept;
+
+        [[nodiscard]] std::optional<std::filesystem::path> TryGetFilePathBasedOnAssetId(
+            uuids::uuid assetId) const noexcept;
 
         virtual ~ResourceLoader() = default;
     };

--- a/include/NovelRT/ResourceManagement/ResourceLoader.h
+++ b/include/NovelRT/ResourceManagement/ResourceLoader.h
@@ -111,6 +111,10 @@ namespace NovelRT::ResourceManagement
 
         [[nodiscard]] virtual StreamableAssetMetadata GetStreamToAsset(uuids::uuid) = 0;
 
+        [[nodiscard]] std::optional<uuids::uuid> TryGetAssetIdBasedOnFilePath(const std::filesystem::path& pathToAsset) const noexcept;
+        
+        [[nodiscard]] std::optional<std::filesystem::path> TryGetFilePathBasedOnAssetId(uuids::uuid assetId) const noexcept;
+
         virtual ~ResourceLoader() = default;
     };
 }

--- a/src/NovelRT/ResourceManagement/ResourceLoader.cpp
+++ b/src/NovelRT/ResourceManagement/ResourceLoader.cpp
@@ -2,7 +2,6 @@
 // for more information.
 
 #include <NovelRT/ResourceManagement/ResourceManagement.h>
-
 namespace NovelRT::ResourceManagement
 {
     uuids::uuid ResourceLoader::RegisterAsset(const std::filesystem::path& filePath)
@@ -49,11 +48,43 @@ namespace NovelRT::ResourceManagement
         return it->second;
     }
 
-    void NovelRT::ResourceManagement::ResourceLoader::UnregisterAssetNoFileWrite(uuids::uuid assetId)
+    void ResourceLoader::UnregisterAssetNoFileWrite(uuids::uuid assetId)
     {
         auto path = _guidsToFilePathsMap.at(assetId);
 
         _filePathsToGuidsMap.erase(path);
         _guidsToFilePathsMap.erase(assetId);
+    }
+
+    std::optional<uuids::uuid> ResourceLoader::TryGetAssetIdBasedOnFilePath(
+        const std::filesystem::path& pathToAsset) const noexcept
+    {
+        std::optional<uuids::uuid> returnOptional;
+
+        const auto& map = GetFilePathsToGuidsMap();
+        auto it = map.find(pathToAsset);
+
+        if (it != map.end())
+        {
+            returnOptional = it->second;
+        }
+
+        return returnOptional;
+    }
+
+    std::optional<std::filesystem::path> ResourceLoader::TryGetFilePathBasedOnAssetId(
+        uuids::uuid assetId) const noexcept
+    {
+        std::optional<std::filesystem::path> returnOptional;
+
+        const auto& map = GetGuidsToFilePathsMap();
+        auto it = map.find(assetId);
+
+        if (it != map.end())
+        {
+            returnOptional = it->second;
+        }
+
+        return returnOptional;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces new APIs for querying asset ID and location information from the resource loader.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
You cannot query this information at all.


**What is the new behavior (if this is a feature change)?**
You can now query this information.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
This PR is designed after the model for Try methods as outlined in #563 . Please review that proposal for more information to see if this is a good way forward or not.