### PR TITLE
Use a build-time command to copy the resources instead

### DIFF
--- a/Samples/Experimental/ImGui/CMakeLists.txt
+++ b/Samples/Experimental/ImGui/CMakeLists.txt
@@ -13,7 +13,7 @@ NovelRTBuildSystem_DeclareModule(EXECUTABLE NovelRT::Samples::Experimental::ImGu
       main.cpp
 
   RESOURCES
-    PUBLIC
+    PRIVATE
       Resources/Fonts/Raleway-Regular.ttf
       Resources/Shaders/imgui_frag.spv
       Resources/Shaders/imgui_vert.spv

--- a/Samples/Experimental/VulkanRender/CMakeLists.txt
+++ b/Samples/Experimental/VulkanRender/CMakeLists.txt
@@ -11,7 +11,7 @@ NovelRTBuildSystem_DeclareModule(EXECUTABLE NovelRT::Samples::Experimental::Vulk
       main.cpp
 
   RESOURCES
-    PUBLIC
+    PRIVATE
       Resources/Shaders/vulkanrenderfrag.spv
       Resources/Shaders/vulkanrendervert.spv
 )

--- a/cmake/NovelRTBuildSystem.cmake
+++ b/cmake/NovelRTBuildSystem.cmake
@@ -105,7 +105,13 @@ function(NovelRTBuildSystem_DeclareModule moduleKind moduleName)
 
   set(resx ${declareModule_RESOURCES_INTERFACE} ${declareModule_RESOURCES_PUBLIC} ${declareModule_RESOURCES_PRIVATE})
   foreach(file IN LISTS resx)
-    configure_file(${file} ${file} COPYONLY)
+    # Copy the resources to their output directory. In the future we may do something more advanced like compiling shaders.
+    add_custom_command(
+      OUTPUT ${file}
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/${file}" "$<TARGET_FILE_DIR:${cmakeSafeName}>/${file}"
+      MAIN_DEPENDENCY ${file}
+      COMMENT "Copying resource ${file}"
+      DEPENDS_EXPLICIT_ONLY)
   endforeach()
 
   list(TRANSFORM declareModule_RESOURCES_INTERFACE REPLACE "^(.+)$" "$<BUILD_INTERFACE:\\1>")
@@ -127,7 +133,20 @@ function(NovelRTBuildSystem_DeclareModule moduleKind moduleName)
     PRIVATE FILE_SET private_headers
     TYPE HEADERS
     BASE_DIRS include ${declareModule_HEADERS_BASE_DIRS}
-    FILES ${declareModule_HEADERS_PRIVATE})
+    FILES ${declareModule_HEADERS_PRIVATE}
+
+    INTERFACE FILE_SET interface_resources
+    TYPE HEADERS
+    BASE_DIRS Resources ${declareModule_RESOURCES_BASE_DIRS}
+    FILES ${declareModule_RESOURCES_INTERFACE}
+    PUBLIC FILE_SET public_resources
+    TYPE HEADERS
+    BASE_DIRS Resources ${declareModule_RESOURCES_BASE_DIRS}
+    FILES ${declareModule_RESOURCES_PUBLIC}
+    PRIVATE FILE_SET private_resources
+    TYPE HEADERS
+    BASE_DIRS Resources ${declareModule_RESOURCES_BASE_DIRS}
+    FILES ${declareModule_RESOURCES_PRIVATE})
 
   target_link_libraries(${cmakeSafeName} PUBLIC ${declareModule_DEPENDS})
   foreach(depends IN LISTS declareModule_OPTIONAL_DEPENDS)
@@ -161,7 +180,10 @@ function(NovelRTBuildSystem_DeclareModule moduleKind moduleName)
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
     FILE_SET interface_headers DESTINATION include
-    FILE_SET public_headers DESTINATION include)
+    FILE_SET public_headers DESTINATION include
+
+    FILE_SET interface_resources DESTINATION bin
+    FILE_SET public_resources DESTINATION bin)
 endfunction()
 
 endblock()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)

**What kind of change does this PR introduce?**
Instead of copying the files at configure time, requiring CMake to be re-ran if they change, we perform it as part of the build instead.

**Is there an open issue that this resolves?**
No. This was reported in Discord.

**What is the current behavior?**
CMake re-runs if the resources are modified.

**What is the new behavior?**
CMake does not re-run if the resources are modified.

**Does this PR introduce a breaking change?** 
It's CMake, who knows :upside_down_face: 

**Other information**:
