### PR TITLE
Add moveOnlyFunction and change builder constructors to be move only

### DIFF
--- a/Ecs/Core/include/NovelRT/Ecs/EcsDefaultsBuilder.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/EcsDefaultsBuilder.hpp
@@ -23,8 +23,8 @@ namespace NovelRT::Ecs
 
     public:
         // Intentionally disallow moving/copying
-        EcsDefaultsBuilder(const EcsDefaultsBuilder& other) = default;
-        EcsDefaultsBuilder& operator=(const EcsDefaultsBuilder& other) = default;
+        EcsDefaultsBuilder(const EcsDefaultsBuilder& other) = delete;
+        EcsDefaultsBuilder& operator=(const EcsDefaultsBuilder& other) = delete;
         EcsDefaultsBuilder(EcsDefaultsBuilder&& other) = default;
         EcsDefaultsBuilder& operator=(EcsDefaultsBuilder&& other) = default;
         ~EcsDefaultsBuilder() = default;

--- a/Ecs/Core/include/NovelRT/Ecs/SystemSchedulerBuilder.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemSchedulerBuilder.hpp
@@ -4,6 +4,7 @@
 // for more information.
 
 #include <NovelRT/Ecs/SystemScheduler.hpp>
+#include <NovelRT/Utilities/MoveOnlyFunction.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -21,9 +22,14 @@ namespace NovelRT::Ecs
     {
     private:
         std::optional<uint32_t> _threadCount;
-        std::vector<std::function<void(SystemScheduler&)>> _configureCallbacks;
+        std::vector<NovelRT::Utilities::MoveOnlyFunction<void(SystemScheduler&)>> _configureCallbacks;
 
     public:
+        SystemSchedulerBuilder() = default;
+        SystemSchedulerBuilder(const SystemSchedulerBuilder& other) = delete;
+        SystemSchedulerBuilder& operator=(const SystemSchedulerBuilder& other) = delete;
+        SystemSchedulerBuilder(SystemSchedulerBuilder&& other) = default;
+        SystemSchedulerBuilder& operator=(SystemSchedulerBuilder&& other) = default;
         /**
          * @brief Defines how many worker threads should be configured for this ECS instance.
          *

--- a/Ecs/Core/include/NovelRT/Ecs/SystemSchedulerBuilder.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemSchedulerBuilder.hpp
@@ -3,8 +3,8 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
-#include <NovelRT/Ecs/SystemScheduler.hpp>
 #include <NovelRT/Utilities/MoveOnlyFunction.hpp>
+#include <NovelRT/Ecs/SystemScheduler.hpp>
 
 #include <cstdint>
 #include <functional>
@@ -52,7 +52,7 @@ namespace NovelRT::Ecs
         T& Configure(T&& configure) noexcept
         {
             auto& fn = _configureCallbacks.emplace_back(std::forward<T>(configure));
-            return *(fn.template target<T>());
+            return *(fn.template Target<T>());
         }
 
         /**

--- a/Ecs/Graphics/include/NovelRT/Ecs/Graphics/EcsGraphicsBuilder.hpp
+++ b/Ecs/Graphics/include/NovelRT/Ecs/Graphics/EcsGraphicsBuilder.hpp
@@ -58,8 +58,8 @@ namespace NovelRT::Ecs::Graphics
         friend EcsGraphicsBuilder<T>& AddGraphics(SystemSchedulerBuilder&);
 
     public:
-        EcsGraphicsBuilder(const EcsGraphicsBuilder& other) = default;
-        EcsGraphicsBuilder& operator=(const EcsGraphicsBuilder& other) = default;
+        EcsGraphicsBuilder(const EcsGraphicsBuilder& other) = delete;
+        EcsGraphicsBuilder& operator=(const EcsGraphicsBuilder& other) = delete;
         EcsGraphicsBuilder(EcsGraphicsBuilder&& other) = default;
         EcsGraphicsBuilder& operator=(EcsGraphicsBuilder&& other) = default;
         ~EcsGraphicsBuilder() = default;

--- a/Ecs/Scripting/include/NovelRT/Ecs/Scripting/EcsScriptingBuilder.hpp
+++ b/Ecs/Scripting/include/NovelRT/Ecs/Scripting/EcsScriptingBuilder.hpp
@@ -39,8 +39,8 @@ namespace NovelRT::Ecs::Scripting
         friend EcsScriptingBuilder& AddScripting(SystemSchedulerBuilder&);
 
     public:
-        EcsScriptingBuilder(const EcsScriptingBuilder& other) = default;
-        EcsScriptingBuilder& operator=(const EcsScriptingBuilder& other) = default;
+        EcsScriptingBuilder(const EcsScriptingBuilder& other) = delete;
+        EcsScriptingBuilder& operator=(const EcsScriptingBuilder& other) = delete;
         EcsScriptingBuilder(EcsScriptingBuilder&& other) = default;
         EcsScriptingBuilder& operator=(EcsScriptingBuilder&& other) = default;
         ~EcsScriptingBuilder() = default;

--- a/Utilities/CMakeLists.txt
+++ b/Utilities/CMakeLists.txt
@@ -23,6 +23,7 @@ NovelRTBuildSystem_DeclareModule(LIBRARY NovelRT::Utilities
       include/NovelRT/Utilities/Paths.hpp
       include/NovelRT/Utilities/Span.hpp
       include/NovelRT/Utilities/Strings.hpp
+      include/NovelRT/Utilities/MoveOnlyFunction.hpp
 
   LINK_LIBRARIES
     PUBLIC

--- a/Utilities/CMakeLists.txt
+++ b/Utilities/CMakeLists.txt
@@ -18,12 +18,12 @@ NovelRTBuildSystem_DeclareModule(LIBRARY NovelRT::Utilities
       include/NovelRT/Utilities/Lazy.hpp
       include/NovelRT/Utilities/Macros.hpp
       include/NovelRT/Utilities/Memory.hpp
+      include/NovelRT/Utilities/MoveOnlyFunction.hpp
       include/NovelRT/Utilities/ObjectPool.hpp
       include/NovelRT/Utilities/Operators.hpp
       include/NovelRT/Utilities/Paths.hpp
       include/NovelRT/Utilities/Span.hpp
       include/NovelRT/Utilities/Strings.hpp
-      include/NovelRT/Utilities/MoveOnlyFunction.hpp
 
   LINK_LIBRARIES
     PUBLIC

--- a/Utilities/include/NovelRT/Utilities/MoveOnlyFunction.hpp
+++ b/Utilities/include/NovelRT/Utilities/MoveOnlyFunction.hpp
@@ -3,6 +3,8 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
+#include <functional>
+
 namespace NovelRT::Utilities
 {
     template<typename...>

--- a/Utilities/include/NovelRT/Utilities/MoveOnlyFunction.hpp
+++ b/Utilities/include/NovelRT/Utilities/MoveOnlyFunction.hpp
@@ -15,15 +15,15 @@ namespace NovelRT::Utilities
         struct Callable
         {
             virtual ~Callable() = default;
-            virtual R call(Args...) = 0;
-            virtual const void* target() = 0;
+            virtual R Call(Args...) = 0;
+            virtual const void* Target() = 0;
         };
         template <typename F>
         struct SpecificCallable : Callable
         {
             template <typename T, typename = std::enable_if_t<!std::is_same_v<std::decay_t<T>, SpecificCallable>>>
             explicit SpecificCallable(T&& func) : func(std::forward<T>(func)) {};
-        R call(Args... args) override
+        R Call(Args... args) override
             {
                 if constexpr(std::is_void_v<R>)
                 { std::invoke(func, std::forward<Args>(args)...); }
@@ -31,7 +31,7 @@ namespace NovelRT::Utilities
                 { return std::invoke(func, std::forward<Args>(args)...); }
             }
             
-            const void* target() override
+            const void* Target() override
             {
                 return std::addressof(func);
             }
@@ -54,14 +54,14 @@ namespace NovelRT::Utilities
 
         R operator()(Args... args) 
         {
-            return _ptr->call(std::forward<Args>(args)...);
+            return _ptr->Call(std::forward<Args>(args)...);
             
         }; 
 
         template <typename F>
-        F* target() noexcept
+        F* Target() noexcept
         {
-            return reinterpret_cast<F*>(const_cast<void*>(_ptr->target()));
+            return reinterpret_cast<F*>(const_cast<void*>(_ptr->Target()));
         };
 
     };

--- a/Utilities/include/NovelRT/Utilities/MoveOnlyFunction.hpp
+++ b/Utilities/include/NovelRT/Utilities/MoveOnlyFunction.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+namespace NovelRT::Utilities
+{
+    template<typename...>
+    class MoveOnlyFunction;
+
+    template <typename R, typename... Args>
+    class MoveOnlyFunction<R(Args...)>
+    {
+    private:
+        struct Callable
+        {
+            virtual ~Callable() = default;
+            virtual R call(Args...) = 0;
+            virtual const void* target() = 0;
+        };
+        template <typename F>
+        struct SpecificCallable : Callable
+        {
+            template <typename T, typename = std::enable_if_t<!std::is_same_v<std::decay_t<T>, SpecificCallable>>>
+            explicit SpecificCallable(T&& func) : func(std::forward<T>(func)) {};
+        R call(Args... args) override
+            {
+                if constexpr(std::is_void_v<R>)
+                { std::invoke(func, std::forward<Args>(args)...); }
+                else
+                { return std::invoke(func, std::forward<Args>(args)...); }
+            }
+            
+            const void* target() override
+            {
+                return std::addressof(func);
+            }
+            F func;
+        };
+
+        std::unique_ptr<Callable> _ptr = nullptr;
+
+    public:
+        MoveOnlyFunction() = default;
+        MoveOnlyFunction(const MoveOnlyFunction& other) = delete;
+        MoveOnlyFunction& operator=(const MoveOnlyFunction& other) = delete;
+        MoveOnlyFunction(MoveOnlyFunction&& other) noexcept = default;
+        MoveOnlyFunction& operator=(MoveOnlyFunction&& other) noexcept = default;
+
+        ~MoveOnlyFunction() = default;
+
+        template <typename F, typename = std::enable_if_t<!std::is_same_v<std::decay_t<F>, MoveOnlyFunction> && std::is_invocable_r_v<R, F&, Args...>>>
+        MoveOnlyFunction(F&& func) : _ptr(std::make_unique<SpecificCallable<std::decay_t<F>>>(std::forward<F>(func))) { }
+
+        R operator()(Args... args) 
+        {
+            return _ptr->call(std::forward<Args>(args)...);
+            
+        }; 
+
+        template <typename F>
+        F* target() noexcept
+        {
+            return reinterpret_cast<F*>(const_cast<void*>(_ptr->target()));
+        };
+
+    };
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
resolves #650 


**What is the current behavior?** (You can also link to an open issue here)
#650 


**What is the new behavior (if this is a feature change)?**
The copy constructors in the ECS builder no longer work. They are move only


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Technical yes, but not one we care about. It breaks copying which is what we want.


**Other information**:
