### PR TITLE
[WIP] Replace Try methods that use out ref to pass the value to std optional

### DIFF
--- a/include/NovelRT/Ecs/ComponentBuffer.h
+++ b/include/NovelRT/Ecs/ComponentBuffer.h
@@ -46,12 +46,10 @@ namespace NovelRT::Ecs
                   poolSize,
                   &deleteInstructionState,
                   sizeof(T),
-                  [](auto rootComponent, auto updateComponent, auto) {
-                      *reinterpret_cast<T*>(rootComponent) += *reinterpret_cast<const T*>(updateComponent);
-                  },
-                  [](const void* left, const void* right) {
-                      return *reinterpret_cast<const T*>(left) == *reinterpret_cast<const T*>(right);
-                  },
+                  [](auto rootComponent, auto updateComponent, auto)
+                  { *reinterpret_cast<T*>(rootComponent) += *reinterpret_cast<const T*>(updateComponent); },
+                  [](const void* left, const void* right)
+                  { return *reinterpret_cast<const T*>(left) == *reinterpret_cast<const T*>(right); },
                   serialisedTypeName))
         {
             static_assert(std::is_trivially_copyable<T>::value,
@@ -156,19 +154,16 @@ namespace NovelRT::Ecs
          * calling a method.
          *
          * @param entity The entity to use for fetching the component.
-         * @param outComponent The output result for the fetched component, if there is one.
-         * @return true if a component was found and returned in outComponent.
-         * @return false if no component exists.
+         * @return optional T result, if the fetch failed the optional will not have a value.
          */
-        [[nodiscard]] bool TryGetComponent(EntityId entity, T& outComponent) const noexcept
+        [[nodiscard]] std::optional<T> TryGetComponent(EntityId entity) const noexcept
         {
             if (!HasComponent(entity))
             {
-                return false;
+                return std::optional<T>{};
             }
 
-            outComponent = GetComponentUnsafe(entity);
-            return true;
+            return GetComponentUnsafe(entity);
         }
 
         /**

--- a/include/NovelRT/Ecs/ComponentView.h
+++ b/include/NovelRT/Ecs/ComponentView.h
@@ -183,13 +183,11 @@ namespace NovelRT::Ecs
          * calling a method.
          *
          * @param entity The entity to use for fetching the component.
-         * @param outComponent The output result for the fetched component, if there is one.
-         * @return true if a component was found and returned in outComponent.
-         * @return false if no component exists.
+         * @return optional of TComponent, if the fetch failed optional will not have a value
          */
-        [[nodiscard]] bool TryGetComponent(EntityId entity, TComponent& outComponent) const noexcept
+        [[nodiscard]] std::optional<TComponent> TryGetComponent(EntityId entity) const noexcept
         {
-            return _componentBuffer.TryGetComponent(entity, outComponent);
+            return _componentBuffer.TryGetComponent(entity);
         }
 
         /**

--- a/include/NovelRT/Ecs/LinkedEntityListView.h
+++ b/include/NovelRT/Ecs/LinkedEntityListView.h
@@ -187,63 +187,57 @@ namespace NovelRT::Ecs
         void AddInsertBeforeIndexInstruction(size_t index, EntityId newNode);
         void AddInsertAfterIndexInstruction(size_t index, EntityId newNode);
 
-        [[nodiscard]] inline bool TryGetComposedDiffInstruction(
-            EntityId node,
-            LinkedEntityListNodeComponent& outNodeComponent) const noexcept
+        [[nodiscard]] inline std::optional<LinkedEntityListNodeComponent> TryGetComposedDiffInstruction(
+            EntityId node) const noexcept
         {
             if (_changes.ContainsKey(node))
             {
-                outNodeComponent = _changes[node];
-                return true;
+                return _changes[node];
             }
 
-            return false;
+            return std::optional<LinkedEntityListNodeComponent>{};
         }
 
-        [[nodiscard]] inline bool TryGetComposedDiffInstructionAtBeginning(
-            LinkedEntityListNodeComponent& outNodeComponent) const noexcept
+        [[nodiscard]] inline std::optional<LinkedEntityListNodeComponent> TryGetComposedDiffInstructionAtBeginning()
+            const noexcept
         {
             if (_newBeginPostDiff.has_value())
             {
-                outNodeComponent = _changes[_newBeginPostDiff.value()];
-                return true;
+                return _changes[_newBeginPostDiff.value()];
             }
 
-            return false;
+            return std::optional<LinkedEntityListNodeComponent>{};
         }
 
-        [[nodiscard]] inline bool TryGetComposedDiffInstructionAtEnd(
-            LinkedEntityListNodeComponent& outNodeComponent) const noexcept
+        [[nodiscard]] inline std::optional<LinkedEntityListNodeComponent> TryGetComposedDiffInstructionAtEnd()
+            const noexcept
         {
             if (_newTailPostDiff.has_value())
             {
-                outNodeComponent = _changes[_newTailPostDiff.value()];
-                return true;
+                return std::optional<LinkedEntityListNodeComponent>(_changes[_newTailPostDiff.value()]);
             }
 
-            return false;
+            return std::optional<LinkedEntityListNodeComponent>{};
         }
 
-        [[nodiscard]] inline bool TryGetNewNodeAtBeginning(EntityId& outEntityId) const noexcept
+        [[nodiscard]] inline std::optional<EntityId> TryGetNewNodeAtBeginning() const noexcept
         {
             if (_newBeginPostDiff.has_value())
             {
-                outEntityId = _newBeginPostDiff.value();
-                return true;
+                return _newBeginPostDiff.value();
             }
 
-            return false;
+            return std::optional<EntityId>{};
         }
 
-        [[nodiscard]] inline bool TryGetNewNodeAtEnd(EntityId& outEntityId) const noexcept
+        [[nodiscard]] inline std::optional<EntityId> TryGetNewNodeAtEnd() const noexcept
         {
             if (_newTailPostDiff.has_value())
             {
-                outEntityId = _newTailPostDiff.value();
-                return true;
+                return _newTailPostDiff.value();
             }
 
-            return false;
+            return std::optional<EntityId>{};
         }
 
         [[nodiscard]] inline EntityId GetOriginalBeginning() const noexcept

--- a/include/NovelRT/Graphics/GraphicsMemoryBlockCollection.h
+++ b/include/NovelRT/Graphics/GraphicsMemoryBlockCollection.h
@@ -29,10 +29,10 @@ namespace NovelRT::Graphics
         void RemoveBlockAt(std::vector<std::shared_ptr<GraphicsMemoryBlock>>::iterator iterator);
         void RemoveBlockAt(size_t index);
 
-        bool TryAllocateRegion(size_t size,
-                               size_t alignment,
-                               GraphicsMemoryRegionAllocationFlags flags,
-                               GraphicsMemoryRegion<GraphicsMemoryBlock>& region);
+        std::optional<GraphicsMemoryRegion<GraphicsMemoryBlock>> TryAllocateRegion(
+            size_t size,
+            size_t alignment,
+            GraphicsMemoryRegionAllocationFlags flags);
 
     protected:
         [[nodiscard]] virtual GraphicsMemoryBlock* CreateBlock(size_t size) = 0;
@@ -81,12 +81,12 @@ namespace NovelRT::Graphics
             size_t alignment = 1,
             GraphicsMemoryRegionAllocationFlags flags = GraphicsMemoryRegionAllocationFlags::None);
 
-        [[nodiscard]] bool TryAllocate(size_t size,
-                                       size_t alignment,
-                                       GraphicsMemoryRegionAllocationFlags flags,
-                                       GraphicsMemoryRegion<GraphicsMemoryBlock>& outRegion);
+        [[nodiscard]] std::optional<GraphicsMemoryRegion<GraphicsMemoryBlock>> TryAllocate(
+            size_t size,
+            size_t alignment,
+            GraphicsMemoryRegionAllocationFlags flags);
 
-        [[nodiscard]] bool TryAllocate(size_t size, GraphicsMemoryRegion<GraphicsMemoryBlock>& outRegion);
+        [[nodiscard]] std::optional<GraphicsMemoryRegion<GraphicsMemoryBlock>> TryAllocate(size_t size);
 
         [[nodiscard]] bool TryAllocate(
             size_t size,

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsBuffer.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsBuffer.h
@@ -68,19 +68,21 @@ namespace NovelRT::Graphics::Vulkan
                                  GraphicsResourceAccess cpuAccess,
                                  VkBuffer vulkanBuffer)
             : VulkanGraphicsBuffer(std::move(device), kind, std::move(blockRegion), cpuAccess, vulkanBuffer),
-              _metadata([&]() {
-                  TMetadata metadata(GraphicsDeviceObject::GetDevice());
-                  GraphicsMemoryRegion<GraphicsMemoryBlock> blockRegionInternal = GetBlockRegion();
-                  std::shared_ptr<GraphicsMemoryBlock> block = blockRegionInternal.GetCollection();
+              _metadata(
+                  [&]()
+                  {
+                      TMetadata metadata(GraphicsDeviceObject::GetDevice());
+                      GraphicsMemoryRegion<GraphicsMemoryBlock> blockRegionInternal = GetBlockRegion();
+                      std::shared_ptr<GraphicsMemoryBlock> block = blockRegionInternal.GetCollection();
 
-                  size_t minimumAllocatedRegionMarginSize = block->GetMinimumAllocatedRegionMarginSize();
-                  size_t minimumFreeRegionSizeToRegister = block->GetMinimumFreeRegionSizeToRegister();
+                      size_t minimumAllocatedRegionMarginSize = block->GetMinimumAllocatedRegionMarginSize();
+                      size_t minimumFreeRegionSizeToRegister = block->GetMinimumFreeRegionSizeToRegister();
 
-                  metadata.Initialise(std::static_pointer_cast<VulkanGraphicsBufferImpl>(shared_from_this()),
-                                      blockRegionInternal.GetSize(), minimumAllocatedRegionMarginSize,
-                                      minimumFreeRegionSizeToRegister);
-                  return metadata;
-              })
+                      metadata.Initialise(std::static_pointer_cast<VulkanGraphicsBufferImpl>(shared_from_this()),
+                                          blockRegionInternal.GetSize(), minimumAllocatedRegionMarginSize,
+                                          minimumFreeRegionSizeToRegister);
+                      return metadata;
+                  })
         {
             static_assert(std::is_base_of_v<IGraphicsMemoryRegionCollection<GraphicsResource>::IMetadata, TMetadata>);
 
@@ -137,9 +139,9 @@ namespace NovelRT::Graphics::Vulkan
             _metadata.getActual().Free(region);
         }
 
-        bool TryAllocate(size_t size, size_t alignment, GraphicsMemoryRegion<GraphicsResource>& outRegion) final
+        std::optional<GraphicsMemoryRegion<GraphicsResource>> TryAllocate(size_t size, size_t alignment) final
         {
-            return _metadata.getActual().TryAllocate(size, alignment, outRegion);
+            return _metadata.getActual().TryAllocate(size, alignment);
         }
 
         [[nodiscard]] std::list<GraphicsMemoryRegion<GraphicsResource>>::iterator begin() final

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsMemoryBlock.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsMemoryBlock.h
@@ -54,17 +54,21 @@ namespace NovelRT::Graphics::Vulkan
         VulkanGraphicsMemoryBlockImpl(std::shared_ptr<VulkanGraphicsDevice> device,
                                       std::shared_ptr<VulkanGraphicsMemoryBlockCollection> collection,
                                       size_t size)
-            : VulkanGraphicsMemoryBlock(std::move(device), std::move(collection)), _metadata([&, size]() {
-                  TMetadata metadata(GetDevice());
-                  const GraphicsMemoryAllocatorSettings& allocatorSettings =
-                      GetCollection()->GetAllocator()->GetSettings();
+            : VulkanGraphicsMemoryBlock(std::move(device), std::move(collection)),
+              _metadata(
+                  [&, size]()
+                  {
+                      TMetadata metadata(GetDevice());
+                      const GraphicsMemoryAllocatorSettings& allocatorSettings =
+                          GetCollection()->GetAllocator()->GetSettings();
 
-                  size_t minimumAllocatedRegionSize = allocatorSettings.MinimumAllocatedRegionMarginSize.value_or(0);
-                  size_t minimumFreeRegionSizeToRegister = allocatorSettings.MinimumFreeRegionSizeToRegister;
-                  metadata.Initialise(std::static_pointer_cast<VulkanGraphicsMemoryBlockImpl>(shared_from_this()), size,
-                                      minimumAllocatedRegionSize, minimumFreeRegionSizeToRegister);
-                  return metadata;
-              })
+                      size_t minimumAllocatedRegionSize =
+                          allocatorSettings.MinimumAllocatedRegionMarginSize.value_or(0);
+                      size_t minimumFreeRegionSizeToRegister = allocatorSettings.MinimumFreeRegionSizeToRegister;
+                      metadata.Initialise(std::static_pointer_cast<VulkanGraphicsMemoryBlockImpl>(shared_from_this()),
+                                          size, minimumAllocatedRegionSize, minimumFreeRegionSizeToRegister);
+                      return metadata;
+                  })
         {
             static_assert(
                 std::is_base_of_v<IGraphicsMemoryRegionCollection<GraphicsMemoryBlock>::IMetadata, TMetadata>);
@@ -127,11 +131,10 @@ namespace NovelRT::Graphics::Vulkan
             _metadata.getActual().Free(region);
         }
 
-        [[nodiscard]] bool TryAllocate(size_t size,
-                                       size_t alignment,
-                                       GraphicsMemoryRegion<GraphicsMemoryBlock>& outRegion) final
+        [[nodiscard]] std::optional<GraphicsMemoryRegion<GraphicsMemoryBlock>> TryAllocate(size_t size,
+                                                                                           size_t alignment) final
         {
-            return _metadata.getActual().TryAllocate(size, alignment, outRegion);
+            return _metadata.getActual().TryAllocate(size, alignment);
         }
 
         [[nodiscard]] std::list<GraphicsMemoryRegion<GraphicsMemoryBlock>>::iterator begin() final

--- a/include/NovelRT/Graphics/Vulkan/VulkanGraphicsTexture.h
+++ b/include/NovelRT/Graphics/Vulkan/VulkanGraphicsTexture.h
@@ -103,20 +103,23 @@ namespace NovelRT::Graphics::Vulkan
                                     height,
                                     depth,
                                     vulkanImage),
-              _metadata([&]() {
-                  TMetadata metadata(GraphicsDeviceObject::GetDevice());
-                  GraphicsMemoryRegion<GraphicsMemoryBlock> blockRegionInternal = GetBlockRegion();
-                  std::shared_ptr<GraphicsMemoryBlock> block = blockRegionInternal.GetCollection();
+              _metadata(
+                  [&]()
+                  {
+                      TMetadata metadata(GraphicsDeviceObject::GetDevice());
+                      GraphicsMemoryRegion<GraphicsMemoryBlock> blockRegionInternal = GetBlockRegion();
+                      std::shared_ptr<GraphicsMemoryBlock> block = blockRegionInternal.GetCollection();
 
-                  size_t minimumAllocatedRegionMarginSize = block->GetMinimumAllocatedRegionMarginSize();
-                  size_t minimumFreeRegionSizeToRegister = block->GetMinimumFreeRegionSizeToRegister();
+                      size_t minimumAllocatedRegionMarginSize = block->GetMinimumAllocatedRegionMarginSize();
+                      size_t minimumFreeRegionSizeToRegister = block->GetMinimumFreeRegionSizeToRegister();
 
-                  metadata.Initialise(
-                      std::static_pointer_cast<VulkanGraphicsTextureImpl<TMetadata>>(shared_from_this()),
-                      blockRegionInternal.GetSize(), minimumAllocatedRegionMarginSize, minimumFreeRegionSizeToRegister);
+                      metadata.Initialise(
+                          std::static_pointer_cast<VulkanGraphicsTextureImpl<TMetadata>>(shared_from_this()),
+                          blockRegionInternal.GetSize(), minimumAllocatedRegionMarginSize,
+                          minimumFreeRegionSizeToRegister);
 
-                  return metadata;
-              })
+                      return metadata;
+                  })
         {
             static_assert(std::is_base_of_v<IGraphicsMemoryRegionCollection<GraphicsResource>::IMetadata, TMetadata>);
 
@@ -173,11 +176,10 @@ namespace NovelRT::Graphics::Vulkan
             _metadata.getActual().Free(region);
         }
 
-        [[nodiscard]] bool TryAllocate(size_t size,
-                                       size_t alignment,
-                                       GraphicsMemoryRegion<GraphicsResource>& outRegion) final
+        [[nodiscard]] std::optional<GraphicsMemoryRegion<GraphicsResource>> TryAllocate(size_t size,
+                                                                                        size_t alignment) final
         {
-            return _metadata.getActual().TryAllocate(size, alignment, outRegion);
+            return _metadata.getActual().TryAllocate(size, alignment);
         }
 
         [[nodiscard]] std::list<GraphicsMemoryRegion<GraphicsResource>>::iterator begin() final

--- a/include/NovelRT/Threading/FutureResult.h
+++ b/include/NovelRT/Threading/FutureResult.h
@@ -29,7 +29,7 @@ namespace NovelRT::Threading
 
         [[nodiscard]] bool IsValueCreated() noexcept
         {
-            return TryGetValue();
+            return TryGetValue().has_value();
         }
 
         [[nodiscard]] std::optional<TResultType> TryGetValue() noexcept

--- a/include/NovelRT/Threading/FutureResult.h
+++ b/include/NovelRT/Threading/FutureResult.h
@@ -29,8 +29,7 @@ namespace NovelRT::Threading
 
         [[nodiscard]] bool IsValueCreated() noexcept
         {
-            TResultType dummy;
-            return TryGetValue(dummy);
+            return TryGetValue();
         }
 
         [[nodiscard]] std::optional<TResultType> TryGetValue() noexcept

--- a/include/NovelRT/Threading/FutureResult.h
+++ b/include/NovelRT/Threading/FutureResult.h
@@ -33,17 +33,16 @@ namespace NovelRT::Threading
             return TryGetValue(dummy);
         }
 
-        [[nodiscard]] bool TryGetValue(TResultType& outValue) noexcept
+        [[nodiscard]] std::optional<TResultType> TryGetValue() noexcept
         {
             std::scoped_lock<ConcurrentSharedPtr<TResultType>> ptrLock(_dataContainer);
 
             if (*_dataContainer == _nullState)
             {
-                return false;
+                return std::optional<TResultType>{};
             }
 
-            outValue = *_dataContainer;
-            return true;
+            return *_dataContainer;
         }
 
         [[nodiscard]] TResultType& GetValue()

--- a/samples/AudioEcsSample/main.cpp
+++ b/samples/AudioEcsSample/main.cpp
@@ -147,19 +147,21 @@ int main()
 
         NovelRT::Ecs::Input::InputEventComponent input;
         bool triggered = false;
-        if (events.TryGetComponent(mouseClick, input) && (input.state == KeyState::KeyDown))
+        const auto value = events.TryGetComponent(mouseClick);
+        if (value.has_value() && (value.value().state == KeyState::KeyDown))
         {
             triggered =
-                uwuBounds.PointIsWithinBounds(NovelRT::Maths::GeoVector2F(input.mousePositionX, input.mousePositionY));
+                uwuBounds.PointIsWithinBounds(NovelRT::Maths::GeoVector2F(value.value().mousePositionX, value.value().mousePositionY));
         }
 
         if (triggered)
         {
             logger.logInfoLine("Clicked!");
             auto states = catalogue.template GetComponentView<AudioEmitterStateComponent>();
-            AudioEmitterStateComponent state;
-            if (states.TryGetComponent(soundEnt, state))
+            const auto value = states.TryGetComponent(soundEnt);
+            if (value.has_value())
             {
+                AudioEmitterStateComponent state = value.value();
                 if (state.state == AudioEmitterState::Stopped)
                 {
                     state.state = AudioEmitterState::ToPlay;

--- a/samples/InputEcsSample/main.cpp
+++ b/samples/InputEcsSample/main.cpp
@@ -95,46 +95,53 @@ int main()
         NovelRT::Maths::GeoVector2F move = NovelRT::Maths::GeoVector2F::Zero();
 
         NovelRT::Ecs::Input::InputEventComponent input;
-        if (events.TryGetComponent(up, input) &&
-            (input.state == KeyState::KeyDown || input.state == KeyState::KeyDownHeld))
+        auto value = events.TryGetComponent(up);
+        if (value.has_value() &&
+            (value.value().state == KeyState::KeyDown || value.value().state == KeyState::KeyDownHeld))
         {
             move += NovelRT::Maths::GeoVector2F{0.0f, 5.0f};
         }
 
-        if (events.TryGetComponent(down, input) &&
-            (input.state == KeyState::KeyDown || input.state == KeyState::KeyDownHeld))
+        value = events.TryGetComponent(down);
+        if (value.has_value() &&
+            (value.value().state == KeyState::KeyDown || value.value().state == KeyState::KeyDownHeld))
         {
             move += NovelRT::Maths::GeoVector2F{0.0f, -5.0f};
         }
 
-        if (events.TryGetComponent(left, input) &&
-            (input.state == KeyState::KeyDown || input.state == KeyState::KeyDownHeld))
+        value = events.TryGetComponent(left);
+        if (value.has_value() &&
+            (value.value().state == KeyState::KeyDown || value.value().state == KeyState::KeyDownHeld))
         {
             move += NovelRT::Maths::GeoVector2F{-5.0f, 0.0f};
         }
 
-        if (events.TryGetComponent(right, input) &&
-            (input.state == KeyState::KeyDown || input.state == KeyState::KeyDownHeld))
+        value = events.TryGetComponent(right);
+        if (value.has_value() &&
+            (value.value().state == KeyState::KeyDown || value.value().state == KeyState::KeyDownHeld))
         {
             move += NovelRT::Maths::GeoVector2F{5.0f, 0.0f};
         }
 
-        if (events.TryGetComponent(buttonA, input) &&
-            (input.state == KeyState::KeyDown || input.state == KeyState::KeyDownHeld))
+        value = events.TryGetComponent(buttonA);
+        if (value.has_value() &&
+            (value.value().state == KeyState::KeyDown || value.value().state == KeyState::KeyDownHeld))
         {
             scale += NovelRT::Maths::GeoVector2F{0.2f, 0.2f};
         }
 
-        if (events.TryGetComponent(buttonB, input) &&
-            (input.state == KeyState::KeyDown || input.state == KeyState::KeyDownHeld))
+        value = events.TryGetComponent(buttonB);
+        if (value.has_value() &&
+            (value.value().state == KeyState::KeyDown || value.value().state == KeyState::KeyDownHeld))
         {
             scale += NovelRT::Maths::GeoVector2F{-0.2f, -0.2f};
         }
 
-        if (events.TryGetComponent(mouseClick, input) &&
-            (input.state == KeyState::KeyDown || input.state == KeyState::KeyDownHeld))
+        value = events.TryGetComponent(mouseClick);
+        if (value.has_value() &&
+            (value.value().state == KeyState::KeyDown || value.value().state == KeyState::KeyDownHeld))
         {
-            logger.logInfo("Clicked at {}, {}", input.mousePositionX, input.mousePositionY);
+            logger.logInfo("Clicked at {}, {}", value.value().mousePositionX, value.value().mousePositionY);
         }
 
         for (auto [entity, transform] : transforms)

--- a/src/NovelRT/Ecs/EntityGraphView.cpp
+++ b/src/NovelRT/Ecs/EntityGraphView.cpp
@@ -66,7 +66,7 @@ namespace NovelRT::Ecs
 
         if (_externalChanges.find(newChildEntity) == _externalChanges.end())
         {
-            unused(view.TryGetComponent(newChildEntity, component));
+            component = view.TryGetComponent(newChildEntity).value();
             _externalChanges.emplace(newChildEntity, EntityGraphView(_catalogue, newChildEntity, component));
         }
 
@@ -115,11 +115,11 @@ namespace NovelRT::Ecs
 
         childGraphView.GetRawComponentData().parent = std::numeric_limits<EntityId>::max();
         _childrenChanges.getActual().AddRemoveNodeInstruction(childToRemove);
+        auto optionalNodeAtBeginning = _childrenChanges.getActual().TryGetNewNodeAtBeginning();
 
-        if (_component.childrenStartNode == childToRemove &&
-            !_childrenChanges.getActual().TryGetNewNodeAtBeginning(_component.childrenStartNode))
+        if (_component.childrenStartNode == childToRemove)
         {
-            _component.childrenStartNode = std::numeric_limits<EntityId>::max();
+            _component.childrenStartNode = optionalNodeAtBeginning.has_value() ? optionalNodeAtBeginning.value() : std::numeric_limits<EntityId>::max();
         }
 
         return childGraphView;

--- a/src/NovelRT/Ecs/EntityGraphView.cpp
+++ b/src/NovelRT/Ecs/EntityGraphView.cpp
@@ -119,7 +119,7 @@ namespace NovelRT::Ecs
 
         if (_component.childrenStartNode == childToRemove)
         {
-            _component.childrenStartNode = optionalNodeAtBeginning.has_value() ? optionalNodeAtBeginning.value() : std::numeric_limits<EntityId>::max();
+            _component.childrenStartNode = optionalNodeAtBeginning.value_or(std::numeric_limits<EntityId>::max());
         }
 
         return childGraphView;

--- a/src/NovelRT/Ecs/Graphics/DefaultRenderingSystem.cpp
+++ b/src/NovelRT/Ecs/Graphics/DefaultRenderingSystem.cpp
@@ -269,12 +269,13 @@ namespace NovelRT::Ecs::Graphics
         for (auto [entity, transformComponent] : transformComponents)
         {
             RenderComponent renderComponent{};
-
-            if (!renderComponents.TryGetComponent(entity, renderComponent))
+            const auto value = renderComponents.TryGetComponent(entity);
+            if (!value.has_value())
             {
                 continue;
             }
 
+            renderComponent = value.value();
             int32_t layer = static_cast<int32_t>(transformComponent.positionAndLayer.z);
 
             if (transformLayerMap.find(layer) == transformLayerMap.end())

--- a/src/NovelRT/Ecs/Input/InputSystem.cpp
+++ b/src/NovelRT/Ecs/Input/InputSystem.cpp
@@ -23,9 +23,10 @@ namespace NovelRT::Ecs::Input
         {
             InputEventComponent in;
             auto state = _device->GetKeyState(input.first);
-            if (inputs.TryGetComponent(input.second, in))
-            {
 
+            if (const auto value = inputs.TryGetComponent(input.second))
+            {
+                in = value.value();
                 switch (state)
                 {
                     case NovelRT::Input::KeyState::KeyUp:

--- a/src/NovelRT/Ecs/LinkedEntityListView.cpp
+++ b/src/NovelRT/Ecs/LinkedEntityListView.cpp
@@ -33,7 +33,11 @@ namespace NovelRT::Ecs
         {
             finalDiffInstructionForNext = _changes[existingNextNode];
         }
-        else if (!nodeView.TryGetComponent(existingNextNode, finalDiffInstructionForNext))
+        else if (const auto value = nodeView.TryGetComponent(existingNextNode))
+        {
+            finalDiffInstructionForNext = value.value();
+        }
+        else
         {
             finalDiffInstructionForNext = nodeView.GetDeleteInstructionState();
         }
@@ -71,7 +75,11 @@ namespace NovelRT::Ecs
         {
             finalDiffInstructionForPrevious = _changes[existingPreviousNode];
         }
-        else if (!nodeView.TryGetComponent(existingPreviousNode, finalDiffInstructionForPrevious))
+        else if (const auto value = nodeView.TryGetComponent(existingPreviousNode))
+        {
+            finalDiffInstructionForPrevious = value.value();
+        }
+        else
         {
             finalDiffInstructionForPrevious = nodeView.GetDeleteInstructionState();
         }
@@ -153,7 +161,11 @@ namespace NovelRT::Ecs
         {
             finalDiffInstructionForPrevious = _changes[existingPreviousNode];
         }
-        else if (!nodeView.TryGetComponent(existingPreviousNode, finalDiffInstructionForPrevious))
+        else if (const auto value = nodeView.TryGetComponent(existingPreviousNode))
+        {
+            finalDiffInstructionForPrevious = value.value();
+        }
+        else
         {
             finalDiffInstructionForPrevious = nodeView.GetDeleteInstructionState();
         }
@@ -191,7 +203,11 @@ namespace NovelRT::Ecs
         {
             finalDiffInstructionForNext = _changes[existingNextNode];
         }
-        else if (!nodeView.TryGetComponent(existingNextNode, finalDiffInstructionForNext))
+        else if (const auto value = nodeView.TryGetComponent(existingNextNode))
+        {
+                finalDiffInstructionForNext = value.value();
+        }
+        else
         {
             finalDiffInstructionForNext = nodeView.GetDeleteInstructionState();
         }
@@ -256,12 +272,15 @@ namespace NovelRT::Ecs
         auto view = _catalogue.GetComponentView<LinkedEntityListNodeComponent>();
         LinkedEntityListNodeComponent currentBeginComponent{};
 
-        if (!view.TryGetComponent(_begin, currentBeginComponent))
+        const auto value = view.TryGetComponent(_begin);
+
+        if (!value.has_value())
         {
             _changes.Insert(_begin, LinkedEntityListNodeComponent{});
         }
         else
         {
+            currentBeginComponent = value.value();
             while (currentBeginComponent.previous != std::numeric_limits<EntityId>::max())
             {
                 _begin = currentBeginComponent.previous;
@@ -580,7 +599,7 @@ namespace NovelRT::Ecs
                         }
                         else
                         {
-                            unused(nodeView.TryGetComponent(currentBeginCandidate, testComponent));
+                            testComponent = nodeView.TryGetComponent(currentBeginCandidate).value();
                         }
                         nextBeginCandidate = testComponent.next;
                     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** 
Code API change to move to a method signature that returns an optional instead of being invoked with a pass by ref parameter that is then set.


**Is there an open issue that this resolves?**
[563](https://github.com/novelrt/NovelRT/issues/563).


**What is the current behavior?**
Method signature is generally something along the lines of:
`bool TrySomething(T& outParam);`


**What is the new behavior (if this is a feature change)?**
New method signature most of the time is now:
`std::optional<T&> TrySomething()`


**Does this PR introduce a breaking change?**
Yes this breaks the API in multiple spots but generally not for the end user *yet* as it's mostly isolated in engine code.
