### PR TITLE
Fix Sparse data shrinkage bug.

### DIFF
--- a/src/NovelRT/Ecs/EntityCache.cpp
+++ b/src/NovelRT/Ecs/EntityCache.cpp
@@ -63,11 +63,10 @@ namespace NovelRT::Ecs
             _registeredEntities.resize(currentSize);
             auto rootIt = _registeredEntities.begin();
             std::advance(rootIt, oldSize);
-            std::copy_if(vector.begin(), vector.end(), rootIt,
-                         [&](auto entity) -> bool {
-                             return std::find(_registeredEntities.begin(), _registeredEntities.end(), entity) ==
-                                    _registeredEntities.end();
-                         });
+            std::copy_if(vector.begin(), vector.end(), rootIt, [&](auto entity) -> bool {
+                return std::find(_registeredEntities.begin(), _registeredEntities.end(), entity) ==
+                       _registeredEntities.end();
+            });
             vector.clear();
         }
     }

--- a/src/NovelRT/Ecs/EntityCache.cpp
+++ b/src/NovelRT/Ecs/EntityCache.cpp
@@ -63,10 +63,11 @@ namespace NovelRT::Ecs
             _registeredEntities.resize(currentSize);
             auto rootIt = _registeredEntities.begin();
             std::advance(rootIt, oldSize);
-            std::copy_if(vector.begin(), vector.end(), rootIt, [&](auto entity) -> bool {
-                return std::find(_registeredEntities.begin(), _registeredEntities.end(), entity) ==
-                       _registeredEntities.end();
-            });
+            std::copy_if(vector.begin(), vector.end(), rootIt,
+                         [&](auto entity) -> bool {
+                             return std::find(_registeredEntities.begin(), _registeredEntities.end(), entity) ==
+                                    _registeredEntities.end();
+                         });
             vector.clear();
         }
     }

--- a/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
+++ b/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
@@ -87,7 +87,7 @@ namespace NovelRT::Ecs
             std::optional<std::vector<size_t>::iterator> targetStart{};
             size_t currentValue = 0;
             size_t finalDenseSize = _dense.size();
-            for (auto it = _sparse.rbegin() + key; it != _sparse.rend(); it++)
+            for (auto it = _sparse.rbegin(); it != _sparse.rend(); it++)
             {
                 currentValue = *it;
                 if (currentValue < finalDenseSize && _dense[currentValue] == currentValue)

--- a/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
+++ b/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
@@ -84,21 +84,23 @@ namespace NovelRT::Ecs
 
         if (!_dense.empty())
         {
-            bool canResize = true;
-            for (auto it = _sparse.begin() + key; it != _sparse.end(); it++)
+            auto bla = _sparse.rbegin().base();
+            std::optional<std::vector<size_t>::iterator> targetStart{};
+            size_t currentValue = 0;
+            size_t finalDenseSize = _dense.size();
+            for (auto it = _sparse.rbegin() + key; it != _sparse.rend(); it++)
             {
-                if (*it == 0 && _dense[0] != key)
+                currentValue = *it;
+                if (currentValue < finalDenseSize && _dense[currentValue] == currentValue)
                 {
-                    continue;
+                    targetStart = it.base();
+                    break;
                 }
-
-                canResize = false;
-                break;
             }
 
-            if (canResize)
+            if (targetStart.has_value() && targetStart.value() != _sparse.end())
             {
-                _sparse.erase(_sparse.begin() + key, _sparse.end());
+                _sparse.erase(targetStart.value(), _sparse.end());
             }
         }
         else

--- a/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
+++ b/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
@@ -106,7 +106,6 @@ namespace NovelRT::Ecs
             _sparse.clear();
         }
 
-
         for (auto&& index : _sparse)
         {
             if (index < indexCutoff || index == 0)

--- a/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
+++ b/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
@@ -82,9 +82,9 @@ namespace NovelRT::Ecs
 
         _sparse[key] = 0;
 
-        bool canResize = true;
         if (!_dense.empty())
         {
+            bool canResize = true;
             for (auto it = _sparse.begin() + key; it != _sparse.end(); it++)
             {
                 if (*it == 0 && _dense[0] != key)
@@ -95,12 +95,17 @@ namespace NovelRT::Ecs
                 canResize = false;
                 break;
             }
+
+            if (canResize)
+            {
+                _sparse.erase(_sparse.begin() + key, _sparse.end());
+            }
+        }
+        else
+        {
+            _sparse.clear();
         }
 
-        if (canResize)
-        {
-            _sparse.erase(_sparse.begin() + key, _sparse.end());
-        }
 
         for (auto&& index : _sparse)
         {
@@ -140,7 +145,7 @@ namespace NovelRT::Ecs
 
     bool SparseSetMemoryContainer::ContainsKey(size_t key) const noexcept
     {
-        if (key >= _sparse.size() || _dense.empty())
+        if (key >= _sparse.size())
         {
             return false;
         }

--- a/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
+++ b/src/NovelRT/Ecs/SparseSetMemoryContainer.cpp
@@ -84,7 +84,6 @@ namespace NovelRT::Ecs
 
         if (!_dense.empty())
         {
-            auto bla = _sparse.rbegin().base();
             std::optional<std::vector<size_t>::iterator> targetStart{};
             size_t currentValue = 0;
             size_t finalDenseSize = _dense.size();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This removes a workaround that was recently introduced to `SparseSetMemoryContainer::ContainsKey` and replaces it with the actual fix to the issue.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
The unit tests pass and sparse set works as intended, with the memory usage shrinking correctly.


**What is the new behavior (if this is a feature change)?**
Ditto.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
N/A
