### PR TITLE
Add freeing ability to GraphicsResourceMemoryRegion objects.

### DIFF
--- a/Graphics/Vulkan/VulkanGraphicsBuffer.cpp
+++ b/Graphics/Vulkan/VulkanGraphicsBuffer.cpp
@@ -15,6 +15,12 @@ namespace NovelRT::Graphics::Vulkan
         return std::static_pointer_cast<VulkanGraphicsResourceMemoryRegion<VulkanGraphicsResource>>(
             std::make_shared<VulkanGraphicsResourceMemoryRegion<VulkanGraphicsBuffer>>(GetDevice(), shared_from_this(), allocation, info));
     }
+    
+    void VulkanGraphicsBuffer::FreeInternal(VulkanGraphicsResourceMemoryRegionBase& region)
+    {
+        unused(region);
+        // TODO: Not sure if we need to support this, but since we do so for allocation, at least having this for freeing makes sense.
+    }
 
     VulkanGraphicsBuffer::VulkanGraphicsBuffer(std::shared_ptr<VulkanGraphicsDevice> graphicsDevice,
                                                std::shared_ptr<VulkanGraphicsMemoryAllocator> allocator,

--- a/Graphics/Vulkan/VulkanGraphicsResource.cpp
+++ b/Graphics/Vulkan/VulkanGraphicsResource.cpp
@@ -6,7 +6,6 @@
 #include <NovelRT/Graphics/Vulkan/VulkanGraphicsMemoryAllocator.hpp>
 #include <NovelRT/Graphics/Vulkan/VulkanGraphicsResource.hpp>
 #include <string>
-#include <iostream>
 
 namespace NovelRT::Graphics::Vulkan
 {

--- a/Graphics/Vulkan/VulkanGraphicsResource.cpp
+++ b/Graphics/Vulkan/VulkanGraphicsResource.cpp
@@ -6,6 +6,7 @@
 #include <NovelRT/Graphics/Vulkan/VulkanGraphicsMemoryAllocator.hpp>
 #include <NovelRT/Graphics/Vulkan/VulkanGraphicsResource.hpp>
 #include <string>
+#include <iostream>
 
 namespace NovelRT::Graphics::Vulkan
 {
@@ -80,6 +81,12 @@ namespace NovelRT::Graphics::Vulkan
     {
         auto [allocation, info] = GetVirtualAllocation(size, alignment);
         return AllocateInternal(allocation, info);
+    }
+    
+    void VulkanGraphicsResource::Free(VulkanGraphicsResourceMemoryRegionBase& region)
+    {
+        vmaVirtualFree(GetVirtualBlock(), region.GetVirtualAllocation());
+        FreeInternal(region);
     }
 
     VmaAllocation VulkanGraphicsResource::GetAllocation() const noexcept

--- a/Graphics/Vulkan/VulkanGraphicsResourceMemoryRegion.cpp
+++ b/Graphics/Vulkan/VulkanGraphicsResourceMemoryRegion.cpp
@@ -24,6 +24,11 @@ namespace NovelRT::Graphics::Vulkan
                 "An invalid memory region of a Vulkan graphics resource was created.");
         }
     }
+    
+    VulkanGraphicsResourceMemoryRegionBase::~VulkanGraphicsResourceMemoryRegionBase()
+    {
+        _owningResource->Free(*this);
+    }
 
     std::shared_ptr<VulkanGraphicsDevice> VulkanGraphicsResourceMemoryRegionBase::GetDevice() const noexcept
     {

--- a/Graphics/Vulkan/VulkanGraphicsTexture.cpp
+++ b/Graphics/Vulkan/VulkanGraphicsTexture.cpp
@@ -104,6 +104,12 @@ namespace NovelRT::Graphics::Vulkan
             std::make_shared<VulkanGraphicsResourceMemoryRegion<VulkanGraphicsTexture>>(
                 GetDevice(), shared_from_this(), allocation, info));
     }
