### PR TITLE
Random debug symbol and shared from this UB fix.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,16 @@ option(NOVELRT_INSTALL "Generate installation targets" ON)
 option(NOVELRT_USE_STD_SPAN "Alias \"NovelRT::Utilities::Misc:Span\" to \"std::span\" instead of \"gsl::span\"." OFF)
 option(NOVELRT_BUILD_DEPS_WITH_MAX_CPU "Use all available CPU processing power when scaffolding/building the NovelRT internal dependences" OFF)
 
+# This has to be applied to ALL TARGETS under clang. This is the easiest way to do it to get the symbols to be consistent.
+# This is due to how we are using templates currently and how Clang elides debug information even in debug builds that makes it hard to understand anything.
+# As a side note, if you see this message, debugging with LLDB will be able to leverage this properly. GDB cannot. - Matt J.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_compile_options(
+        $<$<CXX_COMPILER_ID:Clang>:-fstandalone-debug>
+        $<$<CXX_COMPILER_ID:Clang>:-fno-eliminate-unused-debug-types>
+        $<$<CXX_COMPILER_ID:Clang>:-g3>
+    )
+endif()
 add_subdirectory(ThirdParty)
 
 add_subdirectory(Exceptions)

--- a/Graphics/Core/include/NovelRT/Graphics/GraphicsCmdList.hpp
+++ b/Graphics/Core/include/NovelRT/Graphics/GraphicsCmdList.hpp
@@ -64,7 +64,7 @@ namespace NovelRT::Graphics
     };
 
     template<typename TBackend>
-    class GraphicsCmdList : std::enable_shared_from_this<GraphicsCmdList<TBackend>>
+    class GraphicsCmdList
     {
     public:
         GraphicsCmdList() = delete;

--- a/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsCmdList.hpp
+++ b/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsCmdList.hpp
@@ -23,7 +23,7 @@ namespace NovelRT::Graphics
 {
     template<>
     class GraphicsCmdList<Vulkan::VulkanGraphicsBackend>
-        : std::enable_shared_from_this<GraphicsCmdList<Vulkan::VulkanGraphicsBackend>>
+        : public std::enable_shared_from_this<GraphicsCmdList<Vulkan::VulkanGraphicsBackend>>
     {
     private:
         std::shared_ptr<GraphicsDevice<Vulkan::VulkanGraphicsBackend>> _device;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A crazy bug fix. :)


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
Lol, no.


**What is the current behavior?** (You can also link to an open issue here)
LLDB doesn't work. Also CmdLists have some UB with their shared_from_this implementation which might be causing crashes.


**What is the new behavior (if this is a feature change)?**
LLDB now works. The UB is resolved.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Technically yes? but actually not most likely.


**Other information**:
