### PR TITLE
#388 memcpy_s removal

### DIFF
--- a/include/NovelRT/Ecs/ComponentBufferMemoryContainer.h
+++ b/include/NovelRT/Ecs/ComponentBufferMemoryContainer.h
@@ -36,7 +36,7 @@ namespace NovelRT::Ecs
 
             inline void CopyDataFromLocation(void* outputLocation) const noexcept
             {
-                memcpy(outputLocation, _data, _sizeOfObject);
+                NovelRT::Utilities::Memory::Copy(outputLocation, _sizeOfObject, _data, _sizeOfObject);
             }
 
             [[nodiscard]] inline const void* GetDataHandle() const noexcept

--- a/include/NovelRT/Ecs/Ecs.h
+++ b/include/NovelRT/Ecs/Ecs.h
@@ -14,6 +14,7 @@
 #include "../Utilities/Event.h"
 #include "../Utilities/KeyValuePair.h"
 #include "../Utilities/Misc.h"
+#include "../Utilities/Memory.h"
 #include "../PluginManagement/PluginManagement.h"
 #include "../Threading/Threading.h"
 #include <algorithm>

--- a/include/NovelRT/Ecs/SparseSetMemoryContainer.h
+++ b/include/NovelRT/Ecs/SparseSetMemoryContainer.h
@@ -47,12 +47,12 @@ namespace NovelRT::Ecs
 
             inline void CopyFromLocation(void* outputLocation) const noexcept
             {
-                std::memcpy(outputLocation, &(*_iteratorAtValue), _sizeOfObject);
+                NovelRT::Utilities::Memory::Copy(outputLocation, _sizeOfObject, &(*_iteratorAtValue), _sizeOfObject);
             }
 
             inline void WriteToLocation(void* data) noexcept
             {
-                std::memcpy(&(*_iteratorAtValue), data, _sizeOfObject);
+                NovelRT::Utilities::Memory::Copy(&(*_iteratorAtValue), _sizeOfObject, data, _sizeOfObject);
             }
 
             [[nodiscard]] inline void* GetDataHandle() const noexcept
@@ -91,7 +91,7 @@ namespace NovelRT::Ecs
 
             inline void CopyFromLocation(void* outputLocation) const noexcept
             {
-                std::memcpy(outputLocation, &(*_iteratorAtValue), _sizeOfObject);
+                NovelRT::Utilities::Memory::Copy(outputLocation, _sizeOfObject, &(*_iteratorAtValue), _sizeOfObject);
             }
 
             [[nodiscard]] const void* GetDataHandle() const noexcept

--- a/include/NovelRT/Graphics/Graphics.h
+++ b/include/NovelRT/Graphics/Graphics.h
@@ -12,8 +12,8 @@
 #include "NovelRT/Threading/Threading.h"
 #include "NovelRT/Utilities/Event.h"
 #include "NovelRT/Utilities/Lazy.h"
-#include "NovelRT/Utilities/Misc.h"
 #include "NovelRT/Utilities/Memory.h"
+#include "NovelRT/Utilities/Misc.h"
 #include "RGBAColour.h"
 #include <chrono>
 #include <cstdint>

--- a/include/NovelRT/Graphics/Graphics.h
+++ b/include/NovelRT/Graphics/Graphics.h
@@ -13,6 +13,7 @@
 #include "NovelRT/Utilities/Event.h"
 #include "NovelRT/Utilities/Lazy.h"
 #include "NovelRT/Utilities/Misc.h"
+#include "NovelRT/Utilities/Memory.h"
 #include "RGBAColour.h"
 #include <chrono>
 #include <cstdint>

--- a/include/NovelRT/Graphics/Vulkan/Graphics.Vulkan.h
+++ b/include/NovelRT/Graphics/Vulkan/Graphics.Vulkan.h
@@ -10,8 +10,8 @@
 #include "../../LoggingService.h"
 #include "../../PluginManagement/PluginManagement.h"
 #include "../../Utilities/Lazy.h"
-#include "../../Utilities/Misc.h"
 #include "../../Utilities/Memory.h"
+#include "../../Utilities/Misc.h"
 #include "../Graphics.h"
 #include <array>
 #include <map>

--- a/include/NovelRT/Graphics/Vulkan/Graphics.Vulkan.h
+++ b/include/NovelRT/Graphics/Vulkan/Graphics.Vulkan.h
@@ -11,6 +11,7 @@
 #include "../../PluginManagement/PluginManagement.h"
 #include "../../Utilities/Lazy.h"
 #include "../../Utilities/Misc.h"
+#include "../../Utilities/Memory.h"
 #include "../Graphics.h"
 #include <array>
 #include <map>

--- a/include/NovelRT/Utilities/Memory.h
+++ b/include/NovelRT/Utilities/Memory.h
@@ -1,0 +1,48 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_UTILITIES_MEMORY_H
+#define NOVELRT_UTILITIES_MEMORY_H
+
+#include <string.h>
+#include <cassert>
+#include <cstring>
+#include <NovelRT/Exceptions/Exceptions.h>
+
+namespace NovelRT::Utilities
+{
+    class Memory
+    {
+    public:
+        static void Copy(void* destination, size_t destinationSize, const void* source, size_t count)
+        {
+            #ifdef WIN32
+            int result = memcpy_s(destination, destinationSize, source, count);
+
+            if (result != 0)
+            {
+                switch (result)
+                {
+                    case EINVAL:
+                        throw Exceptions::InvalidOperationException("Due to invalid values passed in.");
+                        break;
+                    case ERANGE:
+                        throw Exceptions::InvalidOperationException("Argument is out of the allowed range");
+                        break;
+                    default:
+                        throw Exceptions::InvalidOperationException("Unknown error");
+                }
+            }
+            #else
+            assert(destination != nullptr);
+            assert(source != nullptr);
+            assert(count != 0);
+            assert(destinationSize >= count);
+
+            memcpy(destination, source, count);
+            #endif
+        }
+    };
+}
+
+#endif //! NOVELRT_UTILITIES_MEMORY_H

--- a/include/NovelRT/Utilities/Memory.h
+++ b/include/NovelRT/Utilities/Memory.h
@@ -17,7 +17,7 @@ namespace NovelRT::Utilities
         static void Copy(void* destination, size_t destinationSize, const void* source, size_t count)
         {
             #ifdef WIN32
-            int result = memcpy_s(destination, destinationSize, source, count);
+            errno_t result = memcpy_s(destination, destinationSize, source, count);
 
             if (result != 0)
             {
@@ -34,10 +34,10 @@ namespace NovelRT::Utilities
                 }
             }
             #else
-            assert(destination != nullptr);
-            assert(source != nullptr);
-            assert(count != 0);
-            assert(destinationSize >= count);
+            if (destination == nullptr || source == nullptr || count <= 0 || destinationSize < count)
+            {
+                throw Exceptions::InvalidOperationException("Due to invalid values passed in.");
+            }
 
             memcpy(destination, source, count);
             #endif

--- a/include/NovelRT/Utilities/Memory.h
+++ b/include/NovelRT/Utilities/Memory.h
@@ -4,10 +4,10 @@
 #ifndef NOVELRT_UTILITIES_MEMORY_H
 #define NOVELRT_UTILITIES_MEMORY_H
 
-#include <string.h>
+#include <NovelRT/Exceptions/Exceptions.h>
 #include <cassert>
 #include <cstring>
-#include <NovelRT/Exceptions/Exceptions.h>
+#include <string.h>
 
 namespace NovelRT::Utilities
 {
@@ -16,7 +16,7 @@ namespace NovelRT::Utilities
     public:
         static void Copy(void* destination, size_t destinationSize, const void* source, size_t count)
         {
-            #ifdef WIN32
+#ifdef WIN32
             errno_t result = memcpy_s(destination, destinationSize, source, count);
 
             if (result != 0)
@@ -33,14 +33,14 @@ namespace NovelRT::Utilities
                         throw Exceptions::InvalidOperationException("Unknown error");
                 }
             }
-            #else
+#else
             if (destination == nullptr || source == nullptr || count <= 0 || destinationSize < count)
             {
                 throw Exceptions::InvalidOperationException("Due to invalid values passed in.");
             }
 
             memcpy(destination, source, count);
-            #endif
+#endif
         }
     };
 }

--- a/src/NovelRT/Ecs/ComponentBufferMemoryContainer.cpp
+++ b/src/NovelRT/Ecs/ComponentBufferMemoryContainer.cpp
@@ -21,7 +21,8 @@ namespace NovelRT::Ecs
           _componentComparatorLogic(std::move(componentComparatorLogic)),
           _serialisedTypeName(serialisedTypeName)
     {
-        std::memcpy(_deleteInstructionState.data(), deleteInstructionState, _sizeOfDataTypeInBytes);
+        NovelRT::Utilities::Memory::Copy(_deleteInstructionState.data(), _sizeOfDataTypeInBytes, deleteInstructionState,
+                                         _sizeOfDataTypeInBytes);
         for (size_t i = 0; i < poolSize; i++)
         {
             _updateSets.emplace_back(sizeOfDataTypeInBytes);

--- a/src/NovelRT/Ecs/Graphics/DefaultRenderingSystem.cpp
+++ b/src/NovelRT/Ecs/Graphics/DefaultRenderingSystem.cpp
@@ -450,9 +450,10 @@ namespace NovelRT::Ecs::Graphics
 
         auto ptr = Threading::MakeConcurrentShared<TextureInfo>();
         std::vector<uint8_t> textureData{};
-        textureData.resize(dataTypeSize * dataLength);
+        const size_t size = dataTypeSize * dataLength;
+        textureData.resize(size);
 
-        memcpy(textureData.data(), data, dataTypeSize * dataLength);
+        NovelRT::Utilities::Memory::Copy(textureData.data(), size, data, size);
 
         ptr->textureName = textureDataName;
         ptr->textureData = textureData;
@@ -553,9 +554,6 @@ namespace NovelRT::Ecs::Graphics
         size_t dataLength)
     {
         std::scoped_lock guard(_vertexQueueMapMutex);
-        assert(data != nullptr && "data is a nullptr, make sure that you are passing in a valid pointer into the method.");
-        assert(dataTypeSize != 0 && "dataTypeSize is zero, make sure the correct size of the type has been passed in.");
-        assert(dataLength != 0 && "dataLength is zero, make sure that the length of the buffer is properly calculated and passed in.");
 
         auto ptr = Threading::MakeConcurrentShared<VertexInfo>();
         size_t size = dataTypeSize * dataLength;
@@ -568,7 +566,7 @@ namespace NovelRT::Ecs::Graphics
         ptr->sizeOfVert = dataTypeSize;
         ptr->stagingPtrLength = dataLength;
 
-        memcpy(ptr->stagingPtr, data, size);
+        NovelRT::Utilities::Memory::Copy(ptr->stagingPtr, size, data, size);
         _vertexDataToInitialise.push(ptr);
 
         return Threading::FutureResult<VertexInfo>(ptr, VertexInfo{});

--- a/src/NovelRT/Ecs/Graphics/DefaultRenderingSystem.cpp
+++ b/src/NovelRT/Ecs/Graphics/DefaultRenderingSystem.cpp
@@ -553,19 +553,22 @@ namespace NovelRT::Ecs::Graphics
         size_t dataLength)
     {
         std::scoped_lock guard(_vertexQueueMapMutex);
+        assert(data != nullptr && "data is a nullptr, make sure that you are passing in a valid pointer into the method.");
+        assert(dataTypeSize != 0 && "dataTypeSize is zero, make sure the correct size of the type has been passed in.");
+        assert(dataLength != 0 && "dataLength is zero, make sure that the length of the buffer is properly calculated and passed in.");
 
         auto ptr = Threading::MakeConcurrentShared<VertexInfo>();
         size_t size = dataTypeSize * dataLength;
         ptr->vertexInfoName = vertexDataName;
         ptr->stagingPtr = malloc(size);
+        if (ptr->stagingPtr == nullptr)
+        {
+            throw NovelRT::Exceptions::OutOfMemoryException();
+        }
         ptr->sizeOfVert = dataTypeSize;
         ptr->stagingPtrLength = dataLength;
 
-#ifdef WIN32
-        memcpy_s(ptr->stagingPtr, size, data, size);
-#else
         memcpy(ptr->stagingPtr, data, size);
-#endif
         _vertexDataToInitialise.push(ptr);
 
         return Threading::FutureResult<VertexInfo>(ptr, VertexInfo{});

--- a/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
+++ b/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
@@ -34,7 +34,7 @@ namespace NovelRT::Ecs
         _sparse[key] = _dense.size() - 1;
         _data.resize(GetStartingByteIndexForDenseIndex(_dense.size()));
         auto dataPtr = GetDataObjectStartAtIndex(_dense.size() - 1);
-        std::memcpy(dataPtr, value, _sizeOfDataTypeInBytes);
+        NovelRT::Utilities::Memory::Copy(dataPtr, _sizeOfDataTypeInBytes, value, _sizeOfDataTypeInBytes);
     }
 
     void SparseSetMemoryContainer::Insert(size_t key, const void* value)
@@ -205,8 +205,11 @@ namespace NovelRT::Ecs
         _data.clear();
         _data.resize(data.size());
 
-        std::memcpy(_dense.data(), ids.data(), sizeof(size_t) * ids.size());
-        std::memcpy(_data.data(), data.data(), sizeof(uint8_t) * data.size());
+        const size_t denseSize = sizeof(size_t) * ids.size();
+        const size_t dataSize = sizeof(uint8_t) * data.size();
+
+        NovelRT::Utilities::Memory::Copy(_dense.data(), denseSize, ids.data(), denseSize);
+        NovelRT::Utilities::Memory::Copy(_data.data(), dataSize, data.data(), dataSize);
 
         for (size_t denseIndex = 0; denseIndex < _dense.size(); denseIndex++)
         {

--- a/src/NovelRT/Graphics/GraphicsResourceManager.cpp
+++ b/src/NovelRT/Graphics/GraphicsResourceManager.cpp
@@ -138,7 +138,7 @@ namespace NovelRT::Graphics
         auto vertexRegion = vertexBuffer->Allocate(sizeToStage, alignment);
         auto writeArea = stagingBuffer->Map<uint8_t>(vertexRegion);
 
-        memcpy(writeArea, data, sizeToStage);
+        NovelRT::Utilities::Memory::Copy(writeArea, sizeToStage, data, sizeToStage);
 
         stagingBuffer->UnmapAndWrite(vertexRegion);
         currentContext->Copy(vertexBuffer, stagingBuffer);
@@ -168,7 +168,7 @@ namespace NovelRT::Graphics
         auto indexRegion = indexBuffer->Allocate(sizeToStage, alignment);
         auto writeArea = stagingBuffer->Map<uint8_t>(indexRegion);
 
-        memcpy(writeArea, data, sizeToStage);
+        NovelRT::Utilities::Memory::Copy(writeArea, sizeToStage, data, sizeToStage);
 
         stagingBuffer->UnmapAndWrite(indexRegion);
         currentContext->Copy(indexBuffer, stagingBuffer);
@@ -287,7 +287,8 @@ namespace NovelRT::Graphics
         auto texture2dRegion = texture2d->Allocate(texture2d->GetSize(), 4);
         auto pTextureData = stagingBuffer->Map<uint8_t>(texture2dRegion);
 
-        memcpy(pTextureData, metadata.data.data(), metadata.data.size());
+        NovelRT::Utilities::Memory::Copy(pTextureData, metadata.data.size(), metadata.data.data(),
+                                         metadata.data.size());
 
         stagingBuffer->UnmapAndWrite(texture2dRegion);
         currentContext->Copy(texture2d, stagingBuffer);
@@ -360,7 +361,7 @@ namespace NovelRT::Graphics
         auto allocation = bufferPtr->Allocate(size, alignment);
         uint8_t* destination = bufferPtr->Map<uint8_t>(allocation);
 
-        memcpy(destination, data, size);
+        NovelRT::Utilities::Memory::Copy(destination, size, data, size);
 
         bufferPtr->UnmapAndWrite(allocation);
         return allocation;
@@ -395,7 +396,7 @@ namespace NovelRT::Graphics
 
         uint8_t* destination = bufferPtr->Map<uint8_t>(targetMemoryResource);
 
-        memcpy(destination, data, size);
+        NovelRT::Utilities::Memory::Copy(destination, size, data, size);
 
         bufferPtr->UnmapAndWrite(targetMemoryResource);
     }

--- a/src/NovelRT/Graphics/GraphicsResourceManager.cpp
+++ b/src/NovelRT/Graphics/GraphicsResourceManager.cpp
@@ -121,6 +121,12 @@ namespace NovelRT::Graphics
                                                                                           size_t dataLength,
                                                                                           size_t alignment)
     {
+        assert(data != nullptr &&
+               "data is a nullptr, make sure that you are passing in a valid pointer into the method.");
+        assert(dataTypeSize != 0 && "dataTypeSize is zero, make sure the correct size of the type has been passed in.");
+        assert(dataLength != 0 &&
+               "dataLength is zero, make sure that the length of the buffer is properly calculated and passed in.");
+
         size_t sizeToStage = dataTypeSize * dataLength;
         auto currentContext = _graphicsDevice->GetCurrentContext();
 
@@ -131,11 +137,9 @@ namespace NovelRT::Graphics
             GetOrCreateGraphicsBufferForAllocationSize(sizeToStage, GraphicsBufferKind::Vertex);
         auto vertexRegion = vertexBuffer->Allocate(sizeToStage, alignment);
         auto writeArea = stagingBuffer->Map<uint8_t>(vertexRegion);
-#ifdef WIN32
-        memcpy_s(writeArea, sizeToStage, data, sizeToStage);
-#else
+
         memcpy(writeArea, data, sizeToStage);
-#endif
+
         stagingBuffer->UnmapAndWrite(vertexRegion);
         currentContext->Copy(vertexBuffer, stagingBuffer);
 
@@ -147,6 +151,12 @@ namespace NovelRT::Graphics
                                                                                          size_t dataLength,
                                                                                          size_t alignment)
     {
+        assert(data != nullptr &&
+               "data is a nullptr, make sure that you are passing in a valid pointer into the method.");
+        assert(dataTypeSize != 0 && "dataTypeSize is zero, make sure the correct size of the type has been passed in.");
+        assert(dataLength != 0 &&
+               "dataLength is zero, make sure that the length of the buffer is properly calculated and passed in.");
+
         size_t sizeToStage = dataTypeSize * dataLength;
         auto currentContext = _graphicsDevice->GetCurrentContext();
 
@@ -157,11 +167,9 @@ namespace NovelRT::Graphics
             GetOrCreateGraphicsBufferForAllocationSize(sizeToStage, GraphicsBufferKind::Index);
         auto indexRegion = indexBuffer->Allocate(sizeToStage, alignment);
         auto writeArea = stagingBuffer->Map<uint8_t>(indexRegion);
-#ifdef WIN32
-        memcpy_s(writeArea, sizeToStage, data, sizeToStage);
-#else
+
         memcpy(writeArea, data, sizeToStage);
-#endif
+
         stagingBuffer->UnmapAndWrite(indexRegion);
         currentContext->Copy(indexBuffer, stagingBuffer);
 
@@ -263,6 +271,9 @@ namespace NovelRT::Graphics
         GraphicsTextureAddressMode addressMode,
         GraphicsTextureKind textureKind)
     {
+        assert(metadata.data.size() != 0 && "metadata.data.size is zero, make sure you are passing in metadata that has a valid size on the data.");
+        assert(metadata.data.data() != nullptr && "metadata.data.data() returns a nullptr, make sure it returns a valid pointer.");
+
         auto currentContext = _graphicsDevice->GetCurrentContext();
 
         std::shared_ptr<GraphicsTexture> texture2d =
@@ -276,11 +287,7 @@ namespace NovelRT::Graphics
         auto texture2dRegion = texture2d->Allocate(texture2d->GetSize(), 4);
         auto pTextureData = stagingBuffer->Map<uint8_t>(texture2dRegion);
 
-#ifdef WIN32
-        memcpy_s(pTextureData, metadata.data.size(), metadata.data.data(), metadata.data.size());
-#else
         memcpy(pTextureData, metadata.data.data(), metadata.data.size());
-#endif
 
         stagingBuffer->UnmapAndWrite(texture2dRegion);
         currentContext->Copy(texture2d, stagingBuffer);
@@ -345,15 +352,15 @@ namespace NovelRT::Graphics
                                                                                                       size_t size,
                                                                                                       size_t alignment)
     {
+        assert(data != nullptr &&
+               "data is a nullptr, make sure that you are passing in a valid pointer into the method.");
+        assert(size != 0 && "size is zero, make sure the correct size has been passed in.");
+
         auto bufferPtr = GetOrCreateGraphicsBufferForAllocationSize(size, GraphicsBufferKind::Constant);
         auto allocation = bufferPtr->Allocate(size, alignment);
         uint8_t* destination = bufferPtr->Map<uint8_t>(allocation);
 
-#ifdef WIN32
-        memcpy_s(destination, size, data, size);
-#else
         memcpy(destination, data, size);
-#endif
 
         bufferPtr->UnmapAndWrite(allocation);
         return allocation;
@@ -364,6 +371,10 @@ namespace NovelRT::Graphics
         void* data,
         size_t size)
     {
+        assert(data != nullptr &&
+               "data is a nullptr, make sure that you are passing in a valid pointer into the method.");
+        assert(size != 0 && "dataTypeSize is zero, make sure the correct size has been passed in.");
+
         auto bufferPtr = std::dynamic_pointer_cast<GraphicsBuffer>(targetMemoryResource.GetCollection());
 
         if (bufferPtr == nullptr)
@@ -384,11 +395,7 @@ namespace NovelRT::Graphics
 
         uint8_t* destination = bufferPtr->Map<uint8_t>(targetMemoryResource);
 
-#ifdef WIN32
-        memcpy_s(destination, size, data, size);
-#else
         memcpy(destination, data, size);
-#endif
 
         bufferPtr->UnmapAndWrite(targetMemoryResource);
     }

--- a/src/NovelRT/Graphics/GraphicsResourceManager.cpp
+++ b/src/NovelRT/Graphics/GraphicsResourceManager.cpp
@@ -271,8 +271,10 @@ namespace NovelRT::Graphics
         GraphicsTextureAddressMode addressMode,
         GraphicsTextureKind textureKind)
     {
-        assert(metadata.data.size() != 0 && "metadata.data.size is zero, make sure you are passing in metadata that has a valid size on the data.");
-        assert(metadata.data.data() != nullptr && "metadata.data.data() returns a nullptr, make sure it returns a valid pointer.");
+        assert(metadata.data.size() != 0 &&
+               "metadata.data.size is zero, make sure you are passing in metadata that has a valid size on the data.");
+        assert(metadata.data.data() != nullptr &&
+               "metadata.data.data() returns a nullptr, make sure it returns a valid pointer.");
 
         auto currentContext = _graphicsDevice->GetCurrentContext();
 

--- a/src/NovelRT/Persistence/Chapter.cpp
+++ b/src/NovelRT/Persistence/Chapter.cpp
@@ -131,7 +131,8 @@ namespace NovelRT::Persistence
 
             for (auto&& [entity, dataView] : dataPair.second)
             {
-                std::memcpy(entityPtr, &entity, sizeof(Ecs::EntityId));
+                const size_t sizeOfEntityId = sizeof(Ecs::EntityId);
+                NovelRT::Utilities::Memory::Copy(entityPtr, sizeOfEntityId, &entity, sizeOfEntityId);
 
                 size_t componentJumpValue = sizeOfComponentType;
                 if (componentMetadata.sizeOfSerialisedDataInBytes == 0)

--- a/src/NovelRT/Persistence/Persistable.cpp
+++ b/src/NovelRT/Persistence/Persistable.cpp
@@ -32,7 +32,7 @@ namespace NovelRT::Persistence
         }
 
         auto newData = it->second->ExecuteSerialiseModification(componentData);
-        memcpy(writeToData.data(), newData.data(), writeToData.size());
+        NovelRT::Utilities::Memory::Copy(writeToData.data(), writeToData.size(), newData.data(), writeToData.size());
     }
 
     void Persistable::ApplyDeserialisationRule(const std::string& serialisedName,
@@ -48,7 +48,7 @@ namespace NovelRT::Persistence
         }
 
         auto newData = it->second->ExecuteDeserialiseModification(serialisedData);
-        memcpy(writeToData.data(), newData.data(), writeToData.size());
+        NovelRT::Utilities::Memory::Copy(writeToData.data(), writeToData.size(), newData.data(), writeToData.size());
     }
 
     // TODO: Rework this at a later date.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Changes the memcpy_s instances to use memcpy directly but adds asserts for debug time issues and if applicable nullptr checks on the destination/source


**Is there an open issue that this resolves? If so, please [link it here](https://github.com/novelrt/NovelRT/issues/388).**



**What is the current behavior?** (You can also link to an open issue here)
N/A


**What is the new behavior (if this is a feature change)?**
N/A


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No breaking change for the end user


**Other information**:
N/A