### PR TITLE
Finally add kdevelop to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,7 @@ CTestTestfile.cmake
 .DS_Store
 internal/build*
 internal/dist*
+
+### KDevelop ###
+.kdev4/*
+*.kdev4


### PR DESCRIPTION
Ruby's been telling me to do this for a while, maybe I should actually get around to doing it :)

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
Makes my `git status` shut up about the .kdev files my IDE creates.

**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
Nope.

**What is the current behavior?**
```
$ git status
On branch main
Your branch is ahead of 'origin/main' by 1039 commits.
  (use "git push" to publish your local commits)

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        .kdev4/
        NovelRT.kdev4

nothing added to commit but untracked files present (use "git add" to track)
```

**What is the new behavior (if this is a feature change)?**
```
$ git status
On branch feature/kdevelop-gitignore
Your branch is up to date with 'origin/feature/kdevelop-gitignore'.

nothing to commit, working tree clean
```

**Does this PR introduce a breaking change?**
If you were expecting to commit editor files that you shouldn't be committing anyway, yes :stuck_out_tongue: 

**Other information**:
N/A