### PR TITLE
Add system dependency tree support to the ECS.

### DIFF
--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -7,12 +7,113 @@
 #include <NovelRT/Ecs/IEcsSystem.hpp>
 #include <NovelRT/Ecs/SystemScheduler.hpp>
 #include <NovelRT/Maths/Utilities.hpp>
+#include <NovelRT/Utilities/Macros.hpp>
 
 #include <cassert>
 #include <functional>
+#include <unordered_map>
 
 namespace NovelRT::Ecs
 {
+    void SystemScheduler::RebuildSystemDependencyTreeLayers()
+    {
+        // Special casing terminal systems e.g. the render orchestrator with this. - Matt J.
+        for (auto&& id : _terminalSystemIds)
+        {
+            std::vector<SystemId> allOtherSystems{};
+            for (auto&& otherId : _systemIds)
+            {
+                if (otherId != id && _terminalSystemIds.find(otherId) == _terminalSystemIds.end())
+                {
+                    allOtherSystems.emplace_back(otherId);
+                }
+            }
+
+            _systemDependencies.at(id) = std::move(allOtherSystems);
+        }
+
+        // This is based on topologic sort with kahn's algorithm. I hope I implemented this right. I am tired. - Matt J.
+
+        std::unordered_map<SystemId, size_t> inDegree{};
+        std::unordered_map<SystemId, std::vector<SystemId>> dependents{};
+
+        for (auto&& id : _systemIds)
+        {
+            inDegree.try_emplace(id, 0);
+            dependents.try_emplace(id, std::vector<SystemId>{});
+        }
+
+        for (auto&& [id, dependencies] : _systemDependencies)
+        {
+            inDegree.at(id) = dependencies.size();
+
+            for (auto&& dep : dependencies)
+            {
+                dependents.at(dep).emplace_back(id);
+            }
+        }
+
+        _schedulingLayers.clear();
+
+        while (true)
+        {
+            std::vector<SystemId> currentLayer{};
+
+            for (auto&& [id, degree] : inDegree)
+            {
+                if (degree == 0)
+                {
+                    currentLayer.emplace_back(id);
+                }
+            }
+
+            if (currentLayer.empty())
+            {
+                break;
+            }
+
+            for (auto&& id : currentLayer)
+            {
+                inDegree.erase(id);
+
+                for (auto&& dependent : dependents.at(id))
+                {
+                    // just want to decrement this value here. Unused macro is for explicitness. - Matt J.
+                    unused(inDegree.at(dependent)--);
+                }
+            }
+
+            _schedulingLayers.emplace_back(std::move(currentLayer));
+        }
+
+        if (!inDegree.empty())
+        {
+            throw Exceptions::InvalidOperationException("A cycle was detected in the system dependency graph. Please "
+                                                        "check your system dependencies for circular references.");
+        }
+    }
+
+    SystemId SystemScheduler::RegisterSystemInternalNoTreeRebuild(
+        std::function<void(Timing::Timestamp, Catalogue)> systemUpdatePtr,
+        std::span<const SystemId> dependencies)
+    {
+        for (SystemId dep : dependencies)
+        {
+            if (std::find(_systemIds.begin(), _systemIds.end(), dep) == _systemIds.end())
+            {
+                throw std::invalid_argument("A provided dependency ID does not match any registered system. "
+                                            "Ensure all dependency systems are registered before being referenced.");
+            }
+        }
+
+        static AtomFactory& systemIdFactory = AtomFactoryDatabase::GetFactory("SystemId");
+
+        SystemId id = systemIdFactory.GetNext();
+        _systems.emplace(id, systemUpdatePtr);
+        _systemIds.emplace_back(id);
+        _systemDependencies.emplace(id, std::move(dependencies));
+    }
+
     SystemScheduler::SystemScheduler(uint32_t maximumThreadCount) noexcept
         : _entityCache(1),
           _componentCache(1),
@@ -23,7 +124,8 @@ namespace NovelRT::Ecs
           _ecsTasks(std::make_unique<tbb::task_group>()),
           _asyncTasks(std::make_unique<tbb::task_group>()),
           _pendingCompletions(),
-          _currentDelta(NovelRT::Timing::TimeFromSeconds(0))
+          _currentDelta(NovelRT::Timing::TimeFromSeconds(0)),
+          _hasExecutedAtLeastOnce(false)
     {
         _workerThreadCount = _ecsArena->max_concurrency();
         _entityCache = EntityCache(_workerThreadCount);
@@ -42,7 +144,8 @@ namespace NovelRT::Ecs
           _ecsTasks(std::move(other._ecsTasks)),
           _asyncTasks(std::move(other._asyncTasks)),
           _pendingCompletions(std::move(other._pendingCompletions)),
-          _currentDelta(other._currentDelta)
+          _currentDelta(other._currentDelta),
+          _hasExecutedAtLeastOnce(other._hasExecutedAtLeastOnce)
     {
     }
 
@@ -60,22 +163,82 @@ namespace NovelRT::Ecs
         _asyncTasks = std::move(other._asyncTasks);
         _currentDelta = other._currentDelta;
         _pendingCompletions = std::move(other._pendingCompletions);
+        _hasExecutedAtLeastOnce = other._hasExecutedAtLeastOnce;
+
         return *this;
     }
 
-    void SystemScheduler::RegisterSystem(std::function<void(Timing::Timestamp, Catalogue)> systemUpdatePtr) noexcept
+    SystemId SystemScheduler::RegisterSystem(std::function<void(Timing::Timestamp, Catalogue)> systemUpdatePtr,
+                                             std::span<const SystemId> dependencies)
     {
-        static AtomFactory& systemIdFactory = AtomFactoryDatabase::GetFactory("SystemId");
+        if (_hasExecutedAtLeastOnce)
+        {
+            throw Exceptions::InvalidOperationException(
+                "Systems cannot be registered after the first iteration has executed. Register all systems during "
+                "initialisation.");
+        }
 
-        Atom id = systemIdFactory.GetNext();
-        _systems.emplace(id, systemUpdatePtr);
-        _systemIds.emplace_back(id);
+        SystemId id = RegisterSystemInternalNoTreeRebuild(systemUpdatePtr, dependencies);
+        RebuildSystemDependencyTreeLayers();
+
+        return id;
     }
 
-    void SystemScheduler::RegisterSystem(std::shared_ptr<IEcsSystem> targetSystem) noexcept
+    SystemId SystemScheduler::RegisterSystem(std::function<void(Timing::Timestamp, Catalogue)> systemUpdatePtr)
     {
+        return RegisterSystem(systemUpdatePtr, {});
+    }
+
+    SystemId SystemScheduler::RegisterSystem(std::shared_ptr<IEcsSystem> targetSystem,
+                                             std::span<const SystemId> dependencies)
+    {
+        if (std::find(_typedSystemCache.begin(), _typedSystemCache.end(), targetSystem) != _typedSystemCache.end())
+        {
+            throw std::invalid_argument(
+                "The provided system pointer has already been registered. Each system may only be registered once.");
+        }
+
         _typedSystemCache.emplace_back(targetSystem);
-        RegisterSystem([targetSystem](auto delta, auto catalogue) { targetSystem->Update(delta, catalogue); });
+
+        return RegisterSystem([targetSystem](auto delta, auto catalogue) { targetSystem->Update(delta, catalogue); },
+                              dependencies);
+    }
+
+    SystemId SystemScheduler::RegisterSystem(std::shared_ptr<IEcsSystem> targetSystem)
+    {
+        return RegisterSystem(targetSystem, {});
+    }
+
+    SystemId SystemScheduler::RegisterSystemDependsOnAll(
+        std::function<void(Timing::Timestamp, Catalogue)> systemUpdatePtr)
+    {
+        if (_hasExecutedAtLeastOnce)
+        {
+            throw Exceptions::InvalidOperationException(
+                "Systems cannot be registered after the first iteration has executed. Register all systems during "
+                "initialisation.");
+        }
+
+        SystemId id = RegisterSystemInternalNoTreeRebuild(systemUpdatePtr, {});
+
+        _terminalSystemIds.emplace(id);
+        RebuildSystemDependencyTreeLayers();
+
+        return id;
+    }
+
+    SystemId SystemScheduler::RegisterSystemDependsOnAll(std::shared_ptr<IEcsSystem> targetSystem)
+    {
+        if (std::find(_typedSystemCache.begin(), _typedSystemCache.end(), targetSystem) != _typedSystemCache.end())
+        {
+            throw std::invalid_argument(
+                "The provided system pointer has already been registered. Each system may only be registered once.");
+        }
+
+        _typedSystemCache.emplace_back(targetSystem);
+
+        return RegisterSystemDependsOnAll([targetSystem](auto delta, auto catalogue)
+                                          { targetSystem->Update(delta, catalogue); });
     }
 
     void SystemScheduler::ScheduleUpdateWork()
@@ -83,49 +246,51 @@ namespace NovelRT::Ecs
         _ecsArena->execute(
             [&]()
             {
-                std::function<void(Timing::Timestamp, Catalogue)> completion{};
-                while (_pendingCompletions.try_pop(completion))
+                for (auto&& layer : _schedulingLayers)
                 {
-                    _ecsTasks->run(
-                        [completion = std::move(completion), this]()
-                        {
-                            size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
-                            completion(_currentDelta, Catalogue(poolId, *this));
-                        });
-                }
+                    std::function<void(Timing::Timestamp, Catalogue)> completion{};
 
-                for (auto&& systemId : _systemIds)
-                {
-                    _ecsTasks->run(
-                        [&, systemId]()
-                        {
-                            size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
-                            _systems[systemId](_currentDelta, Catalogue(poolId, *this));
-                        });
-                }
+                    while (_pendingCompletions.try_pop(completion))
+                    {
+                        _ecsTasks->run(
+                            [completion = std::move(completion), this]()
+                            {
+                                size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
+                                completion(_currentDelta, Catalogue(poolId, *this));
+                            });
+                    }
 
-                _ecsTasks->wait();
+                    for (auto&& systemId : _systemIds)
+                    {
+                        _ecsTasks->run(
+                            [&, systemId]()
+                            {
+                                size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
+                                _systems[systemId](_currentDelta, Catalogue(poolId, *this));
+                            });
+                    }
+
+                    _ecsTasks->wait();
+
+                    _componentCache.PrepAllBuffersForNextFrame(_entityCache.GetEntitiesToRemoveThisFrame());
+                    _entityCache.ProcessEntityRegistrationRequestsFromThreads();
+                    _entityCache.ProcessEntityDeletionRequestsFromThreads();
+                    _entityCache.ApplyEntityDeletionRequestsToRegisteredEntities();
+                }
             });
     }
 
     void SystemScheduler::ExecuteIteration(Timing::Timestamp delta)
     {
+        _hasExecutedAtLeastOnce = true;
         _currentDelta = delta;
-
         ScheduleUpdateWork();
-        _componentCache.PrepAllBuffersForNextFrame(_entityCache.GetEntitiesToRemoveThisFrame());
-        _entityCache.ProcessEntityRegistrationRequestsFromThreads();
-        _entityCache.ProcessEntityDeletionRequestsFromThreads();
-        _entityCache.ApplyEntityDeletionRequestsToRegisteredEntities();
     }
 
     SystemScheduler::~SystemScheduler() noexcept
     {
-        _ecsArena->execute(
-            [&]()
-            {
-                _ecsTasks->wait();
-                _asyncTasks->wait();
-            });
+        _ecsArena->execute([&]() { _ecsTasks->wait(); });
+
+        _asyncArena->execute([&]() { _asyncTasks->wait(); });
     }
 } // namespace NovelRT::Ecs

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -112,6 +112,8 @@ namespace NovelRT::Ecs
         _systems.emplace(id, systemUpdatePtr);
         _systemIds.emplace_back(id);
         _systemDependencies.emplace(id, std::move(dependencies));
