### PR TITLE
Finalise README.md and CMake versioning for Reimu release.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(WIN32)
 endif()
 
 project(NovelRT
-  VERSION 1.0.0 #MVP Version
+  VERSION 2026.0.0
   DESCRIPTION "NovelRT game engine"
   HOMEPAGE_URL "https://novelrt.dev"
   LANGUAGES C CXX

--- a/README.md
+++ b/README.md
@@ -9,61 +9,38 @@ NovelRT is a cross-platform, flexible Visual Novel and 2D game engine. It is aim
 
 [![Discord](https://discordapp.com/api/guilds/543898968380145675/widget.png?style=banner2)](https://discord.novelrt.dev/)
 
-## Current Features
-
-Currently, NovelRT supports the following in its base form:
-- Graphics LLAPI
-- Audio LLAPI
-
-## Future & Immediate Improvements
-
-Current features in development include:
-- C++ HLAPI
-- Fabulist narrative scripting language support
-
-For information on Fabulist, check it out from [here](https://github.com/novelrt/fabulist).
 
 ## Getting Started with NovelRT
 
-Currently there are no binary distributions of the engine as of yet, and we are still in our early alpha for almost everything.
+There is two main ways to use the engine:
+- using the prebuilt binary target for basic visual novels (the VisualNovel target/VisualNovel.exe)
+- from source
+
+In both cases it is recommended you use the designated releases, please see the [releases page](https://github.com/novelrt/NovelRT/releases) to view and download versions.
 
 ### Dependencies
 
 If you wish to attempt to build a basic visual novel with the existing C++ API, you must first install the following dependencies:
 
-- [CMake](https://cmake.org/download/) >= 3.19.8
-- [Vulkan SDK](https://vulkan.lunarg.com) >= 1.3.231.1
+- [CMake](https://cmake.org/download/) >= 3.24
+- [Vulkan SDK](https://vulkan.lunarg.com) >= 1.4.313.0
 - [Python](https://www.python.org/downloads/) >= 3.11
-
-The dependencies that are handled by CMake that do not need to be manually installed are as follows:
-
-- Doxygen 1.8.17 (building docs)
-- fmt 10.2.1
-- GLFW 3.3.7
-- glm 0.9.9.9
-- gtest/gmock 1.11.0
-- fmt 10.2.1
-- libpng 1.6.35
-- libsndfile 1.1.0
-- Microsoft GSL 4.0.0
-- OneTBB 2021.5.0
-- OpenAL 1.23.1
-- spdlog 1.13.0
 
 ### Build instructions
 
 These instructions are based on the CMake build system generator. You can download the latest version here [here.](https://cmake.org/download/)
 
-**If you are compiling on Linux, please note - we do not support GCC at this time. Please use Clang 10+ instead. We will gladly accept contributions towards making GCC compatible, but until support is guaranteed we will _only_ officially support first-party compilers as described in our CI builds found** [here.](https://github.com/novelrt/NovelRT/blob/6d9caf2cb2426f6d3661575c7dbd24014d4260b9/.github/workflows/build-system.yml)
+**If you are compiling on Linux, please note - we do not support GCC at this time. Please use Clang 21+ instead. We will gladly accept contributions towards making GCC compatible, but until support is guaranteed we will _only_ officially support first-party compilers as described in our CI builds found** [here.](https://github.com/novelrt/NovelRT/blob/main/.github/workflows/build-pr.yml)
 
 
 #### Linux
 
-First, you must install the dependencies. On Ubuntu 20.04, it looks like this:
+First, you must install the dependencies. On Ubuntu 24.04, it looks like this:
 ```
 sudo apt install clang  libgl-dev xorg-dev libx11-xcb-dev libxcb-render0-dev libxcb-render-util0-dev libxcb-xkb-dev \
 libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-sync-dev \
 libxcb-xfixes0-dev libxcb-xinerama0-dev xkb-data libxcb-dri3-dev libxcb-util-dev python \
+glslc libxkbcommon-dev vulkan-tools
 ```
 
 If you are building from a command line terminal, clone NovelRT and set up the build folder like so:
@@ -81,15 +58,14 @@ cmake --build . -j
 
 #### Windows (x64 only)
 _Prerequisites:_
-- Windows 10 x64
+- Windows 11 x64
 - Either:
-  - Visual Studio 2019 w/ "Desktop development with C++" Workload,
-  - Visual Studio 2022 w/ "Desktop development with C++" Workload,
+  - Visual Studio 2022 with "Desktop development with C++" Workload,
+  - Visual Studio 2026 with "Desktop development with C++" Workload,
   _OR_
-  - Build Tools for Visual Studio 2019/2022 w/ "Desktop development with C++" Workload
-- CMake 3.19 or above
-_(note: Do not use the included one with Visual Studio at this time! It is outdated as of this time of writing and is considered incompatible.)_
-- Python 3.11 or above
+  - Build Tools for Visual Studio 2022/2026 w/ "Desktop development with C++" Workload
+- CMake 3.24 or above. CMake is now packaged with the build tools as a component, and should work for this purpose.
+- Python 3.11 or above.
 
 (32-bit builds _will not be supported at this time_.)
 
@@ -107,9 +83,9 @@ cmake ..
 cmake --build . -j
 ```
 
-##### Visual studio 2019/2022 specific instructions
+##### Visual studio 2022/2026 specific instructions
 
-When you open the NovelRT folder in VS2019 or VS2022 for the first time the CMakeSettings.json file will contain incorrect values.
+When you open the NovelRT folder in VS2022 or VS2026 for the first time the CMakeSettings.json file will contain incorrect values.
 Change the buildRoot value to `${projectDir}\\build` and the installRoot to `${projectDir}\\install` and restart Visual Studio this will make sure that it uses the same build path as the CLI commands.
 You can delete the `out` folder in the NovelRT root as well as we won't use it anymore.
 Then regenerate the cmake by clicking regenerate on the yellow warning ribbon on the top of Visual Studio.
@@ -119,11 +95,11 @@ Then regenerate the cmake by clicking regenerate on the yellow warning ribbon on
 _Prerequisites:_
 - XCode 12
 - XCode Command Line Tools matching the installed version
-- CMake 3.19.8
-- Vulkan SDK 1.3.231.1
+- CMake 3.24 or greater
+- Vulkan SDK 1.4.313.0
 - Python 3.11 or above
 
-**NOTE: Until native Metal support is introduced at a future time, it is _required_ that you install Vulkan SDK version 1.3.231.1 as a prerequisite to configuring/building NovelRT. The instructions below will indicate directions _assuming_ that the Vulkan SDK is already installed in a non-system path. If it is not installed, NovelRT's build system will fail to properly configure.**
+**NOTE: Until native Metal support is introduced at a future time, it is _required_ that you install the specified version of the Vulkan SDK as a prerequisite to configuring/building NovelRT. The instructions below will indicate directions _assuming_ that the Vulkan SDK is already installed in a non-system path. If it is not installed, NovelRT's build system will fail to properly configure.**
 
 If you are building from a command line terminal, clone NovelRT and set up the build folder like so:
 ```
@@ -145,7 +121,7 @@ cmake .. -DCMAKE_APPLE_SILICON_PROCESSOR="arm64"
 
 If Vulkan SDK is not installed in a system path and the `setup-env.sh` file did not properly add the required environment variables, you can specify the `VULKAN_SDK` environment variable to your local Vulkan SDK location as such:
 ```
-VULKAN_SDK=/Users/youruser/Vulkan SDK/1.3.231.1/macOS cmake ..
+VULKAN_SDK=/Users/youruser/Vulkan SDK/1.4.313.0/macOS cmake ..
 ```
 Please ensure that the path includes the macOS folder, otherwise finding the proper libraries will fail.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you wish to attempt to build a basic visual novel with the existing C++ API, 
 
 These instructions are based on the CMake build system generator. You can download the latest version here [here.](https://cmake.org/download/)
 
-**If you are compiling on Linux, please note - we do not support GCC at this time. Please use Clang 21+ instead. We will gladly accept contributions towards making GCC compatible, but until support is guaranteed we will _only_ officially support first-party compilers as described in our CI builds found** [here.](https://github.com/novelrt/NovelRT/blob/main/.github/workflows/build-pr.yml)
+**If you are compiling on Linux, please note - we do not support GCC at this time. Please use Clang 20+ instead. We will gladly accept contributions towards making GCC compatible, but until support is guaranteed we will _only_ officially support first-party compilers as described in our CI builds found** [here.](https://github.com/novelrt/NovelRT/blob/main/.github/workflows/build-pr.yml)
 
 
 #### Linux


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This change updates our messy README and fixes our CMake project version in preparation for the Reimu release of the engine (2026.0.0).


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
no.


**What is the current behavior?** (You can also link to an open issue here)
N/A


**What is the new behavior (if this is a feature change)?**
N/A


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Only that once Reimu is out, the core of the engine will mostly be locked-in for the long term. This is it!


**Other information**:
I don't fully know if the ubuntu dependencies are correct and could do with a sanity check.