### PR TITLE
Add posing/sprite support to speakers

### DIFF
--- a/Ecs/Scripting/CMakeLists.txt
+++ b/Ecs/Scripting/CMakeLists.txt
@@ -7,24 +7,27 @@ NovelRTBuildSystem_DeclareModule(LIBRARY NovelRT::Ecs::Scripting
 
   SOURCES
     PRIVATE
+      StepSystems/BranchStepSystem.cpp
+      StepSystems/SpokenLineStepSystem.cpp
+
       DecisionTreeStateManager.cpp
       DecisionTreeStepSystem.cpp
       EcsScriptingBuilder.cpp
 
-      StepSystems/BranchStepSystem.cpp
-      StepSystems/SpokenLineStepSystem.cpp
-
   HEADERS
     PUBLIC
       include/NovelRT/Ecs/Scripting/Components/ActiveDecisionTree.hpp
+      include/NovelRT/Ecs/Scripting/Components/Branch.hpp
+      include/NovelRT/Ecs/Scripting/Components/BranchChoice.hpp
       include/NovelRT/Ecs/Scripting/Components/ContinueDecisionTree.hpp
-      include/NovelRT/Ecs/Scripting/Components/DecisionTreeChoice.hpp
+      include/NovelRT/Ecs/Scripting/Components/Pose.hpp
+      include/NovelRT/Ecs/Scripting/Components/SpokenLine.hpp
+
+      include/NovelRT/Ecs/Scripting/StepSystems/BranchStepSystem.hpp
+      include/NovelRT/Ecs/Scripting/StepSystems/SpokenLineStepSystem.hpp
 
       include/NovelRT/Ecs/Scripting/DecisionTreeLoadingSystem.hpp
       include/NovelRT/Ecs/Scripting/DecisionTreeStateManager.hpp
       include/NovelRT/Ecs/Scripting/DecisionTreeStepSystem.hpp
       include/NovelRT/Ecs/Scripting/EcsScriptingBuilder.hpp
-
-      include/NovelRT/Ecs/Scripting/StepSystems/BranchStepSystem.hpp
-      include/NovelRT/Ecs/Scripting/StepSystems/SpokenLineStepSystem.hpp
 )

--- a/Ecs/Scripting/StepSystems/SpokenLineStepSystem.cpp
+++ b/Ecs/Scripting/StepSystems/SpokenLineStepSystem.cpp
@@ -27,7 +27,8 @@ NovelRT::Ecs::Scripting::SpokenLineStepSystem::SpokenLineStepSystem(DecisionTree
     stateManager.RegisterStateHandler(
         [](auto& status, auto& catalogue, auto entityId)
         {
-            auto [spokenLineComponents, poseComponents] = catalogue.template GetComponentViews<Components::SpokenLine, Components::Pose>();
+            auto [spokenLineComponents, poseComponents] =
+                catalogue.template GetComponentViews<Components::SpokenLine, Components::Pose>();
 
             if (auto* spokenLine = dynamic_cast<NovelRT::Scripting::Statuses::SpokenLine*>(status.get()))
             {
@@ -37,7 +38,8 @@ NovelRT::Ecs::Scripting::SpokenLineStepSystem::SpokenLineStepSystem(DecisionTree
 
                 poseComponents.PushComponentUpdateInstruction(
                     entityId, Components::Pose{new std::string(spokenLine->GetPose()->Name),
-                                               new std::string(spokenLine->GetPose()->Sprite)});
+                                               new std::string(spokenLine->GetPose()->Sprite),
+                                               spokenLine->GetPose()->Position, spokenLine->GetPose()->Scale});
 
                 return true;
             }

--- a/Ecs/Scripting/StepSystems/SpokenLineStepSystem.cpp
+++ b/Ecs/Scripting/StepSystems/SpokenLineStepSystem.cpp
@@ -8,6 +8,7 @@
 
 #include <NovelRT/Ecs/Scripting/Components/ActiveDecisionTree.hpp>
 #include <NovelRT/Ecs/Scripting/Components/ContinueDecisionTree.hpp>
+#include <NovelRT/Ecs/Scripting/Components/Pose.hpp>
 #include <NovelRT/Ecs/Scripting/Components/SpokenLine.hpp>
 #include <NovelRT/Ecs/Scripting/DecisionTreeStateManager.hpp>
 #include <NovelRT/Ecs/Scripting/StepSystems/SpokenLineStepSystem.hpp>
@@ -26,13 +27,17 @@ NovelRT::Ecs::Scripting::SpokenLineStepSystem::SpokenLineStepSystem(DecisionTree
     stateManager.RegisterStateHandler(
         [](auto& status, auto& catalogue, auto entityId)
         {
-            auto spokenLineComponents = catalogue.template GetComponentView<Components::SpokenLine>();
+            auto [spokenLineComponents, poseComponents] = catalogue.template GetComponentViews<Components::SpokenLine, Components::Pose>();
 
             if (auto* spokenLine = dynamic_cast<NovelRT::Scripting::Statuses::SpokenLine*>(status.get()))
             {
                 spokenLineComponents.PushComponentUpdateInstruction(
                     entityId, Components::SpokenLine{new std::string(spokenLine->GetSpeaker()),
                                                      new std::string(spokenLine->GetText())});
+
+                poseComponents.PushComponentUpdateInstruction(
+                    entityId, Components::Pose{new std::string(spokenLine->GetPose()->Name),
+                                               new std::string(spokenLine->GetPose()->Sprite)});
 
                 return true;
             }
@@ -62,6 +67,7 @@ void NovelRT::Ecs::Scripting::SpokenLineStepSystem::Update(Timing::Timestamp /* 
             Continue(catalogue, entity, spokenLine->Continue());
         }
 
+        // Note: we intentionally leave the Pose component here
         spokenLineComponents.RemoveComponent(entity);
         continueComponents.RemoveComponent(entity);
     }

--- a/Ecs/Scripting/include/NovelRT/Ecs/Scripting/Components/Pose.hpp
+++ b/Ecs/Scripting/include/NovelRT/Ecs/Scripting/Components/Pose.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <string>
+
+namespace NovelRT::Ecs::Scripting::Components
+{
+    struct Pose
+    {
+        std::string* name;
+        std::string* sprite;
+
+        inline Pose& operator+=(const Pose& other)
+        {
+            delete name;
+            delete sprite;
+
+            *this = other;
+            return *this;
+        }
+
+        [[nodiscard]] inline bool operator==(const Pose& other) const noexcept
+        {
+            return name == other.name && sprite == other.sprite;
+        }
+    };
+}

--- a/Ecs/Scripting/include/NovelRT/Ecs/Scripting/Components/Pose.hpp
+++ b/Ecs/Scripting/include/NovelRT/Ecs/Scripting/Components/Pose.hpp
@@ -3,6 +3,8 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
+#include <NovelRT/Maths/GeoVector2F.hpp>
+
 #include <string>
 
 namespace NovelRT::Ecs::Scripting::Components
@@ -11,6 +13,8 @@ namespace NovelRT::Ecs::Scripting::Components
     {
         std::string* name;
         std::string* sprite;
+        NovelRT::Maths::GeoVector2F position;
+        NovelRT::Maths::GeoVector2F scale;
 
         inline Pose& operator+=(const Pose& other)
         {
@@ -23,7 +27,8 @@ namespace NovelRT::Ecs::Scripting::Components
 
         [[nodiscard]] inline bool operator==(const Pose& other) const noexcept
         {
-            return name == other.name && sprite == other.sprite;
+            // TODO: is comparing the position/scale by value correct here?
+            return name == other.name && sprite == other.sprite && position == other.position && scale == other.scale;
         }
     };
 }

--- a/Ecs/Scripting/include/NovelRT/Ecs/Scripting/Components/Pose.hpp
+++ b/Ecs/Scripting/include/NovelRT/Ecs/Scripting/Components/Pose.hpp
@@ -11,10 +11,10 @@ namespace NovelRT::Ecs::Scripting::Components
 {
     struct Pose
     {
-        std::string* name;
-        std::string* sprite;
-        NovelRT::Maths::GeoVector2F position;
-        NovelRT::Maths::GeoVector2F scale;
+        std::string* name = nullptr;
+        std::string* sprite = nullptr;
+        NovelRT::Maths::GeoVector2F position{0, 0};
+        NovelRT::Maths::GeoVector2F scale{1, 1};
 
         inline Pose& operator+=(const Pose& other)
         {
@@ -27,7 +27,6 @@ namespace NovelRT::Ecs::Scripting::Components
 
         [[nodiscard]] inline bool operator==(const Pose& other) const noexcept
         {
-            // TODO: is comparing the position/scale by value correct here?
             return name == other.name && sprite == other.sprite && position == other.position && scale == other.scale;
         }
     };

--- a/Ecs/Scripting/include/NovelRT/Ecs/Scripting/EcsScriptingBuilder.hpp
+++ b/Ecs/Scripting/include/NovelRT/Ecs/Scripting/EcsScriptingBuilder.hpp
@@ -7,7 +7,6 @@
 
 #include <NovelRT/Ecs/Scripting/Components/ActiveDecisionTree.hpp>
 #include <NovelRT/Ecs/Scripting/Components/ContinueDecisionTree.hpp>
-#include <NovelRT/Ecs/Scripting/Components/DecisionTreeChoice.hpp>
 #include <NovelRT/Ecs/Scripting/DecisionTreeStateManager.hpp>
 
 #include <NovelRT/Scripting/ScriptManager.hpp>

--- a/Samples/Scripting/REPL/Resources/sample.lua
+++ b/Samples/Scripting/REPL/Resources/sample.lua
@@ -1,4 +1,12 @@
 speaker "narrator"
+speaker "character" {
+  pose = "happy",
+  poses = {
+    happy = { sprite = "happy.png" },
+    angry = { sprite = "angry.png" },
+    sad = { sprite = "sad.png" }
+  }
+}
 
 while true do
   narrator
@@ -13,3 +21,9 @@ while true do
     break
   end
 end
+
+character "Wowee!"
+character:pose "sad"
+character "I'm sad now."
+character:pose "angry"
+character "Why would you make me angry?!"

--- a/Samples/Scripting/REPL/Resources/sample.lua
+++ b/Samples/Scripting/REPL/Resources/sample.lua
@@ -4,7 +4,9 @@ speaker "character" {
   poses = {
     happy = { sprite = "happy.png" },
     angry = { sprite = "angry.png" },
-    sad = { sprite = "sad.png" }
+    angry_left = { sprite = "angry.png", position = { -100, 0 } },
+    sad = { sprite = "sad.png", scale = { 1, 1 } },
+    sad_flip = { sprite = "sad.png", scale = { -1, 1 } }
   }
 }
 

--- a/Samples/Scripting/REPL/main.cpp
+++ b/Samples/Scripting/REPL/main.cpp
@@ -53,7 +53,15 @@ int main()
     {
         if (auto* spokenLine = dynamic_cast<NovelRT::Scripting::Statuses::SpokenLine*>(state.get()))
         {
-            std::cout << spokenLine->GetSpeaker() << ": " << spokenLine->GetText();
+            if (spokenLine->GetPose().has_value())
+            {
+                auto pose = spokenLine->GetPose().value();
+                std::cout << spokenLine->GetSpeaker() << " [" << pose.Name << " - " << pose.Sprite << "]: " << spokenLine->GetText();
+            }
+            else
+            {
+                std::cout << spokenLine->GetSpeaker() << ": " << spokenLine->GetText();
+            }
             std::cin.get();
             state = spokenLine->Continue();
         }

--- a/Scripting/Core/Bindings/Fabulist/Speaker.cpp
+++ b/Scripting/Core/Bindings/Fabulist/Speaker.cpp
@@ -26,7 +26,7 @@ struct SpeakerInfo
 int FieldTypeError(lua_State* L, int arg, const char* field, const char* tname)
 {
     // This logic is the same as luaL_typeerror
-    const char *typearg;
+    const char* typearg;
     if (luaL_getmetafield(L, arg, "__name") == LUA_TSTRING)
     {
         typearg = lua_tostring(L, -1);
@@ -74,7 +74,8 @@ std::unordered_map<std::string, PoseInfo> ReadPoses(lua_State* L, int arg, int i
 
         if (lua_type(L, -2) != LUA_TSTRING)
         {
-            FieldTypeError(L, arg, lua_pushfstring(L, "poses.%s", luaL_tolstring(L, -2, nullptr)), lua_typename(L, LUA_TTABLE));
+            FieldTypeError(L, arg, lua_pushfstring(L, "poses.%s", luaL_tolstring(L, -2, nullptr)),
+                           lua_typename(L, LUA_TTABLE));
         }
 
         std::size_t length;
@@ -106,7 +107,6 @@ int SetSpeakerAdditionalProps(lua_State* L)
         return FieldTypeError(L, 1, "poses", lua_typename(L, LUA_TTABLE));
     }
 
-
     lua_getfield(L, 1, "pose");
     if (lua_type(L, -1) == LUA_TSTRING)
     {
@@ -114,7 +114,7 @@ int SetSpeakerAdditionalProps(lua_State* L)
         const char* p = luaL_tolstring(L, -1, &pLength);
         std::string pose(p, pLength);
 
-        if(auto search = it->poses.find(pose); search == it->poses.end())
+        if (auto search = it->poses.find(pose); search == it->poses.end())
         {
             const char* msg = lua_pushfstring(L, "bad field %q (unknown pose %q)", "default_pose", p);
             return luaL_argerror(L, 1, msg);
@@ -176,11 +176,7 @@ int ProduceSpeakerLine(lua_State* L)
     if (it->activePose.has_value())
     {
         auto info = it->poses.at(it->activePose.value());
-        pose = NovelRT::Scripting::Statuses::SpokenLine::Pose
-        {
-            .Name = it->activePose.value(),
-            .Sprite = info.sprite
-        };
+        pose = NovelRT::Scripting::Statuses::SpokenLine::Pose{.Name = it->activePose.value(), .Sprite = info.sprite};
     }
 
     auto* data = new NovelRT::Scripting::Statuses::SpokenLine(it->name, pose, text, L, manager->shared_from_this());
@@ -196,7 +192,7 @@ int SetSpeakerPose(lua_State* L)
     const char* p = luaL_checklstring(L, 2, &pLength);
     std::string pose(p, pLength);
 
-    if(auto search = it->poses.find(pose); search == it->poses.end())
+    if (auto search = it->poses.find(pose); search == it->poses.end())
     {
         const char* msg = lua_pushfstring(L, "unknown pose %q", p);
         return luaL_argerror(L, 2, msg);

--- a/Scripting/Core/Bindings/Fabulist/Speaker.cpp
+++ b/Scripting/Core/Bindings/Fabulist/Speaker.cpp
@@ -14,6 +14,10 @@
 struct PoseInfo
 {
     std::string sprite;
+    double xPos;
+    double yPos;
+    double xScale;
+    double yScale;
 };
 
 struct SpeakerInfo
@@ -49,14 +53,52 @@ PoseInfo ReadPoseInfo(lua_State* L, int arg, int idx, const char* name)
     idx = lua_absindex(L, idx);
     PoseInfo result;
 
-    if (lua_getfield(L, idx, "sprite") != LUA_TSTRING)
+    if (lua_getfield(L, idx, "sprite") == LUA_TSTRING)
+    {
+        std::size_t spriteLength;
+        const char* sprite = lua_tolstring(L, -1, &spriteLength);
+        result.sprite = std::string(sprite, spriteLength);
+        lua_pop(L, 1);
+    }
+    else if (!lua_isnoneornil(L, -1))
     {
         FieldTypeError(L, arg, lua_pushfstring(L, "poses.%s.sprite", name), lua_typename(L, LUA_TSTRING));
     }
 
-    std::size_t spriteLength;
-    const char* sprite = lua_tolstring(L, -1, &spriteLength);
-    result.sprite = std::string(sprite, spriteLength);
+    if (lua_getfield(L, idx, "position") == LUA_TTABLE)
+    {
+        if (lua_rawgeti(L, -1, 1) != LUA_TNUMBER)
+            FieldTypeError(L, arg, lua_pushfstring(L, "poses.%s.position[1]", name), lua_typename(L, LUA_TNUMBER));
+        result.xPos = lua_tonumber(L, -1);
+        lua_pop(L, 1);
+
+        if (lua_rawgeti(L, -1, 2) != LUA_TNUMBER)
+            FieldTypeError(L, arg, lua_pushfstring(L, "poses.%s.position[2]", name), lua_typename(L, LUA_TNUMBER));
+        result.yPos = lua_tonumber(L, -1);
+        lua_pop(L, 2);
+    }
+    else if (!lua_isnoneornil(L, -1))
+    {
+        FieldTypeError(L, arg, lua_pushfstring(L, "poses.%s.position", name), lua_typename(L, LUA_TNUMBER));
+    }
+
+    if (lua_getfield(L, idx, "scale") == LUA_TTABLE)
+    {
+        if (lua_rawgeti(L, -1, 1) != LUA_TNUMBER)
+            FieldTypeError(L, arg, lua_pushfstring(L, "poses.%s.scale[1]", name), lua_typename(L, LUA_TNUMBER));
+        result.xScale = lua_tonumber(L, -1);
+        lua_pop(L, 1);
+
+        if (lua_rawgeti(L, -1, 2) != LUA_TNUMBER)
+            FieldTypeError(L, arg, lua_pushfstring(L, "poses.%s.scale[2]", name), lua_typename(L, LUA_TNUMBER));
+        result.yScale = lua_tonumber(L, -1);
+        lua_pop(L, 2);
+    }
+    else if (!lua_isnoneornil(L, -1))
+    {
+        FieldTypeError(L, arg, lua_pushfstring(L, "poses.%s.scale", name), lua_typename(L, LUA_TNUMBER));
+    }
+
     return result;
 }
 
@@ -95,8 +137,7 @@ int SetSpeakerAdditionalProps(lua_State* L)
     SpeakerInfo* it = static_cast<SpeakerInfo*>(lua_touserdata(L, lua_upvalueindex(1)));
     luaL_checktype(L, 1, LUA_TTABLE);
 
-    lua_getfield(L, 1, "poses");
-    if (lua_type(L, -1) == LUA_TTABLE)
+    if (lua_getfield(L, 1, "poses") == LUA_TTABLE)
     {
         it->poses = ReadPoses(L, 1, -1);
         if (it->poses.size() > 0)
@@ -107,8 +148,7 @@ int SetSpeakerAdditionalProps(lua_State* L)
         return FieldTypeError(L, 1, "poses", lua_typename(L, LUA_TTABLE));
     }
 
-    lua_getfield(L, 1, "pose");
-    if (lua_type(L, -1) == LUA_TSTRING)
+    if (lua_getfield(L, 1, "pose") == LUA_TSTRING)
     {
         std::size_t pLength;
         const char* p = luaL_tolstring(L, -1, &pLength);
@@ -176,7 +216,11 @@ int ProduceSpeakerLine(lua_State* L)
     if (it->activePose.has_value())
     {
         auto info = it->poses.at(it->activePose.value());
-        pose = NovelRT::Scripting::Statuses::SpokenLine::Pose{.Name = it->activePose.value(), .Sprite = info.sprite};
+        pose = NovelRT::Scripting::Statuses::SpokenLine::Pose{
+            .Name = it->activePose.value(),
+            .Sprite = info.sprite,
+            .Position = NovelRT::Maths::GeoVector2F{static_cast<float>(info.xPos), static_cast<float>(info.yPos)},
+            .Scale = NovelRT::Maths::GeoVector2F{static_cast<float>(info.xScale), static_cast<float>(info.yScale)}};
     }
 
     auto* data = new NovelRT::Scripting::Statuses::SpokenLine(it->name, pose, text, L, manager->shared_from_this());

--- a/Scripting/Core/Bindings/Fabulist/Speaker.cpp
+++ b/Scripting/Core/Bindings/Fabulist/Speaker.cpp
@@ -14,8 +14,8 @@
 struct PoseInfo
 {
     std::string sprite;
-    double xPos;
-    double yPos;
+    double xPos = 0;
+    double yPos = 0;
     double xScale = 1;
     double yScale = 1;
 };

--- a/Scripting/Core/Bindings/Fabulist/Speaker.cpp
+++ b/Scripting/Core/Bindings/Fabulist/Speaker.cpp
@@ -16,8 +16,8 @@ struct PoseInfo
     std::string sprite;
     double xPos;
     double yPos;
-    double xScale;
-    double yScale;
+    double xScale = 1;
+    double yScale = 1;
 };
 
 struct SpeakerInfo

--- a/Scripting/Core/Bindings/Fabulist/Speaker.cpp
+++ b/Scripting/Core/Bindings/Fabulist/Speaker.cpp
@@ -7,10 +7,128 @@
 
 #include <Bindings/Bindings.hpp>
 
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+struct PoseInfo
+{
+    std::string sprite;
+};
+
 struct SpeakerInfo
 {
     std::string name;
+    std::optional<std::string> activePose;
+    std::unordered_map<std::string, PoseInfo> poses;
 };
+
+int FieldTypeError(lua_State* L, int arg, const char* field, const char* tname)
+{
+    // This logic is the same as luaL_typeerror
+    const char *typearg;
+    if (luaL_getmetafield(L, arg, "__name") == LUA_TSTRING)
+    {
+        typearg = lua_tostring(L, -1);
+    }
+    else if (lua_type(L, arg) == LUA_TLIGHTUSERDATA)
+    {
+        typearg = "light userdata";
+    }
+    else
+    {
+        typearg = luaL_typename(L, arg);
+    }
+
+    const char* msg = lua_pushfstring(L, "bad field %q (%s expected, got %s)", field, tname, typearg);
+    return luaL_argerror(L, arg, msg);
+}
+
+PoseInfo ReadPoseInfo(lua_State* L, int arg, int idx, const char* name)
+{
+    idx = lua_absindex(L, idx);
+    PoseInfo result;
+
+    if (lua_getfield(L, idx, "sprite") != LUA_TSTRING)
+    {
+        FieldTypeError(L, arg, lua_pushfstring(L, "poses.%s.sprite", name), lua_typename(L, LUA_TSTRING));
+    }
+
+    std::size_t spriteLength;
+    const char* sprite = lua_tolstring(L, -1, &spriteLength);
+    result.sprite = std::string(sprite, spriteLength);
+    return result;
+}
+
+std::unordered_map<std::string, PoseInfo> ReadPoses(lua_State* L, int arg, int idx)
+{
+    idx = lua_absindex(L, idx);
+
+    std::unordered_map<std::string, PoseInfo> result;
+
+    lua_pushnil(L);
+    while (lua_next(L, idx) != 0)
+    {
+        // N.B. we want to keep track of the stack position so that the body of the loop doesn't affect our iteration
+        int top = lua_gettop(L);
+
+        if (lua_type(L, -2) != LUA_TSTRING)
+        {
+            FieldTypeError(L, arg, lua_pushfstring(L, "poses.%s", luaL_tolstring(L, -2, nullptr)), lua_typename(L, LUA_TTABLE));
+        }
+
+        std::size_t length;
+        const char* key = lua_tolstring(L, -2, &length);
+        result[std::string(key, length)] = ReadPoseInfo(L, arg, -1, key);
+
+        // Restore the stack and pop the value so that we can continue iterating.
+        lua_settop(L, top);
+        lua_pop(L, 1);
+    }
+
+    return result;
+}
+
+int SetSpeakerAdditionalProps(lua_State* L)
+{
+    SpeakerInfo* it = static_cast<SpeakerInfo*>(lua_touserdata(L, lua_upvalueindex(1)));
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    lua_getfield(L, 1, "poses");
+    if (lua_type(L, -1) == LUA_TTABLE)
+    {
+        it->poses = ReadPoses(L, 1, -1);
+        if (it->poses.size() > 0)
+            it->activePose = it->poses.begin()->first;
+    }
+    else if (!lua_isnoneornil(L, -1))
+    {
+        return FieldTypeError(L, 1, "poses", lua_typename(L, LUA_TTABLE));
+    }
+
+
+    lua_getfield(L, 1, "pose");
+    if (lua_type(L, -1) == LUA_TSTRING)
+    {
+        std::size_t pLength;
+        const char* p = luaL_tolstring(L, -1, &pLength);
+        std::string pose(p, pLength);
+
+        if(auto search = it->poses.find(pose); search == it->poses.end())
+        {
+            const char* msg = lua_pushfstring(L, "bad field %q (unknown pose %q)", "default_pose", p);
+            return luaL_argerror(L, 1, msg);
+        }
+
+        it->activePose = pose;
+    }
+    else if (!lua_isnoneornil(L, -1))
+    {
+        return FieldTypeError(L, 1, "pose", lua_typename(L, LUA_TSTRING));
+    }
+
+    return 1;
+}
 
 int CreateSpeaker(lua_State* L)
 {
@@ -19,10 +137,15 @@ int CreateSpeaker(lua_State* L)
     luaL_setmetatable(L, "Speaker");
 
     // Because we're creating objects in memory we don't own, we need to use placement new.
-    new (buffer) SpeakerInfo{name};
+    new (buffer) SpeakerInfo{name, std::nullopt, {}};
 
+    // Associate the speaker with the global by that name
+    lua_pushvalue(L, -1);
     lua_setglobal(L, name);
 
+    // Allow the user to configure the speaker
+    lua_pushvalue(L, -1);
+    lua_pushcclosure(L, SetSpeakerAdditionalProps, 1);
     return 1;
 }
 
@@ -49,12 +172,59 @@ int ProduceSpeakerLine(lua_State* L)
     lua_rawget(L, LUA_REGISTRYINDEX);
     auto* manager = static_cast<NovelRT::Scripting::ScriptManager*>(lua_touserdata(L, -1));
 
-    auto* data = new NovelRT::Scripting::Statuses::SpokenLine(it->name, text, L, manager->shared_from_this());
+    std::optional<NovelRT::Scripting::Statuses::SpokenLine::Pose> pose = std::nullopt;
+    if (it->activePose.has_value())
+    {
+        auto info = it->poses.at(it->activePose.value());
+        pose = NovelRT::Scripting::Statuses::SpokenLine::Pose
+        {
+            .Name = it->activePose.value(),
+            .Sprite = info.sprite
+        };
+    }
+
+    auto* data = new NovelRT::Scripting::Statuses::SpokenLine(it->name, pose, text, L, manager->shared_from_this());
     lua_pushlightuserdata(L, data);
     return lua_yieldk(L, 1, 0, ProduceSpeakerLine_Cont);
 }
 
+int SetSpeakerPose(lua_State* L)
+{
+    SpeakerInfo* it = static_cast<SpeakerInfo*>(luaL_checkudata(L, 1, "Speaker"));
+
+    std::size_t pLength;
+    const char* p = luaL_checklstring(L, 2, &pLength);
+    std::string pose(p, pLength);
+
+    if(auto search = it->poses.find(pose); search == it->poses.end())
+    {
+        const char* msg = lua_pushfstring(L, "unknown pose %q", p);
+        return luaL_argerror(L, 2, msg);
+    }
+
+    it->activePose = pose;
+    return 0;
+}
+
+int IndexSpeaker(lua_State* L)
+{
+    luaL_checkudata(L, 1, "Speaker");
+
+    std::size_t idxLength;
+    const char* idx = luaL_checklstring(L, 2, &idxLength);
+    std::string index(idx, idxLength);
+
+    if (index == "pose")
+    {
+        lua_pushcfunction(L, SetSpeakerPose);
+        return 1;
+    }
+
+    return 0;
+}
+
 luaL_Reg SpeakerFuncs[]{
+    {"__index", IndexSpeaker},
     {"__call", ProduceSpeakerLine},
     {"__gc", CleanupSpeaker},
     {nullptr, nullptr},

--- a/Scripting/Core/CMakeLists.txt
+++ b/Scripting/Core/CMakeLists.txt
@@ -3,6 +3,7 @@ include(NovelRTBuildSystem)
 NovelRTBuildSystem_DeclareModule(LIBRARY NovelRT::Scripting::Core
   DEPENDS
     NovelRT::Exceptions
+    NovelRT::Maths
     lua::lua
 
   SOURCES

--- a/Scripting/Core/Statuses/SpokenLine.cpp
+++ b/Scripting/Core/Statuses/SpokenLine.cpp
@@ -17,7 +17,10 @@ NovelRT::Scripting::Statuses::SpokenLine::SpokenLine(const std::string& speaker,
                                                      const std::string& text,
                                                      lua_State* L,
                                                      const std::shared_ptr<ScriptManager>& manager)
-    : DecisionTreeStatus(L, std::move(manager)), _speaker(std::move(speaker)), _pose(std::move(pose)), _text(std::move(text))
+    : DecisionTreeStatus(L, std::move(manager)),
+      _speaker(std::move(speaker)),
+      _pose(std::move(pose)),
+      _text(std::move(text))
 {
 }
 

--- a/Scripting/Core/Statuses/SpokenLine.cpp
+++ b/Scripting/Core/Statuses/SpokenLine.cpp
@@ -13,16 +13,22 @@
 // clang-format on
 
 NovelRT::Scripting::Statuses::SpokenLine::SpokenLine(const std::string& speaker,
+                                                     const std::optional<const Pose>& pose,
                                                      const std::string& text,
                                                      lua_State* L,
                                                      const std::shared_ptr<ScriptManager>& manager)
-    : DecisionTreeStatus(L, std::move(manager)), _speaker(std::move(speaker)), _text(std::move(text))
+    : DecisionTreeStatus(L, std::move(manager)), _speaker(std::move(speaker)), _pose(std::move(pose)), _text(std::move(text))
 {
 }
 
 const std::string NovelRT::Scripting::Statuses::SpokenLine::GetSpeaker() const
 {
     return _speaker;
+}
+
+auto NovelRT::Scripting::Statuses::SpokenLine::GetPose() const -> const std::optional<const Pose>
+{
+    return _pose;
 }
 
 const std::string NovelRT::Scripting::Statuses::SpokenLine::GetText() const

--- a/Scripting/Core/include/NovelRT/Scripting/ScriptManager.hpp
+++ b/Scripting/Core/include/NovelRT/Scripting/ScriptManager.hpp
@@ -3,6 +3,7 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
+#include <cstdint>
 #include <memory>
 #include <span>
 

--- a/Scripting/Core/include/NovelRT/Scripting/Statuses/SpokenLine.hpp
+++ b/Scripting/Core/include/NovelRT/Scripting/Statuses/SpokenLine.hpp
@@ -7,29 +7,41 @@
 #include <NovelRT/Scripting/ScriptManager.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace NovelRT::Scripting::Statuses
 {
     class SpokenLine final : public DecisionTreeStatus
     {
+    public:
+        struct Pose
+        {
+            std::string Name;
+            std::string Sprite;
+        };
+
+    private:
         std::string _speaker;
+        std::optional<const Pose> _pose;
         std::string _text;
 
     public:
         explicit SpokenLine(const std::string& speaker,
+                            const std::optional<const Pose>& pose,
                             const std::string& text,
                             lua_State* L,
                             const std::shared_ptr<ScriptManager>& manager);
         virtual ~SpokenLine() override = default;
 
         SpokenLine(const SpokenLine&) = delete;
-        SpokenLine(SpokenLine&&) = default;
+        SpokenLine(SpokenLine&&) = delete;
 
         SpokenLine& operator=(const SpokenLine&) = delete;
-        SpokenLine& operator=(SpokenLine&&) = default;
+        SpokenLine& operator=(SpokenLine&&) = delete;
 
         const std::string GetSpeaker() const;
+        const std::optional<const Pose> GetPose() const;
         const std::string GetText() const;
 
         std::unique_ptr<DecisionTreeStatus> Continue();

--- a/Scripting/Core/include/NovelRT/Scripting/Statuses/SpokenLine.hpp
+++ b/Scripting/Core/include/NovelRT/Scripting/Statuses/SpokenLine.hpp
@@ -3,6 +3,7 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
+#include <NovelRT/Maths/GeoVector2F.hpp>
 #include <NovelRT/Scripting/DecisionTreeStatus.hpp>
 #include <NovelRT/Scripting/ScriptManager.hpp>
 
@@ -19,6 +20,8 @@ namespace NovelRT::Scripting::Statuses
         {
             std::string Name;
             std::string Sprite;
+            NovelRT::Maths::GeoVector2F Position;
+            NovelRT::Maths::GeoVector2F Scale;
         };
 
     private:


### PR DESCRIPTION
Part three of #629.

This includes the character posing/sprite extensions necessary to decide how a character should appear on screen. Right now, the only field we expose is the sprite to use. This could easily be expanded to include more as necessary (e.g. position, scaling, tinting, etc.)