+        
+        return id;
     }
 
     SystemScheduler::SystemScheduler(uint32_t maximumThreadCount) noexcept
@@ -246,7 +248,7 @@ namespace NovelRT::Ecs
         _ecsArena->execute(
             [&]()
             {
-                for (auto&& layer : _schedulingLayers)
+                for (auto& layer : _schedulingLayers)
                 {
                     std::function<void(Timing::Timestamp, Catalogue)> completion{};
 
@@ -260,7 +262,7 @@ namespace NovelRT::Ecs
                             });
                     }
 
-                    for (auto&& systemId : _systemIds)
+                    for (SystemId systemId : layer)
                     {
                         _ecsTasks->run(
                             [&, systemId]()

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -111,7 +111,7 @@ namespace NovelRT::Ecs
         SystemId id = systemIdFactory.GetNext();
         _systems.emplace(id, systemUpdatePtr);
         _systemIds.emplace_back(id);
-        _systemDependencies.emplace(id, std::move(dependencies));
+        _systemDependencies.emplace(id, std::vector<SystemId>(dependencies.begin(), dependencies.end()));
         
         return id;
     }

--- a/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
@@ -142,4 +142,4 @@ namespace NovelRT::Ecs
     };
 }
 
-#include <NovelRT/Ecs/MiscTemplateImpls.hpp> // This has to be here due to template implementation detials - Matt J.
+#include <NovelRT/Ecs/MiscTemplateImpls.hpp> // This has to be here due to template implementation details - Matt J.

--- a/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
@@ -10,15 +10,15 @@
 #include <NovelRT/Timing/Timestamp.hpp>
 #include <NovelRT/Utilities/Atom.hpp>
 
-#include <atomic>
 #include <functional>
 #include <memory>
+#include <span>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <oneapi/tbb/concurrent_queue.h>
-#include <oneapi/tbb/mutex.h>
 #include <oneapi/tbb/task_arena.h>
 #include <oneapi/tbb/task_group.h>
 
@@ -28,6 +28,8 @@ namespace NovelRT::Ecs
     class ComponentCache;
     class EntityCache;
     class IEcsSystem;
+
+    using SystemId = Atom;
 
     /**
      * @brief Handles all thread and system scheduling related tasks. In a normal ECS instance, this is your root
@@ -39,12 +41,15 @@ namespace NovelRT::Ecs
         friend class Catalogue;
 
     private:
-        std::vector<Atom> _systemIds;
+        std::vector<SystemId> _systemIds;
 
         static constexpr uint32_t DefaultBlindThreadLimit = 8;
 
         std::vector<std::shared_ptr<IEcsSystem>> _typedSystemCache;
-        std::unordered_map<Atom, std::function<void(Timing::Timestamp, Catalogue)>> _systems;
+        std::unordered_map<SystemId, std::function<void(Timing::Timestamp, Catalogue)>> _systems;
+        std::unordered_map<SystemId, std::vector<SystemId>> _systemDependencies;
+        std::vector<std::vector<SystemId>> _schedulingLayers;
+        std::unordered_set<SystemId> _terminalSystemIds;
 
         EntityCache _entityCache;
         ComponentCache _componentCache;
@@ -59,8 +64,7 @@ namespace NovelRT::Ecs
 
         Timing::Timestamp _currentDelta;
 
-        std::atomic_bool _shouldShutDown;
-        bool _threadsAreSpinning;
+        bool _hasExecutedAtLeastOnce;
 
         void ScheduleUpdateWork();
 
@@ -68,6 +72,12 @@ namespace NovelRT::Ecs
         requires Detail::ValidScheduleWithCompletion<TWork, TCompletion> void ScheduleWithCompletion(
             TWork&& work,
             TCompletion&& completion) noexcept;
+
+        void RebuildSystemDependencyTreeLayers();
+
+        [[nodiscard]] SystemId RegisterSystemInternalNoTreeRebuild(
+            std::function<void(Timing::Timestamp, Catalogue)> systemUpdatePtr,
+            std::span<const SystemId> dependencies);
 
     public:
         /**
@@ -99,16 +109,94 @@ namespace NovelRT::Ecs
         /**
          * @brief Registers a function to the SystemScheduler instance.
          *
+         * @warning Registering the same function twice results in undefined behaviour. Unlike IEcsSystem registrations,
+         * duplicate function registrations cannot be detected at runtime. It is the caller's responsibility to ensure
+         * each system function is only registered once.
+         *
          * @param systemUpdatePtr a valid std::function object that points to the system function in question.
+         * @param dependencies a collection of system IDs used to signal to the scheduler when to run this system in a
+         * given iteration.
+         * @return The internal ID of the registered system.
+         *
+         * @exception std::invalid_argument if any of the provided dependency IDs do not match a registered system.
+         * @exception Exceptions::InvalidOperationException if this method is called after the first iteration has been
+         * executed.
          */
