### PR TITLE
Fixed wrong size for texture allocation

### DIFF
--- a/UI/include/NovelRT/UI/ImGui/ImGuiUIProvider.hpp
+++ b/UI/include/NovelRT/UI/ImGui/ImGuiUIProvider.hpp
@@ -591,17 +591,6 @@ namespace NovelRT::UI::ImGui
             auto& io = ::ImGui::GetIO();
             io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
 
-            GraphicsBufferCreateInfo bufferCreateInfo{};
-            bufferCreateInfo.cpuAccessKind = GraphicsResourceAccess::Write;
-            bufferCreateInfo.gpuAccessKind = GraphicsResourceAccess::Read;
-            bufferCreateInfo.size = 64 * 1024 * 4;
-
-            // Create Texture Staging Buffer
-            auto textureStagingBuffer = _memoryAllocator->CreateBuffer(bufferCreateInfo);
-
-            // Begin commands
-            // context->BeginFrame();
-
             // Create the texture
             auto textureCreateInfo = GraphicsTextureCreateInfo{GraphicsTextureAddressMode::Repeat,
                                                                GraphicsTextureKind::TwoDimensional,
@@ -613,6 +602,17 @@ namespace NovelRT::UI::ImGui
                                                                GraphicsMemoryRegionAllocationFlags::None,
                                                                TexelFormat::R8G8B8A8_UNORM};
             auto texture2D = _memoryAllocator->CreateTexture(textureCreateInfo);
+
+            GraphicsBufferCreateInfo bufferCreateInfo{};
+            bufferCreateInfo.cpuAccessKind = GraphicsResourceAccess::Write;
+            bufferCreateInfo.gpuAccessKind = GraphicsResourceAccess::Read;
+            bufferCreateInfo.size = texture2D->GetSize();
+
+            // Create Texture Staging Buffer
+            auto textureStagingBuffer = _memoryAllocator->CreateBuffer(bufferCreateInfo);
+
+            // Begin commands
+            // context->BeginFrame();
 
             // Allocate region based on size of texture
             auto texture2DRegion = texture2D->Allocate(texture2D->GetSize(), 4);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It fixes a bug where IMGUI texture creation fails due to an undersized buffer.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No


**What is the current behavior?** (You can also link to an open issue here)
It crashes


**What is the new behavior (if this is a feature change)?**
It no longer crashes


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope


**Other information**:
