### PR TITLE
Fix spdlog issue and numerous GHActions deprecation warnings

### DIFF
--- a/.github/workflows/build-system.yml
+++ b/.github/workflows/build-system.yml
@@ -33,12 +33,12 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Cache Vulkan SDK (macOS)
         if: "contains(matrix.os, 'macos')"
         id: cache-vulkan-macOS
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: $GITHUB_WORKSPACE/VulkanSDK
           key: ${{ runner.os }}-vulkansdk-${{ matrix.vulkanVersion }}-${{ hashFiles('**/mvk_vulkan.h') }}
@@ -78,7 +78,7 @@ jobs:
       
       - name: Upload NovelRT test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results (${{ matrix.os }})
           path: ./**/test-results.xml
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Generate Documentation
         run: |
@@ -129,7 +129,7 @@ jobs:
     steps:
       - name: Checkout Code
         id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check Formatting
         id: formatting
@@ -146,7 +146,7 @@ jobs:
         run: scripts/ci-checkdiff.sh
 
       - name: Upload Patch
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: clang-format-patch

--- a/.github/workflows/build-system.yml
+++ b/.github/workflows/build-system.yml
@@ -80,7 +80,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: Test Results (${{ matrix.os }})
+          name: Test Results (${{ matrix.os }}-${{ matrix.configuration }})
           path: ./**/test-results.xml
 
   Publish:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -17,7 +17,7 @@ jobs:
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create documentation branch
         run: git checkout -b gh-pages

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ If you wish to attempt to build a basic visual novel with the existing C++ API, 
 The dependencies that are handled by CMake that do not need to be manually installed are as follows:
 
 - Doxygen 1.8.17 (building docs)
+- fmt 10.2.1
 - GLFW 3.3.7
 - glm 0.9.9.9
 - gtest/gmock 1.11.0
@@ -46,7 +47,7 @@ The dependencies that are handled by CMake that do not need to be manually insta
 - Microsoft GSL 4.0.0
 - OneTBB 2021.5.0
 - OpenAL 1.21.1
-- spdlog 1.10.0
+- spdlog 1.13.0
 
 ### Build instructions
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -26,6 +26,10 @@ thirdparty_module(FLAC
   URL_HASH SHA256=8ff0607e75a322dd7cd6ec48f4f225471404ae2730d0ea945127b1355155e737
   OVERRIDE_FIND_PACKAGE
 )
+thirdparty_module(fmt
+  URL https://github.com/fmtlib/fmt/releases/download/10.2.1/fmt-10.2.1.zip
+  URL_HASH SHA512=1cf0e3dd09c7d87e0890b8743559159d3be2a8f33c135516962d17c4eeb7b00659e6acd74518bd5566ee4e83ddaba155fecb4c229f90cd258b3b832e72ad82cd
+)
 thirdparty_module(glfw3
   URL https://github.com/glfw/glfw/archive/refs/tags/3.3.7.zip
   URL_HASH SHA512=0ee020ddbbed783b5f0d271ee0a98b37fe489b633e0a8407821f12b2bcfc3b80645751076192b5224bfe1d26d6092c27af9a9bcd7953a419dcec0182e3716341
@@ -106,7 +110,7 @@ foreach(module
   GTest
   Opus Ogg FLAC Vorbis SndFile OpenAL
   ZLIB PNG
-  spdlog
+  fmt spdlog
   stduuid
   TBB
   VulkanMemoryAllocator)

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -75,8 +75,8 @@ thirdparty_module(SndFile
   URL_HASH SHA512=7e650af94068277246e4ccaf3b5dc20d0f93d2a2e0ecdf0f24f0be79196f879c21ec692ad48d39454f22dd01d9a4864d21458daa8d7b8f5ea4568c9551b345c1
 )
 thirdparty_module(spdlog
-  URL https://github.com/gabime/spdlog/archive/refs/tags/v1.10.0.zip
-  URL_HASH SHA512=9f1c778482446f52fb6e35f752226715412011f608bdcbfc87be5ae4a246d6733179a910fce09c2609e4dc1ba50664a6b0c3421749a7a12d8648dcf2b61c0b99
+  URL https://github.com/gabime/spdlog/archive/refs/tags/v1.13.0.zip
+  URL_HASH SHA512=851febf19949006a17ead8b6392f12ae81e626926268829478d4d0d28a1dfe7682ef57a6c4f151031cf4cc60f1486cf8453999ee7ce40a1f0d3f545c4d7f8555
 )
 thirdparty_module(stduuid
   URL https://github.com/mariusbancila/stduuid/archive/3afe7193facd5d674de709fccc44d5055e144d7a.zip

--- a/thirdparty/fmt/CMakeLists.txt
+++ b/thirdparty/fmt/CMakeLists.txt
@@ -1,0 +1,5 @@
+include(FetchContent)
+
+FetchContent_MakeAvailable(fmt)
+
+set_property(TARGET fmt PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/thirdparty/fmt/CMakeLists.txt
+++ b/thirdparty/fmt/CMakeLists.txt
@@ -3,3 +3,4 @@ include(FetchContent)
 FetchContent_MakeAvailable(fmt)
 
 set_property(TARGET fmt PROPERTY POSITION_INDEPENDENT_CODE ON)
+

--- a/thirdparty/spdlog/CMakeLists.txt
+++ b/thirdparty/spdlog/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
 set(SPDLOG_INSTALL ON)
 set(SPDLOG_ENABLE_PCH ON)
+set(SPDLOG_FMT_EXTERNAL ON)
 
 FetchContent_MakeAvailable(spdlog)
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes a build error induced by spdlog and newer versions of MSVC, and resolves some GH Actions warnings about node12/node16 deprecation.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
Fixes #600 


**What is the current behavior?** (You can also link to an open issue here)
Builds fail when attempting to compile `NovelRT-Graphics` due to iterator usage from spdlog that is deprecated - this is due to older `fmt` builds built into spdlog that use the old behavior.