-        void RegisterSystem(std::function<void(Timing::Timestamp, Catalogue)> systemUpdatePtr) noexcept;
+        [[nodiscard]] SystemId RegisterSystem(std::function<void(Timing::Timestamp, Catalogue)> systemUpdatePtr,
+                                              std::span<const SystemId> dependencies);
+
+        /**
+         * @brief Registers a function to the SystemScheduler instance with no dependencies.
+         *
+         * @warning Registering the same function twice results in undefined behaviour. Unlike IEcsSystem registrations,
+         * duplicate function registrations cannot be detected at runtime. It is the caller's responsibility to ensure
+         * each system function is only registered once.
+         *
+         * @param systemUpdatePtr a valid std::function object that points to the system function in question.
+         * @return The internal ID of the registered system.
+         *
+         * @exception Exceptions::InvalidOperationException if this method is called after the first iteration has been
+         * executed.
+         */
+        [[nodiscard]] SystemId RegisterSystem(std::function<void(Timing::Timestamp, Catalogue)> systemUpdatePtr);
 
         /**
          * @brief Registers an IEcsSystem instance to the SystemScheduler instance.
          *
-         * @param targetSystem a valid std::function object that points to the system function in question.
+         * @param targetSystem a valid IEcsSystem object instance.
+         * @param dependencies a collection of system IDs used to signal to the scheduler when to run this system in a
+         * given iteration.
+         * @return The internal ID of the registered system.
+         *
+         * @exception std::invalid_argument if the provided system has already been registered, or if any of the
+         * provided dependency IDs do not match a registered system.
+         * @exception Exceptions::InvalidOperationException if this method is called after the first iteration has been
+         * executed.
          */
-        void RegisterSystem(std::shared_ptr<IEcsSystem> targetSystem) noexcept;
+        [[nodiscard]] SystemId RegisterSystem(std::shared_ptr<IEcsSystem> targetSystem,
+                                              std::span<const SystemId> dependencies);
+
+        /**
+         * @brief Registers an IEcsSystem instance to the SystemScheduler instance with no dependencies.
+         *
+         * @param targetSystem a valid IEcsSystem object instance.
+         * @return The internal ID of the registered system.
+         *
+         * @exception std::invalid_argument if the provided system has already been registered.
+         * @exception Exceptions::InvalidOperationException if this method is called after the first iteration has been
+         * executed.
+         */
+        [[nodiscard]] SystemId RegisterSystem(std::shared_ptr<IEcsSystem> targetSystem);
+
+        /**
+         * @brief Registers a function to the SystemScheduler instance as a terminal system. A terminal system depends
+         * on all other non-terminal systems and is always scheduled in the final layer of execution.
+         *
+         * @warning Registering the same function twice results in undefined behaviour. Unlike IEcsSystem registrations,
+         * duplicate function registrations cannot be detected at runtime. It is the caller's responsibility to ensure
+         * each system function is only registered once.
+         *
+         * @param systemUpdatePtr a valid std::function object that points to the system function in question.
+         * @return The internal ID of the registered system.
+         *
+         * @exception Exceptions::InvalidOperationException if this method is called after the first iteration has been
+         * executed.
+         */
+        [[nodiscard]] SystemId RegisterSystemDependsOnAll(
+            std::function<void(Timing::Timestamp, Catalogue)> systemUpdatePtr);
+
+        /**
+         * @brief Registers an IEcsSystem instance to the SystemScheduler instance as a terminal system. A terminal
+         * system depends on all other non-terminal systems and is always scheduled in the final layer of execution.
+         *
+         * @param targetSystem a valid IEcsSystem object instance.
+         * @return The internal ID of the registered system.
+         *
+         * @exception std::invalid_argument if the provided system has already been registered.
+         * @exception Exceptions::InvalidOperationException if this method is called after the first iteration has been
+         * executed.
+         */
+        [[nodiscard]] SystemId RegisterSystemDependsOnAll(std::shared_ptr<IEcsSystem> targetSystem);
 
         /**
          * @brief Gets the amount of worker threads associated with this SystemScheduler.
@@ -222,11 +310,12 @@ namespace NovelRT::Ecs
         /**
          * @brief Destroys the SystemScheduler.
          *
-         * The destructor also implicitly shuts down all threads being used by this scheduler.
+         * The destructor waits for any in-flight ECS and async tasks to complete
+         * before releasing all resources.
          *
          */
         ~SystemScheduler() noexcept;
     };
 }
 
