### PR TITLE
Added alias targets to Engine and Interop

### DIFF
--- a/src/NovelRT.Interop/CMakeLists.txt
+++ b/src/NovelRT.Interop/CMakeLists.txt
@@ -71,6 +71,7 @@ set(INTEROP_SOURCES
 )
 
 add_library(Interop SHARED ${INTEROP_SOURCES})
+add_library(NovelRT::Interop ALIAS Interop)
 add_dependencies(Interop Engine)
 set_property(TARGET Interop PROPERTY VERSION ${PROJECT_VERSION})
 

--- a/src/NovelRT/CMakeLists.txt
+++ b/src/NovelRT/CMakeLists.txt
@@ -43,6 +43,7 @@ set(CORE_SOURCES
 )
 
 add_library(Engine SHARED ${CORE_SOURCES})
+add_library(NovelRT::Engine ALIAS Engine)
 set_target_properties(Engine
   PROPERTIES
     OUTPUT_NAME "$<IF:$<CONFIG:Release>,NovelRT,NovelRT-$<CONFIG>>"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Updates the Engine and Interop targets to be callable via aliases (`NovelRT::Engine` and `NovelRT::Interop`) when referenced by projects via `FetchContent`


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No


**What is the current behavior?** (You can also link to an open issue here)
When a user pulls NovelRT down via `FetchContent`, they are required to link to the `Engine` target directly instead of being able to use the `NovelRT::Engine` target (akin to using an "installed" / `find_package` version of NovelRT).


**What is the new behavior (if this is a feature change)?**
Users using `FetchContent` can now use the aliases OR the direct target names.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope