### PR TITLE
Implement Ecs::Graphics APIs and Component Ids for the C API

### DIFF
--- a/include/NovelRT.Interop/Ecs/Audio/NrtEcsAudio.h
+++ b/include/NovelRT.Interop/Ecs/Audio/NrtEcsAudio.h
@@ -7,5 +7,6 @@
 #include "NrtAudioEmitterComponent.h"
 #include "NrtAudioEmitterStateComponent.h"
 #include "NrtAudioSystem.h"
+#include "NrtEcsAudioComponents.h"
 
 #endif // NOVELRT_INTEROP_ECS_AUDIO_H

--- a/include/NovelRT.Interop/Ecs/Audio/NrtEcsAudioComponents.h
+++ b/include/NovelRT.Interop/Ecs/Audio/NrtEcsAudioComponents.h
@@ -1,0 +1,21 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_AUDIO_ECSAUDIOCOMPONENTS_H
+#define NOVELRT_INTEROP_ECS_AUDIO_ECSAUDIOCOMPONENTS_H
+
+#include "../../NrtTypedefs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    NrtAtom Nrt_Components_GetAudioEmitterComponentId();
+    NrtAtom Nrt_Components_GetAudioEmitterStateComponentId();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOVELRT_INTEROP_ECS_AUDIO_ECSAUDIOCOMPONENTS_H

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.h
@@ -1,8 +1,8 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
-#ifndef NOVELRT_INTEROP_ECS_GRAPHICS_NRTDEFAULTRENDERINGSYSTEM_H
-#define NOVELRT_INTEROP_ECS_GRAPHICS_NRTDEFAULTRENDERINGSYSTEM_H
+#ifndef NOVELRT_INTEROP_ECS_GRAPHICS_DEFAULTRENDERINGSYSTEM_H
+#define NOVELRT_INTEROP_ECS_GRAPHICS_DEFAULTRENDERINGSYSTEM_H
 
 #include "../../NrtTypedefs.h"
 
@@ -16,10 +16,40 @@ extern "C"
 
     NrtResult Nrt_DefaultRenderingSystem_ForceVertexTextureFutureResolution(NrtDefaultRenderingSystemHandle system);
 
-    // TODO: Implement GetOrLoadTexture, CreateSpriteEntity and CreateSpriteEntityOutsideOfSystem
+    NrtResult Nrt_DefaultRenderingSystem_GetOrLoadTexture(NrtDefaultRenderingSystemHandle system,
+                                                          const char* textureName,
+                                                          NrtFutureResultOfTextureInfoHandle* outputTextureFuture);
+
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingTextureById(NrtDefaultRenderingSystemHandle system,
+                                                                NrtAtom id,
+                                                                NrtTextureInfoHandle* outputTexture);
+
+    NrtResult Nrt_DefaultRenderingSystem_GetExistingTextureByName(NrtDefaultRenderingSystemHandle system,
+                                                                  const char* name,
+                                                                  NrtTextureInfoHandle* outputTexture);
+
+    // Even after calling a DeleteTexture method, TextureInfo_Destroy still
+    // needs to be called by the user once done with it!
+
+    NrtResult Nrt_DefaultRenderingSystem_DeleteTextureByHandle(NrtDefaultRenderingSystemHandle system,
+                                                               NrtTextureInfoHandle texture);
+
+    NrtResult Nrt_DefaultRenderingSystem_DeleteTextureByName(NrtDefaultRenderingSystemHandle system, const char* name);
+
+    NrtResult Nrt_DefaultRenderingSystem_DeleteTextureById(NrtDefaultRenderingSystemHandle system, NrtAtom id);
+
+    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntity(NrtDefaultRenderingSystemHandle system,
+                                                            NrtTextureInfoHandle texture,
+                                                            NrtCatalogueHandle catalogue,
+                                                            NrtEntityId* outputEntityId);
+
+    NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntityOutsideOfSystem(NrtDefaultRenderingSystemHandle system,
+                                                                           NrtTextureInfoHandle texture,
+                                                                           NrtSystemSchedulerHandle scheduler,
+                                                                           NrtEntityId* outputEntityId);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // NOVELRT_INTEROP_ECS_GRAPHICS_NRTDEFAULTRENDERINGSYSTEM_H
+#endif // NOVELRT_INTEROP_ECS_GRAPHICS_DEFAULTRENDERINGSYSTEM_H

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphics.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphics.h
@@ -4,5 +4,7 @@
 #define NOVELRT_INTEROP_ECS_GRAPHICS_NRTECSGRAPHICS_H
 
 #include "NrtDefaultRenderingSystem.h"