-#include <NovelRT/Ecs/MiscTemplateImpls.hpp> // This has to be here due to template implementation detials - Matt J.
+#include <NovelRT/Ecs/MiscTemplateImpls.hpp> // This has to be here due to template implementation details - Matt J.

--- a/Samples/Ecs/Graphics/main.cpp
+++ b/Samples/Ecs/Graphics/main.cpp
@@ -309,74 +309,75 @@ public:
 
 int main()
 {
-    auto wndProvider = std::make_shared<WindowProvider<Glfw::GlfwWindowingBackend>>(
-        NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F(400, 400));
+    // Commenting this out to fix the issues with the build in a separate PR. - Matt J.
+    //auto wndProvider = std::make_shared<WindowProvider<Glfw::GlfwWindowingBackend>>(
+    //    NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F(400, 400));
 
-    auto gfxProvider = wndProvider->CreateGraphicsProvider<VulkanGraphicsBackend>(true);
-    auto gfxSurfaceContext = std::make_shared<GraphicsSurfaceContext<VulkanGraphicsBackend>>(wndProvider, gfxProvider);
+    //auto gfxProvider = wndProvider->CreateGraphicsProvider<VulkanGraphicsBackend>(true);
+    //auto gfxSurfaceContext = std::make_shared<GraphicsSurfaceContext<VulkanGraphicsBackend>>(wndProvider, gfxProvider);
 
-    VulkanGraphicsAdapterSelector selector{};
-    auto gfxAdapter = selector.GetDefaultRecommendedAdapter(gfxProvider, gfxSurfaceContext);
-    auto gfxDevice = gfxAdapter->CreateDevice(gfxSurfaceContext);
-    TrianglePass<VulkanGraphicsBackend> trianglePass{};
+    //VulkanGraphicsAdapterSelector selector{};
+    //auto gfxAdapter = selector.GetDefaultRecommendedAdapter(gfxProvider, gfxSurfaceContext);
+    //auto gfxDevice = gfxAdapter->CreateDevice(gfxSurfaceContext);
+    //TrianglePass<VulkanGraphicsBackend> trianglePass{};
 
-    SystemSchedulerBuilder builder{};
+    //SystemSchedulerBuilder builder{};
 
-    // FIXME: This is a workaround to silence Vulkan warnings about multiple threads.
-    builder.WithThreadCount(1);
+    //// FIXME: This is a workaround to silence Vulkan warnings about multiple threads.
+    //builder.WithThreadCount(1);
 
-    AddDefaults(builder);
-    AddGraphics<Vulkan::VulkanGraphicsBackend>(builder)
-        .WithGraphicsDevice(gfxDevice)
-        .WithSurfaceContext(gfxSurfaceContext)
-        .ConfigureRenderPasses(
-            [gfxDevice, &trianglePass](RenderPassManager<VulkanGraphicsBackend>& renderPassManager)
-            {
-                GraphicsRenderPassDescription passDesc{};
-                GraphicsAttachmentDescription attachmentDesc{};
+    //AddDefaults(builder);
+    //AddGraphics<Vulkan::VulkanGraphicsBackend>(builder)
+    //    .WithGraphicsDevice(gfxDevice)
+    //    .WithSurfaceContext(gfxSurfaceContext)
+    //    .ConfigureRenderPasses(
+    //        [gfxDevice, &trianglePass](RenderPassManager<VulkanGraphicsBackend>& renderPassManager)
+    //        {
+    //            GraphicsRenderPassDescription passDesc{};
+    //            GraphicsAttachmentDescription attachmentDesc{};
 
-                auto vulkanFormat = gfxDevice->GetSwapchain()->GetVulkanFormat();
-                if (vulkanFormat == VK_FORMAT_R8G8B8A8_UNORM)
-                {
-                    attachmentDesc.texelFormat = TexelFormat::R8G8B8A8_UNORM;
-                }
-                else if (vulkanFormat == VK_FORMAT_B8G8R8A8_UNORM)
-                {
-                    attachmentDesc.texelFormat = TexelFormat::B8G8R8A8_UNORM;
-                }
-                else
-                {
-                    throw NovelRT::Exceptions::InitialisationFailureException("How did you get here?");
-                }
+    //            auto vulkanFormat = gfxDevice->GetSwapchain()->GetVulkanFormat();
+    //            if (vulkanFormat == VK_FORMAT_R8G8B8A8_UNORM)
+    //            {
+    //                attachmentDesc.texelFormat = TexelFormat::R8G8B8A8_UNORM;
+    //            }
+    //            else if (vulkanFormat == VK_FORMAT_B8G8R8A8_UNORM)
+    //            {
+    //                attachmentDesc.texelFormat = TexelFormat::B8G8R8A8_UNORM;
+    //            }
+    //            else
+    //            {
+    //                throw NovelRT::Exceptions::InitialisationFailureException("How did you get here?");
+    //            }
 
-                attachmentDesc.loadOp = LoadOp::Clear;
-                attachmentDesc.storeOp = StoreOp::Store;
-                attachmentDesc.initialLayout = ImageLayout::Undefined;
-                attachmentDesc.finalLayout = ImageLayout::Present;
+    //            attachmentDesc.loadOp = LoadOp::Clear;
+    //            attachmentDesc.storeOp = StoreOp::Store;
+    //            attachmentDesc.initialLayout = ImageLayout::Undefined;
+    //            attachmentDesc.finalLayout = ImageLayout::Present;
 
-                passDesc.attachmentDescriptions.push_back(attachmentDesc);
-                trianglePass.RenderPass = gfxDevice->CreateRenderPass(passDesc);
-                trianglePass.RenderPassId = renderPassManager.RegisterRenderPass(trianglePass.RenderPass);
-            })
-        .WithDefaultOrchestrator();
+    //            passDesc.attachmentDescriptions.push_back(attachmentDesc);
+    //            trianglePass.RenderPass = gfxDevice->CreateRenderPass(passDesc);
+    //            trianglePass.RenderPassId = renderPassManager.RegisterRenderPass(trianglePass.RenderPass);
+    //        })
+    //    .WithDefaultOrchestrator();
 
-    auto triangleSystem = std::make_shared<SampleTriangleRenderingSystem<VulkanGraphicsBackend>>(
-        gfxProvider, gfxDevice, gfxSurfaceContext, trianglePass);
-    builder.Configure([triangleSystem](SystemScheduler& scheduler) { scheduler.RegisterSystem(triangleSystem); });
+    //auto triangleSystem = std::make_shared<SampleTriangleRenderingSystem<VulkanGraphicsBackend>>(
+    //    gfxProvider, gfxDevice, gfxSurfaceContext, trianglePass);
+    //builder.Configure([triangleSystem](SystemScheduler& scheduler) { scheduler.RegisterSystem(triangleSystem); });
 
-    SystemScheduler scheduler = builder.Build();
-    StepTimer timer{};
-    Event<Timestamp::duration> TimerCallback{};
+    //SystemScheduler scheduler = builder.Build();
+    //StepTimer timer{};
+    //Event<Timestamp::duration> TimerCallback{};
 
-    TimerCallback += [&timer, &scheduler](auto /* delta */) { scheduler.ExecuteIteration(timer.getTotalTime()); };
+    //TimerCallback += [&timer, &scheduler](auto /* delta */) { scheduler.ExecuteIteration(timer.getTotalTime()); };
 
-    while (!wndProvider->ShouldClose())
-    {
-        wndProvider->ProcessAllMessages();
-        timer.Tick(TimerCallback);
-    }
+    //while (!wndProvider->ShouldClose())
+    //{
+    //    wndProvider->ProcessAllMessages();
+    //    timer.Tick(TimerCallback);
+    //}
 
-    gfxDevice->WaitForIdle();
+    //gfxDevice->WaitForIdle();
 
     return 0;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change introduces a new feature - a dependency graph/tree for ECS systems. This allows for systems to have dependencies without explicitly taking each other in the constructor, and makes the ECS simulation logic easier to reason about as a side effect.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
Vulkan takes out its metaphorical gun and gets mad at us because this fixes a parallel cmdlist problem we are having.


**What is the new behavior (if this is a feature change)?**
Vulkan no longer gets angry at us and we also get a really important feature. Hooray!


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. Please note the changes to the pre-existing SystemScheduler APIs - specifically dropping noexcept and the new exception handling. Any code that relied on this being noexcept is no longer good code.


**Other information**:
N/A