+    
+    void VulkanGraphicsTexture::FreeInternal(VulkanGraphicsResourceMemoryRegionBase& region)
+    {
+        unused(region);
+        // TODO: Not sure if we need to support this, but since we do so for allocation, at least having this for freeing makes sense.
+    }
 
     VulkanGraphicsTexture::VulkanGraphicsTexture(std::shared_ptr<VulkanGraphicsDevice> device,
                                                  std::shared_ptr<VulkanGraphicsMemoryAllocator> allocator,

--- a/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsBuffer.hpp
+++ b/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsBuffer.hpp
@@ -5,7 +5,6 @@
 
 #include <NovelRT/Graphics/GraphicsBufferKind.hpp>
 #include <NovelRT/Graphics/GraphicsResourceAccess.hpp>
-
 #include <NovelRT/Graphics/Vulkan/VulkanGraphicsResource.hpp>
 #include <memory>
 #include <NovelRT/Graphics/Vulkan/Utilities/Vma.hpp>
@@ -26,6 +25,8 @@ namespace NovelRT::Graphics::Vulkan
 
     protected:
         [[nodiscard]] std::shared_ptr<VulkanGraphicsResourceMemoryRegion<VulkanGraphicsResource>> AllocateInternal(VmaVirtualAllocation allocation, VmaVirtualAllocationInfo info) final;
+        
+        virtual void FreeInternal(VulkanGraphicsResourceMemoryRegionBase& region) final;
 
     public:
         std::shared_ptr<VulkanGraphicsBuffer> shared_from_this()

--- a/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsResource.hpp
+++ b/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsResource.hpp
@@ -25,6 +25,7 @@ namespace NovelRT::Graphics::Vulkan
 
     protected:
         [[nodiscard]] virtual std::shared_ptr<VulkanGraphicsResourceMemoryRegion<VulkanGraphicsResource>> AllocateInternal(VmaVirtualAllocation allocation, VmaVirtualAllocationInfo info) = 0;
+        virtual void FreeInternal(VulkanGraphicsResourceMemoryRegionBase& region) = 0;
 
     public:
         VulkanGraphicsResource(std::shared_ptr<VulkanGraphicsDevice> graphicsDevice,
@@ -44,6 +45,8 @@ namespace NovelRT::Graphics::Vulkan
         [[nodiscard]] size_t GetSize() const noexcept;
 
         [[nodiscard]] std::shared_ptr<VulkanGraphicsResourceMemoryRegion<VulkanGraphicsResource>> Allocate(size_t size, size_t alignment);
+
+        void Free(VulkanGraphicsResourceMemoryRegionBase& region);
 
         [[nodiscard]] virtual NovelRT::Utilities::Misc::Span<uint8_t> MapBytes(size_t rangeOffset, size_t rangeLength) = 0;
 

--- a/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsResourceMemoryRegion.hpp
+++ b/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsResourceMemoryRegion.hpp
@@ -29,7 +29,7 @@ namespace NovelRT::Graphics::Vulkan
                                            VmaVirtualAllocationInfo virtualAllocationInfo);
 
     public:
-        ~VulkanGraphicsResourceMemoryRegionBase() = default;
+        ~VulkanGraphicsResourceMemoryRegionBase();
 
         [[nodiscard]] inline std::shared_ptr<VulkanGraphicsDevice> GetDevice() const noexcept;
 

--- a/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsTexture.hpp
+++ b/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsTexture.hpp
@@ -35,6 +35,8 @@ namespace NovelRT::Graphics::Vulkan
             VmaVirtualAllocation allocation,
             VmaVirtualAllocationInfo info) final;
 
+        virtual void FreeInternal(VulkanGraphicsResourceMemoryRegionBase& region) final;
+
     public:
         std::shared_ptr<VulkanGraphicsTexture> shared_from_this()
         {

--- a/include/NovelRT/Utilities/Misc.h
+++ b/include/NovelRT/Utilities/Misc.h
@@ -30,7 +30,7 @@
 #include <gsl/span>
 #endif // NOVELRT_USE_STD_SPAN
 
-#define unused(x) (void)(x)
+#define unused(x) static_cast<void>(x)
 
 #define assert_message(exp, msg) assert((static_cast<void>(msg), exp));
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This allows us to return virtual suballocations to graphics resources.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
You cannot return virtual allocations, effectively meaning the actual GPU VRAM would constantly be bound up in the previous allocation even if you aren't using it anymore. In other words, a memory leak.


**What is the new behavior (if this is a feature change)?**
Regions now return memory they are not using.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
I explicitly did not add this API to the abstraction yet, mainly because I am unsure what @FiniteReality wants to do with some of her refactoring work and to be honest I was not 100% on how it should work given this.

Please also note that I used a reference here because using a shared pointer in a destructor would've resulted in a segfault.