### PR TITLE
Fix broken artefact naming in build-daily workflow

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -81,5 +81,5 @@ jobs:
       - name: Publish build artefacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.name }}-${{ matrix.configuration }}
+          name: ${{ matrix.os }}-${{ matrix.configuration }}-vk${{ matrix.vulkan }}
           path: artefacts


### PR DESCRIPTION
The classic blunder: forgetting that your variable wasn't assigned