### PR TITLE
Make the graphics ECS sample work again.

### DIFF
--- a/Ecs/Graphics/include/NovelRT/Ecs/Graphics/EcsGraphicsBuilder.hpp
+++ b/Ecs/Graphics/include/NovelRT/Ecs/Graphics/EcsGraphicsBuilder.hpp
@@ -9,6 +9,8 @@
 
 #include <NovelRT/Ecs/SystemSchedulerBuilder.hpp>
 
+#include <NovelRT/Utilities/Macros.hpp>
+
 #include <limits>
 #include <memory>
 #include <utility>
@@ -105,7 +107,7 @@ namespace NovelRT::Ecs::Graphics
             cache.RegisterComponentType(_defaultBuiltCommandListComponent, "NovelRT::Ecs::Graphics::BuiltCommandList");
             cache.RegisterComponentType(_defaultRenderPassComponent, "NovelRT::Ecs::Graphics::RenderPass");
 
-            scheduler.RegisterSystem(_orchestrator);
+            unused(scheduler.RegisterSystemDependsOnAll(_orchestrator));
         }
     };
 

--- a/Samples/Ecs/Graphics/main.cpp
+++ b/Samples/Ecs/Graphics/main.cpp
@@ -309,75 +309,71 @@ public:
 
 int main()
 {
-    // Commenting this out to fix the issues with the build in a separate PR. - Matt J.
-    //auto wndProvider = std::make_shared<WindowProvider<Glfw::GlfwWindowingBackend>>(
-    //    NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F(400, 400));
+    auto wndProvider = std::make_shared<WindowProvider<Glfw::GlfwWindowingBackend>>(
+        NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F(400, 400));
 
-    //auto gfxProvider = wndProvider->CreateGraphicsProvider<VulkanGraphicsBackend>(true);
-    //auto gfxSurfaceContext = std::make_shared<GraphicsSurfaceContext<VulkanGraphicsBackend>>(wndProvider, gfxProvider);
+    auto gfxProvider = wndProvider->CreateGraphicsProvider<VulkanGraphicsBackend>(true);
+    auto gfxSurfaceContext = std::make_shared<GraphicsSurfaceContext<VulkanGraphicsBackend>>(wndProvider, gfxProvider);
 
-    //VulkanGraphicsAdapterSelector selector{};
-    //auto gfxAdapter = selector.GetDefaultRecommendedAdapter(gfxProvider, gfxSurfaceContext);
-    //auto gfxDevice = gfxAdapter->CreateDevice(gfxSurfaceContext);
-    //TrianglePass<VulkanGraphicsBackend> trianglePass{};
+    VulkanGraphicsAdapterSelector selector{};
+    auto gfxAdapter = selector.GetDefaultRecommendedAdapter(gfxProvider, gfxSurfaceContext);
+    auto gfxDevice = gfxAdapter->CreateDevice(gfxSurfaceContext);
+    TrianglePass<VulkanGraphicsBackend> trianglePass{};
 
-    //SystemSchedulerBuilder builder{};
+    SystemSchedulerBuilder builder{};
 
-    //// FIXME: This is a workaround to silence Vulkan warnings about multiple threads.
-    //builder.WithThreadCount(1);
+    AddDefaults(builder);
+    AddGraphics<Vulkan::VulkanGraphicsBackend>(builder)
+        .WithGraphicsDevice(gfxDevice)
+        .WithSurfaceContext(gfxSurfaceContext)
+        .ConfigureRenderPasses(
+            [gfxDevice, &trianglePass](RenderPassManager<VulkanGraphicsBackend>& renderPassManager)
+            {
+                GraphicsRenderPassDescription passDesc{};
+                GraphicsAttachmentDescription attachmentDesc{};
 
-    //AddDefaults(builder);
-    //AddGraphics<Vulkan::VulkanGraphicsBackend>(builder)
-    //    .WithGraphicsDevice(gfxDevice)
-    //    .WithSurfaceContext(gfxSurfaceContext)
-    //    .ConfigureRenderPasses(
-    //        [gfxDevice, &trianglePass](RenderPassManager<VulkanGraphicsBackend>& renderPassManager)
-    //        {
-    //            GraphicsRenderPassDescription passDesc{};
-    //            GraphicsAttachmentDescription attachmentDesc{};
+                auto vulkanFormat = gfxDevice->GetSwapchain()->GetVulkanFormat();
+                if (vulkanFormat == VK_FORMAT_R8G8B8A8_UNORM)
+                {
+                    attachmentDesc.texelFormat = TexelFormat::R8G8B8A8_UNORM;
+                }
+                else if (vulkanFormat == VK_FORMAT_B8G8R8A8_UNORM)
+                {
+                    attachmentDesc.texelFormat = TexelFormat::B8G8R8A8_UNORM;
+                }
+                else
+                {
+                    throw NovelRT::Exceptions::InitialisationFailureException("How did you get here?");
+                }
 
-    //            auto vulkanFormat = gfxDevice->GetSwapchain()->GetVulkanFormat();
-    //            if (vulkanFormat == VK_FORMAT_R8G8B8A8_UNORM)
-    //            {
-    //                attachmentDesc.texelFormat = TexelFormat::R8G8B8A8_UNORM;
-    //            }
-    //            else if (vulkanFormat == VK_FORMAT_B8G8R8A8_UNORM)
-    //            {
-    //                attachmentDesc.texelFormat = TexelFormat::B8G8R8A8_UNORM;
-    //            }
-    //            else
-    //            {
-    //                throw NovelRT::Exceptions::InitialisationFailureException("How did you get here?");
-    //            }
+                attachmentDesc.loadOp = LoadOp::Clear;
+                attachmentDesc.storeOp = StoreOp::Store;
+                attachmentDesc.initialLayout = ImageLayout::Undefined;
+                attachmentDesc.finalLayout = ImageLayout::Present;
 
-    //            attachmentDesc.loadOp = LoadOp::Clear;
-    //            attachmentDesc.storeOp = StoreOp::Store;
-    //            attachmentDesc.initialLayout = ImageLayout::Undefined;
-    //            attachmentDesc.finalLayout = ImageLayout::Present;
+                passDesc.attachmentDescriptions.push_back(attachmentDesc);
+                trianglePass.RenderPass = gfxDevice->CreateRenderPass(passDesc);
+                trianglePass.RenderPassId = renderPassManager.RegisterRenderPass(trianglePass.RenderPass);
+            })
+        .WithDefaultOrchestrator();
 
-    //            passDesc.attachmentDescriptions.push_back(attachmentDesc);
-    //            trianglePass.RenderPass = gfxDevice->CreateRenderPass(passDesc);
-    //            trianglePass.RenderPassId = renderPassManager.RegisterRenderPass(trianglePass.RenderPass);
-    //        })
-    //    .WithDefaultOrchestrator();
+    auto triangleSystem = std::make_shared<SampleTriangleRenderingSystem<VulkanGraphicsBackend>>(
+        gfxProvider, gfxDevice, gfxSurfaceContext, trianglePass);
+    builder.Configure([triangleSystem](SystemScheduler& scheduler) { unused(scheduler.RegisterSystem(triangleSystem)); });
 
-    //auto triangleSystem = std::make_shared<SampleTriangleRenderingSystem<VulkanGraphicsBackend>>(
-    //    gfxProvider, gfxDevice, gfxSurfaceContext, trianglePass);
-    //builder.Configure([triangleSystem](SystemScheduler& scheduler) { scheduler.RegisterSystem(triangleSystem); });
+    SystemScheduler scheduler = builder.Build();
+    StepTimer timer{};
+    Event<Timestamp::duration> TimerCallback{};
 
-    //SystemScheduler scheduler = builder.Build();
-    //StepTimer timer{};
-    //Event<Timestamp::duration> TimerCallback{};
+    TimerCallback += [&timer, &scheduler](auto /* delta */) { scheduler.ExecuteIteration(timer.getTotalTime()); };
 
-    //TimerCallback += [&timer, &scheduler](auto /* delta */) { scheduler.ExecuteIteration(timer.getTotalTime()); };
+    while (!wndProvider->ShouldClose())
+    {
+        wndProvider->ProcessAllMessages();
+        timer.Tick(TimerCallback);
+    }
 
-    //while (!wndProvider->ShouldClose())
-    //{
-    //    wndProvider->ProcessAllMessages();
-    //    timer.Tick(TimerCallback);
-    //}
-
-    //gfxDevice->WaitForIdle();
+    gfxDevice->WaitForIdle();
 
     return 0;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes an issue with the fluency builder where the orchestrator was not using `RegisterSystemDependsOnAll`. This also makes the ecs graphics sample compile again.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
It doesn't compile. Or work. :)


**What is the new behavior (if this is a feature change)?**
It works. :)


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope!


**Other information**:
