### PR TITLE
Feature/ecs dispatch work api

### DIFF
--- a/Ecs/Core/CMakeLists.txt
+++ b/Ecs/Core/CMakeLists.txt
@@ -34,6 +34,7 @@ NovelRTBuildSystem_DeclareModule(LIBRARY NovelRT::Ecs::Core
       include/NovelRT/Ecs/EcsUtils.hpp
       include/NovelRT/Ecs/EntityCache.hpp
       include/NovelRT/Ecs/EntityGraphView.hpp
+      include/NovelRT/Ecs/ExecutionContext.hpp
       include/NovelRT/Ecs/IEcsSystem.hpp
       include/NovelRT/Ecs/LinkedEntityListView.hpp
       include/NovelRT/Ecs/SparseSet.hpp

--- a/Ecs/Core/CMakeLists.txt
+++ b/Ecs/Core/CMakeLists.txt
@@ -36,6 +36,7 @@ NovelRTBuildSystem_DeclareModule(LIBRARY NovelRT::Ecs::Core
       include/NovelRT/Ecs/EntityGraphView.hpp
       include/NovelRT/Ecs/ExecutionContext.hpp
       include/NovelRT/Ecs/IEcsSystem.hpp
+      include/NovelRT/Ecs/ImplDetail.hpp
       include/NovelRT/Ecs/LinkedEntityListView.hpp
       include/NovelRT/Ecs/SparseSet.hpp
       include/NovelRT/Ecs/SparseSetMemoryContainer.hpp

--- a/Ecs/Core/CMakeLists.txt
+++ b/Ecs/Core/CMakeLists.txt
@@ -38,6 +38,7 @@ NovelRTBuildSystem_DeclareModule(LIBRARY NovelRT::Ecs::Core
       include/NovelRT/Ecs/IEcsSystem.hpp
       include/NovelRT/Ecs/ImplDetail.hpp
       include/NovelRT/Ecs/LinkedEntityListView.hpp
+      include/NovelRT/Ecs/MiscTemplateImpls.hpp
       include/NovelRT/Ecs/SparseSet.hpp
       include/NovelRT/Ecs/SparseSetMemoryContainer.hpp
       include/NovelRT/Ecs/SystemScheduler.hpp

--- a/Ecs/Core/Catalogue.cpp
+++ b/Ecs/Core/Catalogue.cpp
@@ -5,15 +5,17 @@
 #include <NovelRT/Ecs/ComponentCache.hpp>
 #include <NovelRT/Ecs/EntityCache.hpp>
 #include <NovelRT/Ecs/UnsafeComponentView.hpp>
+#include <NovelRT/Ecs/SystemScheduler.hpp>
 
 #include <algorithm>
 
 namespace NovelRT::Ecs
 {
-    Catalogue::Catalogue(size_t poolId, ComponentCache& componentCache, EntityCache& entityCache) noexcept
+    Catalogue::Catalogue(size_t poolId, SystemScheduler& scheduler) noexcept
         : _poolId(poolId),
-          _componentCache(componentCache),
-          _entityCache(entityCache),
+          _componentCache(scheduler.GetComponentCache()),
+          _entityCache(scheduler.GetEntityCache()),
+          _scheduler(scheduler),
           _createdEntitiesThisFrame(std::vector<EntityId>{})
     {
     }

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -78,13 +78,13 @@ namespace NovelRT::Ecs
     void SystemScheduler::ScheduleUpdateWork()
     {
         _ecsArena->execute(
-            [&]() mutable
+            [&]() 
             {
                 std::function<void(Timing::Timestamp, Catalogue)> completion{};
                 while (_pendingCompletions.try_pop(completion))
                 {
                     _ecsTasks->run(
-                        [completion = std::move(completion), this]() mutable
+                        [completion = std::move(completion), this]() 
                         {
                             size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
                             completion(_currentDelta, Catalogue(poolId, *this));
@@ -94,7 +94,7 @@ namespace NovelRT::Ecs
                 for (auto&& systemId : _systemIds)
                 {
                     _ecsTasks->run(
-                        [&, systemId]() mutable
+                        [&, systemId]() 
                         {
                             size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
                             _systems[systemId](_currentDelta, Catalogue(poolId, *this));

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -17,12 +17,13 @@ namespace NovelRT::Ecs
         : _entityCache(1),
           _componentCache(1),
           _workerThreadCount(maximumThreadCount),
-          _currentDelta(NovelRT::Timing::TimeFromSeconds(0)),
           _ecsArena(std::make_unique<tbb::task_arena>(maximumThreadCount == 0 ? int(tbb::task_arena::automatic)
                                                                               : static_cast<int>(maximumThreadCount))),
           _asyncArena(std::make_unique<tbb::task_arena>(int(tbb::task_arena::automatic))),
           _ecsTasks(std::make_unique<tbb::task_group>()),
-          _asyncTasks(std::make_unique<tbb::task_group>())
+          _asyncTasks(std::make_unique<tbb::task_group>()),
+          _currentDelta(NovelRT::Timing::TimeFromSeconds(0)),
+          _pendingCompletions()
     {
         _workerThreadCount = _ecsArena->max_concurrency();
         _entityCache = EntityCache(_workerThreadCount);
@@ -40,7 +41,8 @@ namespace NovelRT::Ecs
           _ecsArena(std::move(other._ecsArena)),
           _asyncArena(std::move(other._asyncArena)),
           _ecsTasks(std::move(other._ecsTasks)),
-          _asyncTasks(std::move(other._asyncTasks))
+          _asyncTasks(std::move(other._asyncTasks)),
+          _pendingCompletions(std::move(other._pendingCompletions))
     {
     }
 
@@ -57,6 +59,7 @@ namespace NovelRT::Ecs
         _asyncArena = std::move(other._asyncArena);
         _ecsTasks = std::move(other._ecsTasks);
         _asyncTasks = std::move(other._asyncTasks);
+        _pendingCompletions = std::move(other._pendingCompletions);
         return *this;
     }
 

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -18,23 +18,13 @@ namespace NovelRT::Ecs
           _componentCache(1),
           _workerThreadCount(maximumThreadCount),
           _currentDelta(NovelRT::Timing::TimeFromSeconds(0)),
-          _threadAvailabilityMap(0),
-          _shouldShutDown(false),
-          _threadsAreSpinning(false)
+          _ecsArena(std::make_unique<tbb::task_arena>(maximumThreadCount == 0 ? tbb::task_arena::automatic
+                                                                              : static_cast<int>(maximumThreadCount))),
+          _asyncArena(std::make_unique<tbb::task_arena>(tbb::task_arena::automatic)),
+          _ecsTasks(std::make_unique<tbb::task_group>()),
+          _asyncTasks(std::make_unique<tbb::task_group>())
     {
-        if (_workerThreadCount == 0)
-        {
-            _workerThreadCount = std::thread::hardware_concurrency() - 1;
-        }
-
-        // in case the previous call doesn't work
-        if (_workerThreadCount == 0)
-        {
-            _workerThreadCount = DEFAULT_BLIND_THREAD_LIMIT;
-        }
-
-        _threadAvailabilityMap = (1ULL << _workerThreadCount) - 1;
-
+        _workerThreadCount = _ecsArena->max_concurrency();
         _entityCache = EntityCache(_workerThreadCount);
         _componentCache = ComponentCache(_workerThreadCount);
     }
@@ -47,15 +37,11 @@ namespace NovelRT::Ecs
           _componentCache(std::move(other._componentCache)),
           _workerThreadCount(other._workerThreadCount),
           _currentDelta(other._currentDelta),
-          _threadAvailabilityMap((1ULL << other._workerThreadCount) - 1),
-          _shouldShutDown(false),
-          _threadsAreSpinning(false)
+          _ecsArena(std::move(other._ecsArena)),
+          _asyncArena(std::move(other._asyncArena)),
+          _ecsTasks(std::move(other._ecsTasks)),
+          _asyncTasks(std::move(other._asyncTasks))
     {
-        if (other.GetThreadsAreSpinning())
-        {
-            other.ShutDown();
-            InitialiseThreads();
-        }
     }
 
     SystemScheduler& SystemScheduler::operator=(SystemScheduler&& other) noexcept
@@ -66,18 +52,11 @@ namespace NovelRT::Ecs
         _entityCache = std::move(other._entityCache);
         _componentCache = std::move(other._componentCache);
         _workerThreadCount = other._workerThreadCount;
-        _threadWorkItem = std::move(other._threadWorkItem);
-        _threadCache = std::move(other._threadCache);
         _currentDelta = other._currentDelta;
-        _shouldShutDown = false;
-        _threadsAreSpinning = false;
-
-        if (other.GetThreadsAreSpinning())
-        {
-            other.ShutDown();
-            InitialiseThreads();
-        }
-
+        _ecsArena = std::move(other._ecsArena);
+        _asyncArena = std::move(other._asyncArena);
+        _ecsTasks = std::move(other._ecsTasks);
+        _asyncTasks = std::move(other._asyncTasks);
         return *this;
     }
 
@@ -96,93 +75,26 @@ namespace NovelRT::Ecs
         RegisterSystem([targetSystem](auto delta, auto catalogue) { targetSystem->Update(delta, catalogue); });
     }
 
-    bool SystemScheduler::JobAvailable(size_t poolId) const noexcept
-    {
-        return (_threadAvailabilityMap & (1ULL << poolId)) == 0;
-    }
-
-    void SystemScheduler::WaitForJob(size_t poolId)
-    {
-        _mutexCache[poolId]->lock();
-        assert(JobAvailable(poolId) && "Lock acquired on mutex when no job is available!");
-    }
-
-    void SystemScheduler::CycleForJob(size_t poolId)
-    {
-        while (true)
-        {
-            WaitForJob(poolId);
-
-            Atom workItem = _threadWorkItem[poolId];
-
-            if (workItem == std::numeric_limits<Atom>::max())
-            {
-                _mutexCache[poolId]->unlock();
-                return;
-            }
-
-            _systems[workItem](_currentDelta, Catalogue(poolId, _componentCache, _entityCache));
-
-            assert(((_threadAvailabilityMap & (1ULL << poolId)) == 0) && "Thread marked as available while working!");
-            _threadAvailabilityMap ^= (1ULL << poolId);
-        }
-    }
-
     void SystemScheduler::ScheduleUpdateWork()
     {
-        uint64_t threadAvailabilityMap = _threadAvailabilityMap;
-        assert((threadAvailabilityMap == ((1ULL << _workerThreadCount) - 1)) &&
-               "Some threads are busy while new work is attempted to be scheduled!");
-        for (auto&& systemId : _systemIds)
-        {
-            uint64_t workerIndex;
-
-            while ((workerIndex = NovelRT::Maths::Utilities::LeadingZeroCount64(_threadAvailabilityMap)) == 64)
+        _ecsArena->execute(
+            [&]()
             {
-                std::this_thread::yield();
-            }
+                for (auto&& systemId : _systemIds)
+                {
+                    _ecsTasks->run(
+                        [&, systemId]()
+                        {
+                            // Intentionally no try/catch - engine is fail fast.
+                            // Unhandled exceptions terminate the process with full
+                            // callstack intact for debugging purposes.
+                            size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
 
-            workerIndex = 63 - workerIndex;
-
-            assert((workerIndex <= (_workerThreadCount)) &&
-                   "Returned worker index does not exist! Index out of range.");
-
-            _threadWorkItem[workerIndex] = systemId;
-
-            assert(((_threadAvailabilityMap & (1ULL << workerIndex)) == (1ULL << workerIndex)) &&
-                   "Thread marked as busy while available!");
-            _threadAvailabilityMap ^= (1ULL << workerIndex);
-
-            _mutexCache[workerIndex]->unlock();
-        }
-
-        while (_threadAvailabilityMap != threadAvailabilityMap)
-        {
-            std::this_thread::yield();
-        }
-    }
-
-    void SystemScheduler::InitialiseThreads() noexcept
-    {
-        _shouldShutDown = false;
-
-        _mutexCache.reserve(_workerThreadCount);
-
-        for (size_t i = 0; i < _workerThreadCount; i++)
-        {
-            _mutexCache.emplace_back(std::make_unique<tbb::mutex>());
-            _mutexCache.back()->lock();
-        }
-
-        std::vector<Atom> vec2(_workerThreadCount);
-        _threadWorkItem.swap(vec2);
-
-        for (size_t i = 0; i < _workerThreadCount; i++)
-        {
-            _threadCache.emplace_back(std::thread([&, i]() { CycleForJob(i); }));
-        }
-
-        _threadsAreSpinning = true;
+                            _systems[systemId](_currentDelta, Catalogue(poolId, _componentCache, _entityCache));
+                        });
+                }
+                _ecsTasks->wait();
+            });
     }
 
     void SystemScheduler::ExecuteIteration(Timing::Timestamp delta)
@@ -196,41 +108,13 @@ namespace NovelRT::Ecs
         _entityCache.ApplyEntityDeletionRequestsToRegisteredEntities();
     }
 
-    void SystemScheduler::ShutDown() noexcept
-    {
-        assert((_threadAvailabilityMap == ((1ULL << _workerThreadCount) - 1)) &&
-               "Work was scheduled while the SystemScheduler is shutting down!");
-        for (auto&& workItem : _threadWorkItem)
-        {
-            workItem = std::numeric_limits<Atom>::max();
-        }
-
-        _threadAvailabilityMap = 0;
-
-        for (auto&& mutex : _mutexCache)
-        {
-            mutex->unlock();
-        }
-
-        for (auto&& i : _threadCache)
-        {
-            if (i.joinable())
-            {
-                i.join();
-            }
-        }
-
-        _threadCache.clear();
-        _threadWorkItem.clear();
-        _mutexCache.clear();
-        _threadsAreSpinning = false;
-    }
-
     SystemScheduler::~SystemScheduler() noexcept
     {
-        if (GetThreadsAreSpinning())
-        {
-            ShutDown();
-        }
+        _ecsArena->execute(
+            [&]()
+            {
+                _ecsTasks->wait();
+                _asyncTasks->wait();
+            });
     }
 } // namespace NovelRT::Ecs

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -80,19 +80,29 @@ namespace NovelRT::Ecs
         _ecsArena->execute(
             [&]()
             {
+                // Drain pending completions first, before normal system work
+                std::function<void(Timing::Timestamp, Catalogue)> completion;
+                while (_pendingCompletions.try_pop(completion))
+                {
+                    _ecsTasks->run(
+                        [completion = std::move(completion), this]() mutable
+                        {
+                            size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
+                            completion(_currentDelta, Catalogue(poolId, *this));
+                        });
+                }
+
+                // Normal system work
                 for (auto&& systemId : _systemIds)
                 {
                     _ecsTasks->run(
                         [&, systemId]()
                         {
-                            // Intentionally no try/catch - engine is fail fast.
-                            // Unhandled exceptions terminate the process with full
-                            // callstack intact for debugging purposes.
                             size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
-
-                            _systems[systemId](_currentDelta, Catalogue(poolId, _componentCache, _entityCache));
+                            _systems[systemId](_currentDelta, Catalogue(poolId, *this));
                         });
                 }
+
                 _ecsTasks->wait();
             });
     }

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -78,10 +78,9 @@ namespace NovelRT::Ecs
     void SystemScheduler::ScheduleUpdateWork()
     {
         _ecsArena->execute(
-            [&]()
+            [&]() mutable
             {
-                // Drain pending completions first, before normal system work
-                std::function<void(Timing::Timestamp, Catalogue)> completion;
+                std::function<void(Timing::Timestamp, Catalogue)> completion{};
                 while (_pendingCompletions.try_pop(completion))
                 {
                     _ecsTasks->run(
@@ -92,11 +91,10 @@ namespace NovelRT::Ecs
                         });
                 }
 
-                // Normal system work
                 for (auto&& systemId : _systemIds)
                 {
                     _ecsTasks->run(
-                        [&, systemId]()
+                        [&, systemId]() mutable
                         {
                             size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
                             _systems[systemId](_currentDelta, Catalogue(poolId, *this));

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -22,8 +22,8 @@ namespace NovelRT::Ecs
           _asyncArena(std::make_unique<tbb::task_arena>(int(tbb::task_arena::automatic))),
           _ecsTasks(std::make_unique<tbb::task_group>()),
           _asyncTasks(std::make_unique<tbb::task_group>()),
+          _pendingCompletions(),
           _currentDelta(NovelRT::Timing::TimeFromSeconds(0)),
-          _pendingCompletions()
     {
         _workerThreadCount = _ecsArena->max_concurrency();
         _entityCache = EntityCache(_workerThreadCount);
@@ -37,11 +37,11 @@ namespace NovelRT::Ecs
           _entityCache(std::move(other._entityCache)),
           _componentCache(std::move(other._componentCache)),
           _workerThreadCount(other._workerThreadCount),
-          _currentDelta(other._currentDelta),
           _ecsArena(std::move(other._ecsArena)),
           _asyncArena(std::move(other._asyncArena)),
           _ecsTasks(std::move(other._ecsTasks)),
           _asyncTasks(std::move(other._asyncTasks)),
+          _currentDelta(other._currentDelta),
           _pendingCompletions(std::move(other._pendingCompletions))
     {
     }
@@ -54,11 +54,11 @@ namespace NovelRT::Ecs
         _entityCache = std::move(other._entityCache);
         _componentCache = std::move(other._componentCache);
         _workerThreadCount = other._workerThreadCount;
-        _currentDelta = other._currentDelta;
         _ecsArena = std::move(other._ecsArena);
         _asyncArena = std::move(other._asyncArena);
         _ecsTasks = std::move(other._ecsTasks);
         _asyncTasks = std::move(other._asyncTasks);
+        _currentDelta = other._currentDelta;
         _pendingCompletions = std::move(other._pendingCompletions);
         return *this;
     }

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -23,7 +23,7 @@ namespace NovelRT::Ecs
           _ecsTasks(std::make_unique<tbb::task_group>()),
           _asyncTasks(std::make_unique<tbb::task_group>()),
           _pendingCompletions(),
-          _currentDelta(NovelRT::Timing::TimeFromSeconds(0)),
+          _currentDelta(NovelRT::Timing::TimeFromSeconds(0))
     {
         _workerThreadCount = _ecsArena->max_concurrency();
         _entityCache = EntityCache(_workerThreadCount);

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -41,8 +41,8 @@ namespace NovelRT::Ecs
           _asyncArena(std::move(other._asyncArena)),
           _ecsTasks(std::move(other._ecsTasks)),
           _asyncTasks(std::move(other._asyncTasks)),
-          _currentDelta(other._currentDelta),
-          _pendingCompletions(std::move(other._pendingCompletions))
+          _pendingCompletions(std::move(other._pendingCompletions)),
+          _currentDelta(other._currentDelta)
     {
     }
 

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -81,13 +81,13 @@ namespace NovelRT::Ecs
     void SystemScheduler::ScheduleUpdateWork()
     {
         _ecsArena->execute(
-            [&]() 
+            [&]()
             {
                 std::function<void(Timing::Timestamp, Catalogue)> completion{};
                 while (_pendingCompletions.try_pop(completion))
                 {
                     _ecsTasks->run(
-                        [completion = std::move(completion), this]() 
+                        [completion = std::move(completion), this]()
                         {
                             size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
                             completion(_currentDelta, Catalogue(poolId, *this));
@@ -97,7 +97,7 @@ namespace NovelRT::Ecs
                 for (auto&& systemId : _systemIds)
                 {
                     _ecsTasks->run(
-                        [&, systemId]() 
+                        [&, systemId]()
                         {
                             size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
                             _systems[systemId](_currentDelta, Catalogue(poolId, *this));

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -18,9 +18,9 @@ namespace NovelRT::Ecs
           _componentCache(1),
           _workerThreadCount(maximumThreadCount),
           _currentDelta(NovelRT::Timing::TimeFromSeconds(0)),
-          _ecsArena(std::make_unique<tbb::task_arena>(maximumThreadCount == 0 ? tbb::task_arena::automatic
+          _ecsArena(std::make_unique<tbb::task_arena>(maximumThreadCount == 0 ? int(tbb::task_arena::automatic)
                                                                               : static_cast<int>(maximumThreadCount))),
-          _asyncArena(std::make_unique<tbb::task_arena>(tbb::task_arena::automatic)),
+          _asyncArena(std::make_unique<tbb::task_arena>(int(tbb::task_arena::automatic))),
           _ecsTasks(std::make_unique<tbb::task_group>()),
           _asyncTasks(std::make_unique<tbb::task_group>())
     {

--- a/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
@@ -6,6 +6,7 @@
 #include <NovelRT/Ecs/ComponentCache.hpp>
 #include <NovelRT/Ecs/EcsUtils.hpp>
 #include <NovelRT/Ecs/ImplDetail.hpp>
+#include <NovelRT/Ecs/SystemScheduler.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -18,7 +19,6 @@ namespace NovelRT::Ecs
     class ComponentView;
     class EntityCache;
     class UnsafeComponentView;
-    class SystemScheduler;
 
     /**
      * @brief A thread-aware context into the current state of the ECS instance that created an instance of this object.

--- a/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
@@ -17,6 +17,7 @@ namespace NovelRT::Ecs
     class ComponentView;
     class EntityCache;
     class UnsafeComponentView;
+    class SystemScheduler;
 
     /**
      * @brief A thread-aware context into the current state of the ECS instance that created an instance of this object.
@@ -31,6 +32,7 @@ namespace NovelRT::Ecs
         size_t _poolId;
         ComponentCache& _componentCache;
         EntityCache& _entityCache;
+        SystemScheduler& _scheduler;
         std::vector<EntityId> _createdEntitiesThisFrame;
 
     public:
@@ -42,7 +44,7 @@ namespace NovelRT::Ecs
          * @param entityCache The storage object for all modifications being made directly to entities themselves (such
          * as a delete instruction).
          */
-        Catalogue(size_t poolId, ComponentCache& componentCache, EntityCache& entityCache) noexcept;
+        Catalogue(size_t poolId, SystemScheduler& scheduler) noexcept;
 
         /**
          * @brief Gets a view into the ComponentCache for the specified component type based on the context of the
@@ -74,7 +76,7 @@ namespace NovelRT::Ecs
          * that has their threading contexts set to the current thread.
          */
         template<typename... TComponents>
-        [[nodiscard]] std::tuple<ComponentView<TComponents>...> GetComponentViews() const noexcept
+        [[nodiscard]] std::tuple<ComponentView<TComponents>...> GetComponentViews() noexcept
         {
             return std::make_tuple(
                 ComponentView<TComponents>(_poolId, _componentCache.GetComponentBuffer<TComponents>())...);
@@ -109,5 +111,35 @@ namespace NovelRT::Ecs
          * @param entity The entity to delete.
          */
         void DeleteEntity(EntityId entity) noexcept;
+
+        /**
+         * @brief Schedules a unit of work to be executed outside of the ECS context, with a completion
+         * callback that is executed on the next iteration of the ECS once the work is done.
+         *
+         * The work functor is executed asynchronously on a separate thread pool and must not interact
+         * with the ECS or capture any references to a Catalogue instance, as the behaviour is undefined.
+         * The completion functor is executed on the ECS thread pool in the next available iteration,
+         * and receives a fresh Catalogue instance with the correct threading context, the current delta time,
+         * and the result of the work functor.
+         *
+         * This is a pure method with respect to the Catalogue itself. Calling this without using the
+         * result of the work functor in the completion has no effect and introduces overhead.
+         *
+         * @tparam TWork The type of the work functor. Must be invocable with no arguments.
+         * @tparam TCompletion The type of the completion functor. Must be invocable with a
+         * Timing::Timestamp, a Catalogue, and the return type of TWork.
+         *
+         * @param work A functor to be executed outside of the ECS context. Must not capture or interact
+         * with any ECS state.
+         * @param completion A functor to be executed on the ECS thread pool once the work is complete.
+         * Receives the current delta time, a valid Catalogue instance, and the result of the work functor.
+         */
+        template<typename TWork, typename TCompletion>
+        requires Detail::ValidScheduleWithCompletion<TWork, TCompletion> void ScheduleWithCompletion(
+            TWork&& work,
+            TCompletion&& completion) noexcept
+        {
+            _scheduler.ScheduleWithCompletion(std::forward<TWork>(work), std::forward<TCompletion>(completion));
+        }
     };
 }

--- a/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
@@ -5,6 +5,7 @@
 
 #include <NovelRT/Ecs/ComponentCache.hpp>
 #include <NovelRT/Ecs/EcsUtils.hpp>
+#include <NovelRT/Ecs/ImplDetail.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
@@ -6,7 +6,6 @@
 #include <NovelRT/Ecs/ComponentCache.hpp>
 #include <NovelRT/Ecs/EcsUtils.hpp>
 #include <NovelRT/Ecs/ImplDetail.hpp>
-#include <NovelRT/Ecs/SystemScheduler.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -18,6 +17,7 @@ namespace NovelRT::Ecs
     template<typename TComponent>
     class ComponentView;
     class EntityCache;
+    class SystemScheduler;
     class UnsafeComponentView;
 
     /**
@@ -138,9 +138,8 @@ namespace NovelRT::Ecs
         template<typename TWork, typename TCompletion>
         requires Detail::ValidScheduleWithCompletion<TWork, TCompletion> void ScheduleWithCompletion(
             TWork&& work,
-            TCompletion&& completion) noexcept
-        {
-            _scheduler.ScheduleWithCompletion(std::forward<TWork>(work), std::forward<TCompletion>(completion));
-        }
+            TCompletion&& completion) noexcept;
     };
 }
+
+#include <NovelRT/Ecs/MiscTemplateImpls.hpp> // This has to be here due to template implementation detials - Matt J.

--- a/Ecs/Core/include/NovelRT/Ecs/ExecutionContext.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/ExecutionContext.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <cstddef>
+
+namespace NovelRT::Ecs
+{
+    class SystemScheduler;
+
+    struct ExecutionContext
+    {
+        SystemScheduler& _scheduler;
+        size_t _poolId;
+    };
+}

--- a/Ecs/Core/include/NovelRT/Ecs/ImplDetail.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/ImplDetail.hpp
@@ -3,13 +3,10 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
+#include <NovelRT/Timing/Timestamp.hpp>
+
 namespace NovelRT
 {
-    namespace Timing
-    {
-        class Timestamp;
-    }
-
     namespace Ecs
     {
         class Catalogue;

--- a/Ecs/Core/include/NovelRT/Ecs/ImplDetail.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/ImplDetail.hpp
@@ -3,6 +3,19 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
+namespace NovelRT
+{
+    namespace Timing
+    {
+        class Timestamp;
+    }
+
+    namespace Ecs
+    {
+        class Catalogue;
+    }
+}
+
 namespace NovelRT::Ecs::Detail
 {
     template<typename TWork, typename TCompletion>

--- a/Ecs/Core/include/NovelRT/Ecs/ImplDetail.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/ImplDetail.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+namespace NovelRT::Ecs::Detail
+{
+    template<typename TWork, typename TCompletion>
+    concept ValidScheduleWithCompletion =
+        std::invocable<TWork> && std::invocable<TCompletion, Timing::Timestamp, Catalogue, std::invoke_result_t<TWork>>;
+}

--- a/Ecs/Core/include/NovelRT/Ecs/MiscTemplateImpls.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/MiscTemplateImpls.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <NovelRT/Ecs/Catalogue.hpp>
+#include <NovelRT/Ecs/SystemScheduler.hpp>
+
+namespace NovelRT::Ecs
+{
+    template<typename TWork, typename TCompletion>
+    requires Detail::ValidScheduleWithCompletion<TWork, TCompletion> void Catalogue::ScheduleWithCompletion(
+        TWork&& work,
+        TCompletion&& completion) noexcept
+    {
+        _scheduler.ScheduleWithCompletion(std::forward<TWork>(work), std::forward<TCompletion>(completion));
+    }
+
+    template<typename TWork, typename TCompletion>
+    requires Detail::ValidScheduleWithCompletion<TWork, TCompletion> void SystemScheduler::ScheduleWithCompletion(
+        TWork&& work,
+        TCompletion&& completion) noexcept
+    {
+        _asyncArena->execute(
+            [&]()
+            {
+                _asyncTasks->run(
+                    [work = std::forward<TWork>(work), completion = std::forward<TCompletion>(completion),
+                     this]() mutable
+                    {
+                        auto result = work();
+                        _pendingCompletions.push([completion = std::move(completion), result = std::move(result)](
+                                                     Timing::Timestamp delta, Catalogue cat) mutable
+                                                 { completion(delta, cat, std::move(result)); });
+                    });
+            });
+    }
+}

--- a/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
@@ -19,6 +19,7 @@
 #include <oneapi/tbb/mutex.h>
 #include <oneapi/tbb/task_arena.h>
 #include <oneapi/tbb/task_group.h>
+#include<oneapi/tbb/concurrent_queue.h>
 
 namespace NovelRT::Ecs
 {
@@ -26,6 +27,14 @@ namespace NovelRT::Ecs
     class ComponentCache;
     class EntityCache;
     class IEcsSystem;
+
+    namespace Detail
+    {
+        template<typename TWork, typename TCompletion>
+        concept ValidScheduleWithCompletion =
+            std::invocable<TWork> &&
+            std::invocable<TCompletion, Timing::Timestamp, Catalogue, std::invoke_result_t<TWork>>;
+    }
 
     /**
      * @brief Handles all thread and system scheduling related tasks. In a normal ECS instance, this is your root
@@ -39,6 +48,7 @@ namespace NovelRT::Ecs
 
         static constexpr uint32_t DefaultBlindThreadLimit = 8;
 
+
         std::vector<std::shared_ptr<IEcsSystem>> _typedSystemCache;
         std::unordered_map<Atom, std::function<void(Timing::Timestamp, Catalogue)>> _systems;
 
@@ -51,6 +61,7 @@ namespace NovelRT::Ecs
         std::unique_ptr<tbb::task_arena> _asyncArena;
         std::unique_ptr<tbb::task_group> _ecsTasks;
         std::unique_ptr<tbb::task_group> _asyncTasks;
+        tbb::concurrent_queue<std::function<void(Timing::Timestamp, Catalogue)>> _pendingCompletions;
 
         Timing::Timestamp _currentDelta;
 
@@ -58,6 +69,26 @@ namespace NovelRT::Ecs
         bool _threadsAreSpinning;
 
         void ScheduleUpdateWork();
+
+        template<typename TWork, typename TCompletion>
+        requires Detail::ValidScheduleWithCompletion<TWork, TCompletion> void ScheduleWithCompletion(
+            TWork&& work,
+            TCompletion&& completion) noexcept
+        {
+            _asyncArena->execute(
+                [&]()
+                {
+                    _asyncTasks->run(
+                        [work = std::forward<TWork>(work), completion = std::forward<TCompletion>(completion),
+                         this]() mutable
+                        {
+                            auto result = work();
+                            _pendingCompletions.push([completion = std::move(completion), result = std::move(result)](
+                                                         Timing::Timestamp delta, Catalogue cat) mutable
+                                                     { completion(delta, cat, std::move(result)); });
+                        });
+                });
+        }
 
     public:
         /**

--- a/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
@@ -17,6 +17,8 @@
 #include <vector>
 
 #include <oneapi/tbb/mutex.h>
+#include <oneapi/tbb/task_arena.h>
+#include <oneapi/tbb/task_group.h>
 
 namespace NovelRT::Ecs
 {
@@ -35,7 +37,7 @@ namespace NovelRT::Ecs
     private:
         std::vector<Atom> _systemIds;
 
-        static inline const uint32_t DEFAULT_BLIND_THREAD_LIMIT = 8;
+        static constexpr uint32_t DefaultBlindThreadLimit = 8;
 
         std::vector<std::shared_ptr<IEcsSystem>> _typedSystemCache;
         std::unordered_map<Atom, std::function<void(Timing::Timestamp, Catalogue)>> _systems;
@@ -45,20 +47,16 @@ namespace NovelRT::Ecs
 
         uint32_t _workerThreadCount;
 
-        std::vector<Atom> _threadWorkItem;
-        std::vector<std::thread> _threadCache;
-        std::vector<std::unique_ptr<tbb::mutex>> _mutexCache;
+        std::unique_ptr<tbb::task_arena> _ecsArena;
+        std::unique_ptr<tbb::task_arena> _asyncArena;
+        std::unique_ptr<tbb::task_group> _ecsTasks;
+        std::unique_ptr<tbb::task_group> _asyncTasks;
 
         Timing::Timestamp _currentDelta;
-        std::atomic_uint64_t _threadAvailabilityMap;
-        // std::atomic_uint64_t _threadShutDownStatus;
 
         std::atomic_bool _shouldShutDown;
         bool _threadsAreSpinning;
 
-        bool JobAvailable(size_t poolId) const noexcept;
-        void WaitForJob(size_t poolId);
-        void CycleForJob(size_t poolId);
         void ScheduleUpdateWork();
 
     public:
@@ -87,16 +85,6 @@ namespace NovelRT::Ecs
          * @return The moved instance of SystemScheduler.
          */
         SystemScheduler& operator=(SystemScheduler&& other) noexcept;
-
-        /**
-         * @brief Gets the current state of the threads.
-         *
-         * @returns true if the threads are spinning, false if they aren't.
-         */
-        [[nodiscard]] inline bool GetThreadsAreSpinning() const noexcept
-        {
-            return _threadsAreSpinning;
-        }
 
         /**
          * @brief Registers a function to the SystemScheduler instance.
@@ -213,14 +201,6 @@ namespace NovelRT::Ecs
         }
 
         /**
-         * @brief Initialises the allocated worker threads for ECS processing.
-         *
-         * This only needs to be called once, and should not be called by the developer in a standard ECS instance.
-         *
-         */
-        void InitialiseThreads() noexcept;
-
-        /**
          * @brief Executes an iteration of the ECS.
          *
          * @param delta the current delta time to supply to systems.
@@ -228,11 +208,6 @@ namespace NovelRT::Ecs
          * @exception Any and all exceptions that might possibly propagate from any given system.
          */
         void ExecuteIteration(Timing::Timestamp delta);
-
-        /**
-         * @brief Shuts down the ECS instance and terminates threads.
-         */
-        void ShutDown() noexcept;
 
         /**
          * @brief Destroys the SystemScheduler.

--- a/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
@@ -68,22 +68,7 @@ namespace NovelRT::Ecs
         template<typename TWork, typename TCompletion>
         requires Detail::ValidScheduleWithCompletion<TWork, TCompletion> void ScheduleWithCompletion(
             TWork&& work,
-            TCompletion&& completion) noexcept
-        {
-            _asyncArena->execute(
-                [&]()
-                {
-                    _asyncTasks->run(
-                        [work = std::forward<TWork>(work), completion = std::forward<TCompletion>(completion),
-                         this]() mutable
-                        {
-                            auto result = work();
-                            _pendingCompletions.push([completion = std::move(completion), result = std::move(result)](
-                                                         Timing::Timestamp delta, Catalogue cat) mutable
-                                                     { completion(delta, cat, std::move(result)); });
-                        });
-                });
-        }
+            TCompletion&& completion) noexcept;
 
     public:
         /**

--- a/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
@@ -5,6 +5,7 @@
 
 #include <NovelRT/Ecs/ComponentCache.hpp>
 #include <NovelRT/Ecs/EntityCache.hpp>
+#include <NovelRT/Ecs/ImplDetail.hpp>
 #include <NovelRT/Exceptions/KeyNotFoundException.hpp>
 #include <NovelRT/Timing/Timestamp.hpp>
 #include <NovelRT/Utilities/Atom.hpp>

--- a/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
@@ -17,10 +17,10 @@
 #include <unordered_map>
 #include <vector>
 
+#include <oneapi/tbb/concurrent_queue.h>
 #include <oneapi/tbb/mutex.h>
 #include <oneapi/tbb/task_arena.h>
 #include <oneapi/tbb/task_group.h>
-#include<oneapi/tbb/concurrent_queue.h>
 
 namespace NovelRT::Ecs
 {
@@ -42,7 +42,6 @@ namespace NovelRT::Ecs
         std::vector<Atom> _systemIds;
 
         static constexpr uint32_t DefaultBlindThreadLimit = 8;
-
 
         std::vector<std::shared_ptr<IEcsSystem>> _typedSystemCache;
         std::unordered_map<Atom, std::function<void(Timing::Timestamp, Catalogue)>> _systems;

--- a/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
@@ -229,3 +229,5 @@ namespace NovelRT::Ecs
         ~SystemScheduler() noexcept;
     };
 }
+
+#include <NovelRT/Ecs/MiscTemplateImpls.hpp> // This has to be here due to template implementation detials - Matt J.

--- a/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
@@ -28,14 +28,6 @@ namespace NovelRT::Ecs
     class EntityCache;
     class IEcsSystem;
 
-    namespace Detail
-    {
-        template<typename TWork, typename TCompletion>
-        concept ValidScheduleWithCompletion =
-            std::invocable<TWork> &&
-            std::invocable<TCompletion, Timing::Timestamp, Catalogue, std::invoke_result_t<TWork>>;
-    }
-
     /**
      * @brief Handles all thread and system scheduling related tasks. In a normal ECS instance, this is your root
      * object.

--- a/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
@@ -43,6 +43,8 @@ namespace NovelRT::Ecs
      */
     class SystemScheduler
     {
+        friend class Catalogue;
+
     private:
         std::vector<Atom> _systemIds;
 

--- a/Ecs/Core/include/NovelRT/Ecs/SystemSchedulerBuilder.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemSchedulerBuilder.hpp
@@ -64,8 +64,6 @@ namespace NovelRT::Ecs
                 configure(scheduler);
             }
 
-            scheduler.InitialiseThreads();
-
             return scheduler;
         }
     };

--- a/ThirdParty/CMakeLists.txt
+++ b/ThirdParty/CMakeLists.txt
@@ -99,8 +99,8 @@ thirdparty_module(stduuid
   URL_HASH SHA512=a0e1c4b889919b43290ab8c978e96c2f51782a1c7972780351c80b4a860f1c4a488a957bf832b3e38eea97a8efa1dcce632c04fbb083331e2b83f54b16e87a67
 )
 thirdparty_module(TBB
-  URL https://github.com/uxlfoundation/oneTBB/archive/refs/tags/v2022.1.0.zip
-  URL_HASH SHA512=f87fffa1fec7eed77ba26353825ec8aef574e4ee8d6694882ada04bfe89eba12167036aeca4cc132b6838cd655812dba976b686956fd47e7bae8551bfc98c55e
+  URL https://github.com/uxlfoundation/oneTBB/archive/refs/tags/v2023.0.0.zip
+  URL_HASH SHA512=7bfd6f59978fefb3f6dafc605bf7ba99bb837b03743a1b53e77a4da9c5a67acdc9f6b235dcce36d59e2fa4df69e7a1ccb4312b6670d2b2f79bee47900dbbf19d
 )
 thirdparty_module(Vorbis
   URL https://github.com/xiph/vorbis/releases/download/v1.3.7/libvorbis-1.3.7.tar.gz

--- a/Utilities/Strings.cpp
+++ b/Utilities/Strings.cpp
@@ -1,5 +1,5 @@
 #include <NovelRT/Utilities/Strings.hpp>
-
+#include <NovelRT/Utilities/Span.hpp>
 namespace NovelRT::Utilities
 {
     [[nodiscard]] std::vector<const char*> GetStringSpanAsCharPtrVector(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This updates the SystemScheduler internals to just use TBB, as well as add a new work dispatching API on the catalogue in the form of ScheduleWithCompletion. It even has our very first C++ concept for the template!


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
You just cannot do long running work independent of framerate.


**What is the new behavior (if this is a feature change)?**
You can now do this.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. As part of this PR I have cleaned up an API inconsistency to ensure the API is "semantically correct" even if the compiler allows it to otherwise not be.


**Other information**:
We will need to possibly move TBB to our threading CMake target in the future. For now though I literally don't care this is fine.