+#include "NrtEcsGraphicsComponents.h"
+#include "NrtTextureInfo.h"
 
 #endif // NOVELRT_INTEROP_ECS_GRAPHICS_NRTECSGRAPHICS_H

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsComponents.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsComponents.h
@@ -1,0 +1,21 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_GRAPHICS_ECSGRAPHICSCOMPONENTS_H
+#define NOVELRT_INTEROP_ECS_GRAPHICS_ECSGRAPHICSCOMPONENTS_H
+
+#include "../../NrtTypedefs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    NrtAtom Nrt_Components_GetRenderComponentTypeId();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif // NOVELRT_INTEROP_ECS_GRAPHICS_ECSGRAPHICSCOMPONENTS_H

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsTypedefs.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsTypedefs.h
@@ -10,6 +10,17 @@ extern "C"
 
     typedef struct NrtDefaultRenderingSystem* NrtDefaultRenderingSystemHandle;
 
+    // Component types
+
+    typedef struct {
+        NrtAtom vertexDataId;
+        NrtAtom textureId;
+        NrtAtom pipelineId;
+        NrtAtom primitiveInfoId;
+        bool requiresCustomRendering;
+        bool markedForDeletion;
+    } NrtRenderComponent;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/NovelRT.Interop/Ecs/Graphics/NrtTextureInfo.h
+++ b/include/NovelRT.Interop/Ecs/Graphics/NrtTextureInfo.h
@@ -1,0 +1,30 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_GRAPHICS_TEXTUREINFO_H
+#define NOVELRT_INTEROP_ECS_GRAPHICS_TEXTUREINFO_H
+
+#include "../../NrtTypedefs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    NrtResult Nrt_TextureInfo_Destroy(NrtTextureInfoHandle texture);
+
+    char* Nrt_TextureInfo_GetTextureName(NrtTextureInfoHandle texture);
+
+    uint32_t Nrt_TextureInfo_GetTextureWidth(NrtTextureInfoHandle texture);
+
+    uint32_t Nrt_TextureInfo_GetTextureHeight(NrtTextureInfoHandle texture);
+
+    NrtAtom Nrt_TextureInfo_GetEcsId(NrtTextureInfoHandle texture);
+
+    NrtBool Nrt_TextureInfo_Equals(NrtTextureInfoHandle lhs, NrtTextureInfoHandle rhs);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOVELRT_INTEROP_ECS_GRAPHICS_TEXTUREINFO_H

--- a/include/NovelRT.Interop/Ecs/Input/NrtEcsInput.h
+++ b/include/NovelRT.Interop/Ecs/Input/NrtEcsInput.h
@@ -1,0 +1,10 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_INPUT_ECSINPUT_H
+#define NOVELRT_INTEROP_ECS_INPUT_ECSINPUT_H
+
+#include "NrtEcsInputComponents.h"
+#include "NrtEcsInputTypedefs.h"
+
+#endif // NOVELRT_INTEROP_ECS_INPUT_ECSINPUT_H

--- a/include/NovelRT.Interop/Ecs/Input/NrtEcsInputComponents.h
+++ b/include/NovelRT.Interop/Ecs/Input/NrtEcsInputComponents.h
@@ -1,0 +1,20 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_INPUT_ECSINPUTCOMPONENTS_H
+#define NOVELRT_INTEROP_ECS_INPUT_ECSINPUTCOMPONENTS_H
+
+#include "../../NrtTypedefs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    NrtAtom Nrt_Components_GetInputEventComponentTypeId();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOVELRT_INTEROP_ECS_INPUT_ECSINPUTCOMPONENTS_H

--- a/include/NovelRT.Interop/Ecs/Input/NrtEcsInputTypedefs.h
+++ b/include/NovelRT.Interop/Ecs/Input/NrtEcsInputTypedefs.h
@@ -1,0 +1,34 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_INPUT_NRTECSINPUTTYPEDEFS_H
+#define NOVELRT_INTEROP_ECS_INPUT_NRTECSINPUTTYPEDEFS_H
+
+#include "../../NrtTypedefs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    // Components
+    // Note that int32_t is used instead of NrtKeyState, as, in C,
+    // enums are *not* guaranteed to be exactly the size of an int.
+    // Even though it is in 99.99% of the cases due to system ABI,
+    // we better enforce the size given by the C++ NovelRT API.
+    // See KeyState definition:
+    //     enum class KeyState : int32_t <---
+
+    typedef struct {
+        NrtAtom actionId;
+        // Uses the NrtKeyState enum.
+        int32_t state;
+        float mousePositionX;
+        float mousePositionY;
+    } NrtInputEventComponent;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOVELRT_INTEROP_ECS_INPUT_NRTECSINPUTTYPEDEFS_H

--- a/include/NovelRT.Interop/Ecs/NrtEcs.h
+++ b/include/NovelRT.Interop/Ecs/NrtEcs.h
@@ -9,6 +9,7 @@
 #include "NrtComponentCache.h"
 #include "NrtConfigurator.h"
 #include "NrtEntityCache.h"
+#include "NrtEcsComponents.h"
 #include "NrtEntityIdVector.h"
 #include "NrtSparseSetMemoryContainer.h"
 #include "NrtSystemScheduler.h"

--- a/include/NovelRT.Interop/Ecs/NrtEcsComponents.h
+++ b/include/NovelRT.Interop/Ecs/NrtEcsComponents.h
@@ -1,0 +1,23 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_ECS_ECSCOMPONENTS_H
+#define NOVELRT_INTEROP_ECS_ECSCOMPONENTS_H
+
+#include "../NrtTypedefs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    NrtAtom Nrt_Components_GetTransformComponentTypeId();
+    NrtAtom Nrt_Components_GetEntityGraphComponentTypeId();
+    NrtAtom Nrt_Components_LinkedEntityListNodeComponentTypeId();
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif // NOVELRT_INTEROP_ECS_ECSCOMPONENTS_H

--- a/include/NovelRT.Interop/Ecs/NrtEcsTypedefs.h
+++ b/include/NovelRT.Interop/Ecs/NrtEcsTypedefs.h
@@ -34,6 +34,34 @@ extern "C"
     typedef NrtAtom NrtEntityId;
     typedef NrtAtom NrtComponentTypeId;
 
+    // Default components, equivalents in C structs
+    // When a component is modified in DefaultComponentTypes.h,
+    // it must also be updated there.
+
+    // Note that we do not use the NrtBool type,
+    // as it doesn't have the same as a standard C/C++ bool.
+
+    typedef struct
+    {
+        NrtGeoVector3F positionAndLayer;
+        NrtGeoVector2F scale;
+        float rotationInRadians;
+    } NrtTransformComponent;
+
+    typedef struct
+    {
+        bool isValid;
+        NrtEntityId parent;
+        NrtEntityId childrenStartNode;
+    } NrtEntityGraphComponent;
+
+    typedef struct
+    {
+        bool isValid;
+        NrtEntityId parent;
+        NrtEntityId childrenStartNode;
+    } NrtLinkedEntityListNodeComponent;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/NovelRT.Interop/Graphics/NrtGraphicsTypedefs.h
+++ b/include/NovelRT.Interop/Graphics/NrtGraphicsTypedefs.h
@@ -18,6 +18,8 @@ extern "C"
 
     typedef struct NrtGraphicsProvider* NrtGraphicsProviderHandle;
 
+    typedef struct NrtTextureInfo* NrtTextureInfoHandle;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/NovelRT.Interop/NrtTypedefs.h
+++ b/include/NovelRT.Interop/NrtTypedefs.h
@@ -71,6 +71,7 @@ extern "C"
 #include "Audio/NrtAudioTypedefs.h"
 #include "Ecs/Audio/NrtEcsAudioTypedefs.h"
 #include "Ecs/Graphics/NrtEcsGraphicsTypedefs.h"
+#include "Ecs/Input/NrtEcsInputTypedefs.h"
 #include "Ecs/NrtEcsTypedefs.h"
 #include "Graphics/NrtGraphicsTypedefs.h"
 #include "Input/NrtInputTypedefs.h"
@@ -78,6 +79,7 @@ extern "C"
 #include "ResourceManagement/NrtResourceManagementTypedefs.h"
 #include "SceneGraph/NrtSceneGraphTypedefs.h"
 #include "Windowing/NrtWindowingTypedefs.h"
+#include "Threading/NrtThreadingTypedefs.h"
 
     // clang-format on
 

--- a/include/NovelRT.Interop/Threading/NrtFutureResult.h
+++ b/include/NovelRT.Interop/Threading/NrtFutureResult.h
@@ -1,0 +1,24 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_THREADING_FUTURERESULT_H
+#define NOVELRT_INTEROP_THREADING_FUTURERESULT_H
+
+#include "../NrtTypedefs.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    // FutureResult<TextureInfo>
+    NrtResult Nrt_FutureResultOfTextureInfo_Destroy(NrtFutureResultOfTextureInfoHandle handle);
+
+    NrtBool Nrt_FutureResultOfTextureInfo_TryGetValue(NrtFutureResultOfTextureInfoHandle handle,
+                                                      NrtTextureInfoHandle* outValue);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOVELRT_INTEROP_THREADING_FUTURERESULT_H

--- a/include/NovelRT.Interop/Threading/NrtThreadingTypedefs.h
+++ b/include/NovelRT.Interop/Threading/NrtThreadingTypedefs.h
@@ -1,0 +1,18 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#ifndef NOVELRT_INTEROP_THREADING_THREADINGTYPEDEFS_H
+#define NOVELRT_INTEROP_THREADING_THREADINGTYPEDEFS_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct NrtFutureResultOfTextureInfo* NrtFutureResultOfTextureInfoHandle;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NOVELRT_INTEROP_THREADING_THREADINGTYPEDEFS_H

--- a/src/NovelRT.Interop/CMakeLists.txt
+++ b/src/NovelRT.Interop/CMakeLists.txt
@@ -8,6 +8,7 @@ set(INTEROP_SOURCES
   Ecs/NrtConfigurator.cpp
   Ecs/NrtComponentBufferMemoryContainer.cpp
   Ecs/NrtComponentCache.cpp
+  Ecs/NrtEcsComponents.cpp
   Ecs/NrtEntityCache.cpp
   Ecs/NrtEntityIdVector.cpp
   Ecs/NrtSparseSetMemoryContainer.cpp
@@ -17,8 +18,13 @@ set(INTEROP_SOURCES
   Ecs/Audio/NrtAudioSystem.cpp
   Ecs/Audio/NrtAudioEmitterComponent.cpp
   Ecs/Audio/NrtAudioEmitterStateComponent.cpp
+  Ecs/Audio/NrtEcsAudioComponents.cpp
 
   Ecs/Graphics/NrtDefaultRenderingSystem.cpp
+  Ecs/Graphics/NrtTextureInfo.cpp
+  Ecs/Graphics/NrtEcsGraphicsComponents.cpp
+
+  Ecs/Input/NrtEcsInputComponents.cpp
 
   Graphics/NrtRGBAColour.cpp
   Graphics/NrtGraphicsProvider.cpp
@@ -43,7 +49,7 @@ set(INTEROP_SOURCES
   ResourceManagement/NrtTextureMetadata.cpp
   ResourceManagement/NrtResourceLoader.cpp
   ResourceManagement/NrtUint8Vector.cpp
-        ResourceManagement/NrtInt16Vector.cpp
+  ResourceManagement/NrtInt16Vector.cpp
   ResourceManagement/NrtUuidFilePathMap.cpp
 
   PluginManagement/NrtDefaultPluginSelector.cpp
@@ -61,14 +67,15 @@ set(INTEROP_SOURCES
   SceneGraph/NrtSceneNodeBreadthFirstIterator.cpp
   SceneGraph/NrtSceneNodeDepthFirstIterator.cpp
 
+  Threading/NrtFutureResult.cpp
+
   Timing/NrtStepTimer.cpp
   Timing/NrtTimestamp.cpp
 
   Utilities/NrtMisc.cpp
   Utilities/NrtEvent.cpp
 
-  Windowing/NrtIWindowingDevice.cpp
-)
+  Windowing/NrtIWindowingDevice.cpp)
 
 add_library(Interop SHARED ${INTEROP_SOURCES})
 add_dependencies(Interop Engine)

--- a/src/NovelRT.Interop/Ecs/Audio/NrtEcsAudioComponents.cpp
+++ b/src/NovelRT.Interop/Ecs/Audio/NrtEcsAudioComponents.cpp
@@ -1,0 +1,18 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <NovelRT.Interop/Ecs/Audio/NrtEcsAudioComponents.h>
+#include <NovelRT/Ecs/Ecs.h>
+
+using namespace NovelRT::Ecs;
+using namespace NovelRT::Ecs::Audio;
+
+NrtAtom Nrt_Components_GetAudioEmitterComponentId()
+{
+    return GetComponentTypeId<AudioEmitterComponent>();
+}
+
+NrtAtom Nrt_Components_GetAudioEmitterStateComponentId()
+{
+    return GetComponentTypeId<AudioEmitterStateComponent>();
+}

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.cpp
@@ -1,13 +1,15 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
+#include "../../LifetimeExtender.h"
 #include <NovelRT.Interop/Ecs/Graphics/NrtDefaultRenderingSystem.h>
 #include <NovelRT.Interop/NrtErrorHandling.h>
 #include <NovelRT/Ecs/Ecs.h>
-#include <NovelRT/Ecs/Graphics/Ecs.Graphics.h>
 
 using namespace NovelRT::Ecs;
 using namespace NovelRT::Ecs::Graphics;
+using namespace NovelRT::Threading;
+using namespace NovelRT::Interop;
 
 NrtResult Nrt_DefaultRenderingSystem_FindInScheduler(NrtSystemSchedulerHandle scheduler,
                                                      NrtDefaultRenderingSystemHandle* outputResult)
@@ -48,5 +50,255 @@ NrtResult Nrt_DefaultRenderingSystem_ForceVertexTextureFutureResolution(NrtDefau
     }
 
     reinterpret_cast<DefaultRenderingSystem*>(system)->ForceVertexTextureFutureResolution();
+    return NRT_SUCCESS;
+}
+NrtResult Nrt_DefaultRenderingSystem_GetOrLoadTexture(NrtDefaultRenderingSystemHandle system,
+                                                      const char* textureName,
+                                                      NrtFutureResultOfTextureInfoHandle* outputTextureFuture)
+{
+    if (system == nullptr)
+    {
+        Nrt_setErrMsgIsNullInstanceProvidedInternal();
+        return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+    }
+    if (textureName == nullptr)
+    {
+        Nrt_setErrMsgIsNullArgumentProvidedInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+
+    auto* rendering = reinterpret_cast<DefaultRenderingSystem*>(system);
+    FutureResult<TextureInfo>&& future = rendering->GetOrLoadTexture(std::string(textureName));
+    // Let's move the FutureResult to the C land.
+    *outputTextureFuture =
+        reinterpret_cast<NrtFutureResultOfTextureInfoHandle>(new FutureResult<TextureInfo>{std::move(future)});
+
+    return NRT_SUCCESS;
+}
+
+NrtResult Nrt_DefaultRenderingSystem_GetExistingTextureById(NrtDefaultRenderingSystemHandle system,
+                                                            NrtAtom id,
+                                                            NrtTextureInfoHandle* outputTexture)
+{
+    if (system == nullptr)
+    {
+        Nrt_setErrMsgIsNullInstanceProvidedInternal();
+        return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+    }
+    if (outputTexture == nullptr)
+    {
+        Nrt_setErrMsgIsNullArgumentProvidedInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+
+    auto* rendering = reinterpret_cast<DefaultRenderingSystem*>(system);
+    ConcurrentSharedPtr<TextureInfo> texture(nullptr);
+    try
+    {
+        texture = rendering->GetExistingTexture(id);
+    }
+    catch (const std::out_of_range&)
+    {
+        return NRT_FAILURE_KEY_NOT_FOUND;
+    }
+
+    *outputTexture = reinterpret_cast<NrtTextureInfoHandle>(texture.get());
+    ConcurrentLifetime::KeepAlive(std::move(texture));
+
+    return NRT_SUCCESS;
+}
+
+NrtResult Nrt_DefaultRenderingSystem_GetExistingTextureByName(NrtDefaultRenderingSystemHandle system,
+                                                              const char* name,
+                                                              NrtTextureInfoHandle* outputTexture)
+{
+    if (system == nullptr)
+    {
+        Nrt_setErrMsgIsNullInstanceProvidedInternal();
+        return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+    }
+    if (name == nullptr)
+    {
+        Nrt_setErrMsgIsNullArgumentProvidedInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+    if (outputTexture == nullptr)
+    {
+        Nrt_setErrMsgIsNullArgumentProvidedInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+
+    auto* rendering = reinterpret_cast<DefaultRenderingSystem*>(system);
+    ConcurrentSharedPtr<TextureInfo> texture(nullptr);
+    try
+    {
+        texture = rendering->GetExistingTexture(std::string(name));
+    }
+    catch (const NovelRT::Exceptions::KeyNotFoundException&)
+    {
+        return NRT_FAILURE_KEY_NOT_FOUND;
+    }
+
+    *outputTexture = reinterpret_cast<NrtTextureInfoHandle>(texture.get());
+    ConcurrentLifetime::KeepAlive(std::move(texture));
+
+    return NRT_SUCCESS;
+}
+NrtResult Nrt_DefaultRenderingSystem_DeleteTextureByHandle(NrtDefaultRenderingSystemHandle system,
+                                                           NrtTextureInfoHandle texture)
+{
+    if (system == nullptr)
+    {
+        Nrt_setErrMsgIsNullInstanceProvidedInternal();
+        return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+    }
+    if (texture == nullptr)
+    {
+        Nrt_setErrMsgIsNullArgumentProvidedInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+
+    auto* cppTexture = reinterpret_cast<TextureInfo*>(texture);
+    ConcurrentSharedPtr<TextureInfo> sharedTexture = ConcurrentLifetime::Find(cppTexture);
+    if (sharedTexture == nullptr)
+    {
+        Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
+        return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
+    }
+
+    auto* rendering = reinterpret_cast<DefaultRenderingSystem*>(system);
+    rendering->DeleteTexture(sharedTexture);
+
+    return NRT_SUCCESS;
+}
+
+NrtResult Nrt_DefaultRenderingSystem_DeleteTextureByName(NrtDefaultRenderingSystemHandle system, const char* name)
+{
+    if (system == nullptr)
+    {
+        Nrt_setErrMsgIsNullInstanceProvidedInternal();
+        return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+    }
+    if (name == nullptr)
+    {
+        Nrt_setErrMsgIsNullArgumentProvidedInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+
+    auto* rendering = reinterpret_cast<DefaultRenderingSystem*>(system);
+    try
+    {
+        rendering->DeleteTexture(std::string(name));
+    }
+    catch (const NovelRT::Exceptions::KeyNotFoundException&)
+    {
+        return NRT_FAILURE_KEY_NOT_FOUND;
+    }
+
+    return NRT_SUCCESS;
+}
+
+NrtResult Nrt_DefaultRenderingSystem_DeleteTextureById(NrtDefaultRenderingSystemHandle system, NrtAtom id)
+{
+    if (system == nullptr)
+    {
+        Nrt_setErrMsgIsNullInstanceProvidedInternal();
+        return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+    }
+
+    auto* rendering = reinterpret_cast<DefaultRenderingSystem*>(system);
+    try
+    {
+        rendering->DeleteTexture(id);
+    }
+    catch (const NovelRT::Exceptions::KeyNotFoundException&)
+    {
+        return NRT_FAILURE_KEY_NOT_FOUND;
+    }
+
+    return NRT_SUCCESS;
+}
+NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntity(NrtDefaultRenderingSystemHandle system,
+                                                        NrtTextureInfoHandle texture,
+                                                        NrtCatalogueHandle catalogue,
+                                                        NrtEntityId* outputEntityId)
+{
+    if (system == nullptr)
+    {
+        Nrt_setErrMsgIsNullInstanceProvidedInternal();
+        return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+    }
+    if (texture == nullptr)
+    {
+        Nrt_setErrMsgIsNullArgumentProvidedInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+    if (catalogue == nullptr)
+    {
+        Nrt_setErrMsgIsNullArgumentProvidedInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+    if (outputEntityId == nullptr)
+    {
+        Nrt_setErrMsgIsNullArgumentProvidedInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+
+    auto* rendering = reinterpret_cast<DefaultRenderingSystem*>(system);
+    auto* cppTexture = reinterpret_cast<TextureInfo*>(texture);
+    auto* cppCatalogue = reinterpret_cast<Catalogue*>(catalogue);
+
+    ConcurrentSharedPtr<TextureInfo> sharedTexture = ConcurrentLifetime::Find(cppTexture);
+    if (sharedTexture == nullptr)
+    {
+        Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
+        return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
+    }
+
+    NrtAtom id = rendering->CreateSpriteEntity(sharedTexture, *cppCatalogue);
+    *outputEntityId = id;
+
+    return NRT_SUCCESS;
+}
+NrtResult Nrt_DefaultRenderingSystem_CreateSpriteEntityOutsideOfSystem(NrtDefaultRenderingSystemHandle system,
+                                                                       NrtTextureInfoHandle texture,
+                                                                       NrtSystemSchedulerHandle scheduler,
+                                                                       NrtEntityId* outputEntityId)
+{
+    if (system == nullptr)
+    {
+        Nrt_setErrMsgIsNullInstanceProvidedInternal();
+        return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+    }
+    if (texture == nullptr)
+    {
+        Nrt_setErrMsgIsNullArgumentProvidedInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+    if (scheduler == nullptr)
+    {
+        Nrt_setErrMsgIsNullArgumentProvidedInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+    if (outputEntityId == nullptr)
+    {
+        Nrt_setErrMsgIsNullArgumentProvidedInternal();
+        return NRT_FAILURE_NULL_ARGUMENT_PROVIDED;
+    }
+
+    auto* rendering = reinterpret_cast<DefaultRenderingSystem*>(system);
+    auto* cppTexture = reinterpret_cast<TextureInfo*>(texture);
+    auto* cppScheduler = reinterpret_cast<SystemScheduler*>(scheduler);
+
+    ConcurrentSharedPtr<TextureInfo> sharedTexture = ConcurrentLifetime::Find(cppTexture);
+    if (sharedTexture == nullptr)
+    {
+        Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
+        return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
+    }
+
+    NrtAtom id = rendering->CreateSpriteEntityOutsideOfSystem(sharedTexture, *cppScheduler);
+    *outputEntityId = id;
+
     return NRT_SUCCESS;
 }

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsComponents.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsComponents.cpp
@@ -1,0 +1,13 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <NovelRT.Interop/Ecs/Graphics/NrtEcsGraphicsComponents.h>
+#include <NovelRT/Ecs/Ecs.h>
+
+using namespace NovelRT::Ecs;
+using namespace NovelRT::Ecs::Graphics;
+
+NrtAtom Nrt_Components_GetRenderComponentTypeId()
+{
+    return GetComponentTypeId<RenderComponent>();
+}

--- a/src/NovelRT.Interop/Ecs/Graphics/NrtTextureInfo.cpp
+++ b/src/NovelRT.Interop/Ecs/Graphics/NrtTextureInfo.cpp
@@ -1,0 +1,55 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include "../../LifetimeExtender.h"
+#include <NovelRT.Interop/Ecs/Graphics/NrtTextureInfo.h>
+#include <NovelRT.Interop/NrtErrorHandling.h>
+#include <NovelRT/Ecs/Ecs.h>
+
+using namespace NovelRT::Ecs::Graphics;
+using namespace NovelRT::Interop;
+
+// TextureInfo is a "shared" object. Its lifetime is managed by ConcurrentLifetime (LifetimeExtender.h),
+// which can provide a ConcurrentSharedPtr for the TextureInfo.
+
+NrtResult Nrt_TextureInfo_Destroy(NrtTextureInfoHandle texture)
+{
+    if (texture == nullptr)
+    {
+        Nrt_setErrMsgIsNullInstanceProvidedInternal();
+        return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+    }
+
+    if (!ConcurrentLifetime::Release(reinterpret_cast<TextureInfo*>(texture)))
+    {
+        Nrt_setErrMsgIsAlreadyDeletedOrRemovedInternal();
+        return NRT_FAILURE_ALREADY_DELETED_OR_REMOVED;
+    }
+
+    return NRT_SUCCESS;
+}
+
+char* Nrt_TextureInfo_GetTextureName(NrtTextureInfoHandle texture)
+{
+    return reinterpret_cast<TextureInfo*>(texture)->textureName.data();
+}
+
+uint32_t Nrt_TextureInfo_GetTextureWidth(NrtTextureInfoHandle texture)
+{
+    return reinterpret_cast<TextureInfo*>(texture)->width;
+}
+
+uint32_t Nrt_TextureInfo_GetTextureHeight(NrtTextureInfoHandle texture)
+{
+    return reinterpret_cast<TextureInfo*>(texture)->height;
+}
+
+NrtAtom Nrt_TextureInfo_GetEcsId(NrtTextureInfoHandle texture)
+{
+    return reinterpret_cast<TextureInfo*>(texture)->ecsId;
+}
+
+NrtBool Nrt_TextureInfo_Equals(NrtTextureInfoHandle lhs, NrtTextureInfoHandle rhs)
+{
+    return *reinterpret_cast<TextureInfo*>(lhs) == *reinterpret_cast<TextureInfo*>(rhs);
+}

--- a/src/NovelRT.Interop/Ecs/Input/NrtEcsInputComponents.cpp
+++ b/src/NovelRT.Interop/Ecs/Input/NrtEcsInputComponents.cpp
@@ -1,0 +1,13 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <NovelRT.Interop/Ecs/Input/NrtEcsInputComponents.h>
+#include <NovelRT/Ecs/Ecs.h>
+
+using namespace NovelRT::Ecs;
+using namespace NovelRT::Ecs::Input;
+
+NrtAtom Nrt_Components_GetInputEventComponentTypeId()
+{
+    return GetComponentTypeId<InputEventComponent>();
+}

--- a/src/NovelRT.Interop/Ecs/NrtEcsComponents.cpp
+++ b/src/NovelRT.Interop/Ecs/NrtEcsComponents.cpp
@@ -1,0 +1,20 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <NovelRT.Interop/Ecs/NrtEcsComponents.h>
+#include <NovelRT/Ecs/Ecs.h>
+
+using namespace NovelRT::Ecs;
+
+NrtAtom Nrt_Components_GetTransformComponentTypeId()
+{
+    return GetComponentTypeId<TransformComponent>();
+}
+NrtAtom Nrt_Components_GetEntityGraphComponentTypeId()
+{
+    return GetComponentTypeId<EntityGraphComponent>();
+}
+NrtAtom Nrt_Components_LinkedEntityListNodeComponentTypeId()
+{
+    return GetComponentTypeId<LinkedEntityListNodeComponent>();
+}

--- a/src/NovelRT.Interop/Threading/NrtFutureResult.cpp
+++ b/src/NovelRT.Interop/Threading/NrtFutureResult.cpp
@@ -1,0 +1,78 @@
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include "../LifetimeExtender.h"
+#include "NovelRT.Interop/NrtErrorHandling.h"
+#include <NovelRT.Interop/Threading/NrtFutureResult.h>
+#include <NovelRT/Ecs/Ecs.h>
+#include <NovelRT/Threading/Threading.h>
+
+using namespace NovelRT::Threading;
+
+/*
+ * FutureResults are implemented in a similar fashion to Events, but in a much simpler way.
+ * An NrtFutureResultOfXHandle is simply a pointer to a C++ FutureResult, copied to the heap.
+ * Until the NrtFutureResult is destroyed, it holds a reference to the ConcurrentSharedPtr,
+ * keeping it alive.
+ * Once the value is requested, a "global" reference to X is added using the Lifetime system
+ * (see LifetimeExtender.h). It is the user's responsibility to remove this reference by calling
+ * the Destroy method on the instance of X, which usually calls Lifetime::Release.
+ *
+ * Each NrtFutureResultOfX requires two functions (NrtFutureResultOfXHandle = FRH for conciseness):
+ * - NrtResult Destroy(FRH future)
+ *      Destroys the future result, removing one reference count.
+ * - NrtBool TryGetValue(FRH future, XHandle* outValue)
+ *      If the value exists:
+ *          If outValue is not null:
+ *              Write the value handle to outValue
+ *              Add a ref count using ConcurrentLifetime (see LifetimeExtender.h)
+ *          Return true.
+ *      If it doesn't exist: Return false.
+ *
+ * You can use the GenericFutureResult methods to implement those functions.
+ * */
+
+template<typename X> NrtResult GenericFutureResultDestroy(void* handle)
+{
+    if (handle == nullptr)
+    {
+        Nrt_setErrMsgIsNullInstanceProvidedInternal();
+        return NRT_FAILURE_NULL_INSTANCE_PROVIDED;
+    }
+
+    delete reinterpret_cast<FutureResult<X>*>(handle);
+    return NRT_SUCCESS;
+}
+
+template<typename X, typename XHandle> NrtBool GenericFutureResultTryGetValue(void* handle, XHandle* outValue)
+{
+    auto future = reinterpret_cast<FutureResult<X>*>(handle);
+
+    if (future->IsValueCreated())
+    {
+        if (outValue != nullptr)
+        {
+            ConcurrentSharedPtr<X> sharedPtr = future->GetBackingConcurrentSharedPtr();
+
+            *outValue = reinterpret_cast<XHandle>(sharedPtr.get());
+            NovelRT::Interop::ConcurrentLifetime::KeepAlive(std::move(sharedPtr));
+        }
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+using TextureInfo = NovelRT::Ecs::Graphics::TextureInfo;
+
+NrtResult Nrt_FutureResultOfTextureInfo_Destroy(NrtFutureResultOfTextureInfoHandle handle)
+{
+    return GenericFutureResultDestroy<TextureInfo>(handle);
+}
+NrtBool Nrt_FutureResultOfTextureInfo_TryGetValue(NrtFutureResultOfTextureInfoHandle handle,
+                                                  NrtTextureInfoHandle* outValue)
+{
+    return GenericFutureResultTryGetValue<TextureInfo, NrtTextureInfoHandle>(handle, outValue);
+}


### PR DESCRIPTION
Rendering has always been a missing part in the C API. This PR fixes this and adds all methods required to get sprites on the screen.

This PR implements:

- A `FutureResult` equivalent for the C API
- Methods for the `DefaultRenderingSystem`, related to textures and entities
- `TextureInfo` support
- Methods to retrieve component ids of all built-in components
- C struct equivalents for all built-in components

This PR fixes:
- #405

Concerns:
- Is the new `LifetimeExtender.h` going to work well since we have global static stuff going on? 
- Should we make it clear for the user that `TextureInfo` (among other objects) aren't really "created" and "destroyed" per se, but rather tracked using `LifetimeExtender.h` with a `ConcurrentSharedPtr`?
- Is error handling good enough in `NrtFutureResult` and `NrtTextureInfo`?
- It looks like Audio already got some components-related code going on. In the future, how should we harmonise the C API for manipulating components?

Stuff to do:
- [ ] Write some tests (which parts to test?)
- [ ] Review the code