### PR TITLE
Fix vulkanrender sample.

### DIFF
--- a/Graphics/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Graphics/Vulkan/VulkanGraphicsDevice.cpp
@@ -473,7 +473,6 @@ namespace NovelRT::Graphics::Vulkan
     void VulkanGraphicsDevice::PresentFrame()
     {
         auto presentCompletionGraphicsFence = GetPresentCompletionFence();
-        //presentCompletionGraphicsFence->Wait();
         presentCompletionGraphicsFence->Reset();
 
         uint32_t contextIndex = static_cast<uint32_t>(GetContextIndex());
@@ -496,8 +495,6 @@ namespace NovelRT::Graphics::Vulkan
         {
             throw std::runtime_error("Failed to present the data within the present queue!");
         }
-        
-        
 
         VkResult acquireNextImageResult =
             vkAcquireNextImageKHR(GetVulkanDevice(), vulkanSwapchain, std::numeric_limits<uint64_t>::max(),

--- a/samples/Experimental/VulkanRender/main.cpp
+++ b/samples/Experimental/VulkanRender/main.cpp
@@ -199,6 +199,7 @@ int main()
     gfxContext->EndFrame();
     gfxDevice->Signal(gfxContext->GetFence());
     gfxDevice->WaitForIdle();
+    gfxContext->GetFence()->Reset();
 
     auto surface = gfxDevice->GetSurface();
 
@@ -208,7 +209,6 @@ int main()
         if (device->GetIsVisible())
         {
             auto context = gfxDevice->GetCurrentContext();
-            logger.logWarningLine("Context index: " + std::to_string(context->GetIndex()));
             auto currentCmdList = context->BeginFrame();
 
             float surfaceWidth = surface->GetWidth();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes a fencing issue that was introduced in the VulkanRender sample with some fencing changes I made to our engine internals. This whole setup is a symptom of us not using the correct queue for copy commands, so in lieu of the correct fix, I am just doing the same hack I did in the imgui sample.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
The sample just crashes.


**What is the new behavior (if this is a feature change)?**
The sample renders as expected. The sync hazard from the imgui changes is still there, but that is out of scope for this submission.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
N/A
