### PR TITLE
Fix KeyDownHeld reset (fixes #576)

### DIFF
--- a/src/NovelRT/Input/Glfw/GlfwInputDevice.cpp
+++ b/src/NovelRT/Input/Glfw/GlfwInputDevice.cpp
@@ -210,7 +210,8 @@ namespace NovelRT::Input::Glfw
                     release = glfwGetKey(_window, mapIterator->pairedKey.GetExternalKeyCode()) == GLFW_RELEASE;
                 }
 
-                if (press && stateIterator->state == KeyState::KeyDown)
+                if (press &&
+                    (stateIterator->state == KeyState::KeyDown || stateIterator->state == KeyState::KeyDownHeld))
                 {
                     mapIterator->state = KeyState::KeyDownHeld;
                 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes the issue where keys would be reset to `Idle` state while held.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
Fixes #576 


**What is the current behavior?** (You can also link to an open issue here)
If a key is pressed while in `KeyDownHeld` state, it will reset to `Idle` state in next frame.


**What is the new behavior (if this is a feature change)?**
If a key is pressed while in `KeyDownHeld` state, it's going to stay that way until another key is pressed.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Not really.
