### PR TITLE
disable clang-format entirely for now

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -18,8 +18,8 @@ jobs:
 
       - uses: novelrt/setup-cpp@v1
 
-      - name: Install modern clang-format
-        shell: bash
+      - name: Preinstall dependencies
+        if: ${{ runner.os == 'Linux' }}
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo tee /etc/apt/sources.list.d/llvm-toolchain.list <<EOF
@@ -32,22 +32,6 @@ jobs:
           deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main
           deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main
           EOF
-          sudo apt-get update
-          sudo apt-get install clang-format-21
-
-      - name: Check formatting via clang-format
-        shell: bash
-        run: |
-          clang-format --version
-          buildDir="$(pwd)/build"
-          legacySrcDir="$(pwd)/LegacySrc"
-          artefactsDir="$(pwd)/artefacts"
-          find "$(pwd)" \( -path "$buildDir" -o -path "$legacySrcDir" -o -path "$artefactsDir" \) -prune -o \
-            \( -name '*.cpp' -o -name '*.hpp' \) -exec clang-format-21 -i --verbose --dry-run --Werror --style=file '{}' \+
-
-      - name: Preinstall dependencies
-        if: ${{ runner.os == 'Linux' }}
-        run: |
           sudo apt-get update
           sudo apt-get install libglm-dev cmake libxcb-dri3-0 libxcb-present0 \
             libpciaccess0 libpng-dev libxcb-keysyms1-dev libxcb-dri3-dev \
@@ -69,7 +53,7 @@ jobs:
           version: 1.4.313.0
 
       - name: Generate build system
-        run: cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/clang-21 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-21 -DNOVELRT_CLANG_TIDY=ON -DNOVELRT_CLANG_TIDY_PATH=/usr/bin/clang-tidy-21 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        run: cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: Build NovelRT with Clang-Tidy
         run: cmake --build build --config Debug --parallel


### PR DESCRIPTION
"I can't be fucked trying to figure out every little fucking thing right now"

clang-format/clang-tidy is being a pain in the arse and it's causing more build failures than it's actually resolving.