### PR TITLE
Simplify Atom to using typedef.

### DIFF
--- a/include/NovelRT/Atom.h
+++ b/include/NovelRT/Atom.h
@@ -11,69 +11,7 @@
 
 namespace NovelRT
 {
-    class Atom
-    {
-        friend class AtomHashFunction;
-
-    private:
-        uintptr_t _value;
-
-    public:
-        constexpr Atom() noexcept : Atom(0)
-        {
-        }
-
-        constexpr Atom(uintptr_t value) noexcept : _value(value)
-        {
-        }
-
-        bool operator==(Atom other) const noexcept
-        {
-            return _value == other._value;
-        }
-
-        bool operator==(uintptr_t other) const noexcept
-        {
-            return _value == other;
-        }
-
-        bool operator!=(Atom other) const noexcept
-        {
-            return _value != other._value;
-        }
-
-        bool operator!=(uintptr_t other) const noexcept
-        {
-            return _value != other;
-        }
-
-        bool operator<(Atom other) const noexcept
-        {
-            return _value < other._value;
-        }
-
-        bool operator<=(Atom other) const noexcept
-        {
-            return _value <= other._value;
-        }
-
-        bool operator>(Atom other) const noexcept
-        {
-            return _value > other._value;
-        }
-
-        bool operator>=(Atom other) const noexcept
-        {
-            return _value >= other._value;
-        }
-
-        operator uintptr_t() const noexcept
-        {
-            return _value;
-        }
-
-        static Atom GetNextEcsPrimitiveInfoConfigurationId() noexcept;
-    };
+    using Atom = uintptr_t;
 
     class AtomFactory
     {
@@ -99,22 +37,6 @@ namespace NovelRT
     {
     public:
         [[nodiscard]] static AtomFactory& GetFactory(const std::string& factoryName) noexcept;
-    };
-
-    class AtomHashFunction
-    {
-    public:
-        size_t operator()(Atom atom) const noexcept
-        {
-            return static_cast<size_t>(atom._value);
-        }
-    };
-}
-
-namespace std
-{
-    template<> class numeric_limits<NovelRT::Atom> : public numeric_limits<uintptr_t>
-    {
     };
 }
 

--- a/include/NovelRT/Ecs/ComponentCache.h
+++ b/include/NovelRT/Ecs/ComponentCache.h
@@ -18,7 +18,7 @@ namespace NovelRT::Ecs
     class ComponentCache
     {
     private:
-        std::unordered_map<ComponentTypeId, std::shared_ptr<ComponentBufferMemoryContainer>, AtomHashFunction>
+        std::unordered_map<ComponentTypeId, std::shared_ptr<ComponentBufferMemoryContainer>>
             _componentMap;
         size_t _poolSize;
         Utilities::Event<const std::vector<EntityId>&> _bufferPrepEvent;

--- a/include/NovelRT/Ecs/ComponentCache.h
+++ b/include/NovelRT/Ecs/ComponentCache.h
@@ -18,8 +18,7 @@ namespace NovelRT::Ecs
     class ComponentCache
     {
     private:
-        std::unordered_map<ComponentTypeId, std::shared_ptr<ComponentBufferMemoryContainer>>
-            _componentMap;
+        std::unordered_map<ComponentTypeId, std::shared_ptr<ComponentBufferMemoryContainer>> _componentMap;
         size_t _poolSize;
         Utilities::Event<const std::vector<EntityId>&> _bufferPrepEvent;
 

--- a/include/NovelRT/Ecs/SystemScheduler.h
+++ b/include/NovelRT/Ecs/SystemScheduler.h
@@ -23,7 +23,7 @@ namespace NovelRT::Ecs
         static inline const uint32_t DEFAULT_BLIND_THREAD_LIMIT = 8;
 
         std::vector<std::shared_ptr<IEcsSystem>> _typedSystemCache;
-        std::unordered_map<Atom, std::function<void(Timing::Timestamp, Catalogue)>, AtomHashFunction> _systems;
+        std::unordered_map<Atom, std::function<void(Timing::Timestamp, Catalogue)>> _systems;
 
         EntityCache _entityCache;
         ComponentCache _componentCache;

--- a/include/NovelRT/NovelRT.h
+++ b/include/NovelRT/NovelRT.h
@@ -58,7 +58,6 @@
    * It is aimed at designers and developers alike, however many of the designer tools and features we have on our roadmap have yet to be implemented.
    */
   namespace NovelRT {
-    typedef class Atom Atom;
     typedef class LoggingService LoggingService;
   }
 

--- a/src/NovelRT/Atom.cpp
+++ b/src/NovelRT/Atom.cpp
@@ -12,14 +12,6 @@
 
 namespace NovelRT
 {
-
-    Atom Atom::GetNextEcsPrimitiveInfoConfigurationId() noexcept
-    {
-        static std::atomic_uintptr_t _nextEcsPrimitiveInfoConfigurationId(0);
-        auto value = ++_nextEcsPrimitiveInfoConfigurationId;
-        return Atom(value);
-    }
-
     AtomFactory::AtomFactory() noexcept : AtomFactory(0)
     {
     }

--- a/src/NovelRT/Ecs/ComponentCache.cpp
+++ b/src/NovelRT/Ecs/ComponentCache.cpp
@@ -7,8 +7,7 @@
 namespace NovelRT::Ecs
 {
     ComponentCache::ComponentCache(size_t poolSize) noexcept
-        : _componentMap(
-              std::unordered_map<ComponentTypeId, std::shared_ptr<ComponentBufferMemoryContainer>>{}),
+        : _componentMap(std::unordered_map<ComponentTypeId, std::shared_ptr<ComponentBufferMemoryContainer>>{}),
           _poolSize(poolSize),
           _bufferPrepEvent(Utilities::Event<const std::vector<EntityId>&>())
     {

--- a/src/NovelRT/Ecs/ComponentCache.cpp
+++ b/src/NovelRT/Ecs/ComponentCache.cpp
@@ -8,7 +8,7 @@ namespace NovelRT::Ecs
 {
     ComponentCache::ComponentCache(size_t poolSize) noexcept
         : _componentMap(
-              std::unordered_map<ComponentTypeId, std::shared_ptr<ComponentBufferMemoryContainer>, AtomHashFunction>{}),
+              std::unordered_map<ComponentTypeId, std::shared_ptr<ComponentBufferMemoryContainer>>{}),
           _poolSize(poolSize),
           _bufferPrepEvent(Utilities::Event<const std::vector<EntityId>&>())
     {

--- a/src/NovelRT/Ecs/Graphics/DefaultRenderingSystem.cpp
+++ b/src/NovelRT/Ecs/Graphics/DefaultRenderingSystem.cpp
@@ -292,7 +292,7 @@ namespace NovelRT::Ecs::Graphics
             size_t currentIndex = 0;
         };
 
-        std::unordered_map<Atom, std::map<int32_t, GpuSpanCounter>, AtomHashFunction> gpuSpanCounterMap{};
+        std::unordered_map<Atom, std::map<int32_t, GpuSpanCounter>> gpuSpanCounterMap{};
 
         for (auto reverseIt = transformLayerMap.rbegin(); reverseIt != transformLayerMap.rend(); reverseIt++)
         {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This simplifies the atom type to a simple using style typedef, which should fix ambigious API usage issues we were having previously.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
Atom is a class.


**What is the new behavior (if this is a feature change)?**
Atom is a using typedef.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. The AtomHashFunction and the std namespace template overload associated with it no longer exists.


**Other information**:
N/A