### PR TITLE
Redesign selection API to solve crash on intel iris.

### DIFF
--- a/Graphics/Core/CMakeLists.txt
+++ b/Graphics/Core/CMakeLists.txt
@@ -15,6 +15,7 @@ NovelRTBuildSystem_DeclareModule(LIBRARY NovelRT::Graphics::Core
 
   HEADERS
     PUBLIC
+      include/NovelRT/Graphics/FeatureProviderExtensionGroup.hpp
       include/NovelRT/Graphics/GraphicsAdapter.hpp
       include/NovelRT/Graphics/GraphicsBuffer.hpp
       include/NovelRT/Graphics/GraphicsBufferCreateInfo.hpp

--- a/Graphics/Core/include/NovelRT/Graphics/FeatureProviderExtensionGroup.hpp
+++ b/Graphics/Core/include/NovelRT/Graphics/FeatureProviderExtensionGroup.hpp
@@ -32,31 +32,7 @@ namespace NovelRT::Graphics
 
         bool operator==(const FeatureProviderExtensionGroup& other) const noexcept
         {
-            if (extensionNames.size() != other.extensionNames.size())
-            {
-                return false;
-            }
-
-            for (const auto& ext : extensionNames)
-            {
-                bool match = false;
-
-                for (const auto& otherExt : other.extensionNames)
-                {
-                    if (ext == otherExt)
-                    {
-                        match = true;
-                        break;
-                    }
-                }
-
-                if (!match)
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return std::ranges::equal(extensionNames, other.extensionNames);
         }
     };
 }

--- a/Graphics/Core/include/NovelRT/Graphics/FeatureProviderExtensionGroup.hpp
+++ b/Graphics/Core/include/NovelRT/Graphics/FeatureProviderExtensionGroup.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <algorithm>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace NovelRT::Graphics
+{
+    struct FeatureProviderExtensionGroup
+    {
+        std::vector<std::string> extensionNames;
+
+        [[nodiscard]] std::optional<std::string> FindFirstAvailableExtension(
+            std::span<const std::string> extensionNamesTestCandidate) const noexcept
+        {
+            for (const std::string& ext : extensionNames)
+            {
+                auto iter = std::find(extensionNamesTestCandidate.begin(), extensionNamesTestCandidate.end(), ext);
+                if (iter != extensionNamesTestCandidate.end())
+                {
+                    return *iter;
+                }
+            }
+
+            return std::nullopt;
+        }
+
+        bool operator==(const FeatureProviderExtensionGroup& other) const noexcept
+        {
+            if (extensionNames.size() != other.extensionNames.size())
+            {
+                return false;
+            }
+
+            for (const auto& ext : extensionNames)
+            {
+                bool match = false;
+
+                for (const auto& otherExt : other.extensionNames)
+                {
+                    if (ext == otherExt)
+                    {
+                        match = true;
+                        break;
+                    }
+                }
+
+                if (!match)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    };
+}

--- a/Graphics/Core/include/NovelRT/Graphics/IGraphicsAdapterSelector.hpp
+++ b/Graphics/Core/include/NovelRT/Graphics/IGraphicsAdapterSelector.hpp
@@ -3,33 +3,11 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
-#include <algorithm>
+#include <NovelRT/Graphics/FeatureProviderExtensionGroup.hpp>
 #include <memory>
-#include <optional>
-#include <span>
-#include <vector>
 
 namespace NovelRT::Graphics
 {
-    struct FeatureProviderExtensionGroup
-    {
-        std::vector<std::string> extensionNames;
-
-        [[nodiscard]] std::optional<std::string> FindFirstAvailableExtension(
-            std::span<const std::string> extensionNames) const noexcept
-        {
-            for (const std::string& ext : extensionNames)
-            {
-                auto iter = std::find(extensionNames.begin(), extensionNames.end(), ext);
-                if (iter != extensionNames.end())
-                {
-                    return *iter;
-                }
-            }
-
-            return std::nullopt;
-        }
-    };
 
     template<typename TBackend>
     class GraphicsAdapter;

--- a/Graphics/Core/include/NovelRT/Graphics/IGraphicsAdapterSelector.hpp
+++ b/Graphics/Core/include/NovelRT/Graphics/IGraphicsAdapterSelector.hpp
@@ -3,10 +3,34 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
+#include <algorithm>
 #include <memory>
+#include <optional>
+#include <span>
+#include <vector>
 
 namespace NovelRT::Graphics
 {
+    struct FeatureProviderExtensionGroup
+    {
+        std::vector<std::string> extensionNames;
+
+        [[nodiscard]] std::optional<std::string> FindFirstAvailableExtension(
+            std::span<const std::string> extensionNames) const noexcept
+        {
+            for (const std::string& ext : extensionNames)
+            {
+                auto iter = std::find(extensionNames.begin(), extensionNames.end(), ext);
+                if (iter != extensionNames.end())
+                {
+                    return *iter;
+                }
+            }
+
+            return std::nullopt;
+        }
+    };
+
     template<typename TBackend>
     class GraphicsAdapter;
     template<typename TBackend>

--- a/Graphics/Vulkan/VulkanGraphicsAdapter.cpp
+++ b/Graphics/Vulkan/VulkanGraphicsAdapter.cpp
@@ -5,6 +5,7 @@
 #include <NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.hpp>
 #include <NovelRT/Graphics/Vulkan/VulkanGraphicsProvider.hpp>
 
+#include <NovelRT/Graphics/FeatureProviderExtensionGroup.hpp>
 #include <NovelRT/Graphics/GraphicsDevice.hpp>
 #include <NovelRT/Graphics/GraphicsRenderPass.hpp>
 
@@ -87,26 +88,32 @@ namespace NovelRT::Graphics
     {
         return CreateDevice(
             surfaceContext,
-            std::vector<std::string>{VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_MAINTENANCE_7_EXTENSION_NAME},
-            std::vector<std::string>{VK_EXT_NESTED_COMMAND_BUFFER_EXTENSION_NAME});
+            std::vector<FeatureProviderExtensionGroup>{
+                {.extensionNames = {VK_KHR_SWAPCHAIN_EXTENSION_NAME}},
+                {.extensionNames = {VK_EXT_NESTED_COMMAND_BUFFER_EXTENSION_NAME, VK_KHR_MAINTENANCE_7_EXTENSION_NAME}}},
+            std::vector<FeatureProviderExtensionGroup>{});
     }
 
     std::shared_ptr<VulkanGraphicsDevice> VulkanGraphicsAdapter::CreateDevice(
         const std::shared_ptr<VulkanGraphicsSurfaceContext>& surfaceContext,
-        std::vector<std::string> requiredDeviceExtensions,
-        std::vector<std::string> optionalDeviceExtensions)
+        std::vector<FeatureProviderExtensionGroup> requiredDeviceExtensions,
+        std::vector<FeatureProviderExtensionGroup> optionalDeviceExtensions)
     {
         // Add VK_KHR_swapchain as a required extension if it's not already there
-        auto requiredSwapchainExtension = std::find(requiredDeviceExtensions.begin(), requiredDeviceExtensions.end(),
-                                                    VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+        auto requiredSwapchainExtension =
+            std::find(requiredDeviceExtensions.begin(), requiredDeviceExtensions.end(),
+                      FeatureProviderExtensionGroup{.extensionNames = {VK_KHR_SWAPCHAIN_EXTENSION_NAME}});
+
         if (requiredSwapchainExtension == requiredDeviceExtensions.end())
         {
             // To avoid weird behavior, make sure that optionalDeviceExtensions doesn't contain it
-            optionalDeviceExtensions.erase(std::remove(optionalDeviceExtensions.begin(), optionalDeviceExtensions.end(),
-                                                       VK_KHR_SWAPCHAIN_EXTENSION_NAME),
-                                           optionalDeviceExtensions.end());
+            optionalDeviceExtensions.erase(
+                std::remove(optionalDeviceExtensions.begin(), optionalDeviceExtensions.end(),
+                            FeatureProviderExtensionGroup{.extensionNames = {VK_KHR_SWAPCHAIN_EXTENSION_NAME}}),
+                optionalDeviceExtensions.end());
 
-            requiredDeviceExtensions.emplace_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+            requiredDeviceExtensions.emplace_back(
+                FeatureProviderExtensionGroup{.extensionNames = {VK_KHR_SWAPCHAIN_EXTENSION_NAME}});
         }
 
         return std::make_shared<VulkanGraphicsDevice>(shared_from_this(), surfaceContext, requiredDeviceExtensions,

--- a/Graphics/Vulkan/VulkanGraphicsAdapterSelector.cpp
+++ b/Graphics/Vulkan/VulkanGraphicsAdapterSelector.cpp
@@ -16,6 +16,7 @@
 #include <ranges>
 #include <string>
 #include <vector>
+#include <vulkan/vulkan_core.h>
 
 namespace NovelRT::Graphics::Vulkan
 {
@@ -184,7 +185,8 @@ namespace NovelRT::Graphics::Vulkan
         return GetDefaultRecommendedAdapter(
             provider, surfaceContext,
             std::vector<FeatureProviderExtensionGroup>{
-                {.extensionNames = {VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_EXT_NESTED_COMMAND_BUFFER_EXTENSION_NAME}}},
+                {.extensionNames = {VK_KHR_SWAPCHAIN_EXTENSION_NAME}},
+                {.extensionNames = {VK_EXT_NESTED_COMMAND_BUFFER_EXTENSION_NAME, VK_KHR_MAINTENANCE_7_EXTENSION_NAME}}},
             std::vector<FeatureProviderExtensionGroup>{});
     }
 } // namespace NovelRT::Graphics::Vulkan

--- a/Graphics/Vulkan/VulkanGraphicsAdapterSelector.cpp
+++ b/Graphics/Vulkan/VulkanGraphicsAdapterSelector.cpp
@@ -99,9 +99,10 @@ namespace NovelRT::Graphics::Vulkan
 
                 for (const auto& extStr : ext.extensionNames)
                 {
-                    if (firstRun)
+                    if (!firstRun)
                     {
                         extensionGroupOutput += "OR ";
+                        firstRun = false;
                     }
 
                     extensionGroupOutput += extStr;

--- a/Graphics/Vulkan/VulkanGraphicsAdapterSelector.cpp
+++ b/Graphics/Vulkan/VulkanGraphicsAdapterSelector.cpp
@@ -3,6 +3,7 @@
 
 // TODO: clean this up good grief
 #include <NovelRT/Exceptions/NotSupportedException.hpp>
+#include <NovelRT/Graphics/IGraphicsAdapterSelector.hpp>
 #include <NovelRT/Graphics/Vulkan/QueueFamilyIndices.hpp>
 #include <NovelRT/Graphics/Vulkan/SwapChainSupportDetails.hpp>
 #include <NovelRT/Graphics/Vulkan/Utilities/Support.hpp>
@@ -12,6 +13,7 @@
 #include <NovelRT/Graphics/Vulkan/VulkanGraphicsSurfaceContext.hpp>
 
 #include <algorithm>
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -22,8 +24,9 @@ namespace NovelRT::Graphics::Vulkan
     using VulkanGraphicsSurfaceContext = GraphicsSurfaceContext<Vulkan::VulkanGraphicsBackend>;
     using VulkanGraphicsProvider = GraphicsProvider<Vulkan::VulkanGraphicsBackend>;
 
-    static int32_t GetOptionalExtensionSupportScore(const std::vector<std::string>& availableDeviceExtensions,
-                                                    const std::vector<std::string>& optionalDeviceExtensions)
+    static int32_t GetOptionalExtensionSupportScore(
+        const std::vector<std::string>& availableDeviceExtensions,
+        const std::vector<FeatureProviderExtensionGroup>& optionalDeviceExtensions)
     {
         // If the user didn't request any optional extensions, don't give them a score.
         if (optionalDeviceExtensions.empty())
@@ -31,17 +34,21 @@ namespace NovelRT::Graphics::Vulkan
             return 0;
         }
 
-        auto isOptionalExtension = [begin = optionalDeviceExtensions.begin(), end = optionalDeviceExtensions.end()](
-                                       const auto& it) { return std::find(begin, end, it) != end; };
         auto foundOptionalExtensions =
-            std::count_if(availableDeviceExtensions.begin(), availableDeviceExtensions.end(), isOptionalExtension);
+            optionalDeviceExtensions |
+            std::views::transform([&](const auto& x)
+                                  { return x.FindFirstAvailableExtension(availableDeviceExtensions); }) |
+            std::views::filter([](const auto& opt) { return opt.has_value(); }) |
+            std::views::transform([](const auto& opt) -> const std::string& { return *opt; });
 
         const float percentageStep = (1.0f / static_cast<float>(optionalDeviceExtensions.size())) * 100;
-        return static_cast<int32_t>(static_cast<float>(foundOptionalExtensions) * percentageStep);
+        return static_cast<int32_t>(static_cast<float>(std::ranges::distance(foundOptionalExtensions)) *
+                                    percentageStep);
     }
 
-    static bool CheckRequiredExtensionSupport(const std::vector<std::string>& availableDeviceExtensions,
-                                              const std::vector<std::string>& requiredDeviceExtensions)
+    static bool CheckRequiredExtensionSupport(
+        const std::vector<std::string>& availableDeviceExtensions,
+        const std::vector<FeatureProviderExtensionGroup>& requiredDeviceExtensions)
     {
         // If the user didn't request any required extensions, pass immediately.
         if (requiredDeviceExtensions.empty())
@@ -49,20 +56,15 @@ namespace NovelRT::Graphics::Vulkan
             return true;
         }
 
-        auto isRequiredExtension = [begin = requiredDeviceExtensions.begin(), end = requiredDeviceExtensions.end()](
-                                       const auto& it) { return std::find(begin, end, it) != end; };
-        auto foundRequiredExtensions =
-            std::count_if(availableDeviceExtensions.begin(), availableDeviceExtensions.end(), isRequiredExtension);
-
-        return static_cast<decltype(requiredDeviceExtensions.size())>(foundRequiredExtensions) ==
-               requiredDeviceExtensions.size();
+        return std::ranges::all_of(requiredDeviceExtensions, [&](const auto& x)
+                                   { return x.FindFirstAvailableExtension(availableDeviceExtensions).has_value(); });
     }
 
     int32_t VulkanGraphicsAdapterSelector::RateDeviceSuitability(
         const VulkanGraphicsAdapter& adapter,
         const VulkanGraphicsSurfaceContext& surfaceContext,
-        const std::vector<std::string>& requiredDeviceExtensions,
-        const std::vector<std::string>& optionalDeviceExtensions) const
+        const std::vector<FeatureProviderExtensionGroup>& requiredDeviceExtensions,
+        const std::vector<FeatureProviderExtensionGroup>& optionalDeviceExtensions) const
     {
         uint32_t extensionCount = 0;
         vkEnumerateDeviceExtensionProperties(adapter.GetPhysicalDevice(), nullptr, &extensionCount, nullptr);
@@ -80,24 +82,31 @@ namespace NovelRT::Graphics::Vulkan
         {
             _logger.logWarningLine("Rejecting adapater " + adapter.GetName() + " due to missing required extensions:");
 
+            size_t groupCounter = 0ULL;
+
             for (const auto& ext : requiredDeviceExtensions)
             {
-                bool skip = false;
-                for (const auto& foundExt : extensionNames)
-                {
-                    if (ext == foundExt)
-                    {
-                        skip = true;
-                        break;
-                    }
-                }
 
-                if (skip)
+                if (ext.FindFirstAvailableExtension(extensionNames).has_value())
                 {
                     continue;
                 }
 
-                _logger.logWarningLine("  " + ext);
+                std::string extensionGroupOutput{};
+
+                bool firstRun = true;
+
+                for (const auto& extStr : ext.extensionNames)
+                {
+                    if (firstRun)
+                    {
+                        extensionGroupOutput += "OR ";
+                    }
+
+                    extensionGroupOutput += extStr;
+                }
+
+                _logger.logWarningLine("GROUP " + std::to_string(groupCounter) + ": " + extensionGroupOutput);
             }
 
             _logger.logWarningLine("Available extensions are:");
@@ -147,8 +156,8 @@ namespace NovelRT::Graphics::Vulkan
     std::shared_ptr<VulkanGraphicsAdapter> VulkanGraphicsAdapterSelector::GetDefaultRecommendedAdapter(
         const std::shared_ptr<VulkanGraphicsProvider>& provider,
         const std::shared_ptr<VulkanGraphicsSurfaceContext>& surfaceContext,
-        const std::vector<std::string>& requiredDeviceExtensions,
-        const std::vector<std::string>& optionalDeviceExtensions) const
+        const std::vector<FeatureProviderExtensionGroup>& requiredDeviceExtensions,
+        const std::vector<FeatureProviderExtensionGroup>& optionalDeviceExtensions) const
     {
         std::weak_ptr<VulkanGraphicsAdapter> adapter;
         int32_t highestScore = -1;
@@ -174,7 +183,8 @@ namespace NovelRT::Graphics::Vulkan
     {
         return GetDefaultRecommendedAdapter(
             provider, surfaceContext,
-            std::vector<std::string>{VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_EXT_NESTED_COMMAND_BUFFER_EXTENSION_NAME},
-            std::vector<std::string>{VK_KHR_MAINTENANCE_7_EXTENSION_NAME});
+            std::vector<FeatureProviderExtensionGroup>{
+                {.extensionNames = {VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_EXT_NESTED_COMMAND_BUFFER_EXTENSION_NAME}}},
+            std::vector<FeatureProviderExtensionGroup>{});
     }
 } // namespace NovelRT::Graphics::Vulkan

--- a/Graphics/Vulkan/VulkanGraphicsDevice.cpp
+++ b/Graphics/Vulkan/VulkanGraphicsDevice.cpp
@@ -25,6 +25,7 @@
 #include <NovelRT/Utilities/Strings.hpp>
 
 #include <algorithm>
+#include <ranges>
 #include <set>
 #include <vulkan/vulkan_core.h>
 
@@ -56,8 +57,8 @@ namespace NovelRT::Graphics
     }
 
     std::vector<std::string> VulkanGraphicsDevice::GetFinalPhysicalDeviceExtensionSet(
-        std::vector<std::string> requiredDeviceExtensions,
-        std::vector<std::string> optionalDeviceExtensions) const
+        std::vector<FeatureProviderExtensionGroup> requiredDeviceExtensions,
+        std::vector<FeatureProviderExtensionGroup> optionalDeviceExtensions) const
     {
         uint32_t extensionCount = 0;
         auto adapter = GetAdapter();
@@ -66,7 +67,7 @@ namespace NovelRT::Graphics
         vkEnumerateDeviceExtensionProperties(adapter->GetPhysicalDevice(), nullptr, &extensionCount,
                                              extensionProperties.data());
 
-        _logger.logInfoLine("Found the following available physical device extensions:");
+        _logger.logInfoLine("Found the following available physical device extensions as part of VkDevice setup:");
 
         for (auto&& extensionProperty : extensionProperties)
         {
@@ -74,45 +75,97 @@ namespace NovelRT::Graphics
                                 "  Spec Version: " + std::to_string(extensionProperty.specVersion));
         }
 
+        std::vector<std::string> cppNames{};
+
+        std::ranges::transform(extensionProperties, std::back_inserter(cppNames),
+                               [&](const auto& x) -> std::string { return std::string(x.extensionName); });
+
+        size_t groupCounter = 0ULL;
+
+        std::vector<std::string> finalRequiredDeviceExtensions{};
+
         // TODO: EngineConfig was here
         for (auto&& requestedRequiredExt : requiredDeviceExtensions)
         {
-            auto result = std::find_if(extensionProperties.begin(), extensionProperties.end(), [&](auto& x)
-                                       { return strcmp(requestedRequiredExt.c_str(), x.extensionName) == 0; });
+            auto result = requestedRequiredExt.FindFirstAvailableExtension(cppNames);
 
-            if (result == extensionProperties.end())
+            if (!result.has_value())
             {
+                std::string missingExtensions{};
+
+                bool firstRun = true;
+
+                for (const auto& extStr : requestedRequiredExt.extensionNames)
+                {
+                    if (!firstRun)
+                    {
+                        missingExtensions += "OR ";
+                        firstRun = false;
+                    }
+
+                    missingExtensions += extStr;
+                }
+
                 throw Exceptions::InitialisationFailureException(
-                    "The required Vulkan extension " + requestedRequiredExt + " is not available on this device.");
+                    "None of the required Vulkan extensions in group " + std::to_string(groupCounter) +
+                    " are available on this device. Extensions missing:\n" + missingExtensions);
             }
+
+            finalRequiredDeviceExtensions.emplace_back(*result);
+
+            groupCounter += 1ULL;
         }
+
+        size_t groupCounterOptionals = 0ULL;
 
         std::vector<std::string> finalOptionalExtensions{};
 
         // TODO: EngineConfig was here
         for (auto&& requestedOptionalExt : optionalDeviceExtensions)
         {
-            auto result = std::find_if(extensionProperties.begin(), extensionProperties.end(), [&](auto& x)
-                                       { return strcmp(requestedOptionalExt.c_str(), x.extensionName) == 0; });
 
-            if (result == extensionProperties.end())
+            auto result = requestedOptionalExt.FindFirstAvailableExtension(cppNames);
+
+            if (!result.has_value())
             {
-                _logger.logWarningLine("The optional Vulkan extension " + requestedOptionalExt +
-                                       " is not available on this device. Vulkan may not behave as you expect.");
+                std::string missingExtensions{};
+
+                bool firstRun = true;
+
+                for (const auto& extStr : requestedOptionalExt.extensionNames)
+                {
+                    if (!firstRun)
+                    {
+                        missingExtensions += "OR ";
+                        firstRun = false;
+                    }
+
+                    missingExtensions += extStr;
+                }
+
+                _logger.logWarningLine("The optional Vulkan extensions in group " +
+                                       std::to_string(groupCounterOptionals) +
+                                       " are not available on this device. Vulkan may not behave as you expect. "
+                                       "Optionally requested was one of the following:");
+
+                _logger.logWarningLine(missingExtensions);
                 continue;
             }
 
-            finalOptionalExtensions.emplace_back(requestedOptionalExt);
+            finalOptionalExtensions.emplace_back(*result);
+
+            groupCounter += 1ULL;
         }
 
-        // TODO: EngineConfig was here
-        std::vector<std::string> allExtensions{requiredDeviceExtensions};
+        // TODO: EngineConfig was here}
+        std::vector<std::string> allExtensions{finalRequiredDeviceExtensions};
         allExtensions.insert(allExtensions.end(), finalOptionalExtensions.begin(), finalOptionalExtensions.end());
         return allExtensions;
     }
 
-    VkDevice VulkanGraphicsDevice::CreateLogicalDevice(std::vector<std::string> requiredDeviceExtensions,
-                                                       std::vector<std::string> optionalDeviceExtensions)
+    VkDevice VulkanGraphicsDevice::CreateLogicalDevice(
+        std::vector<FeatureProviderExtensionGroup> requiredDeviceExtensions,
+        std::vector<FeatureProviderExtensionGroup> optionalDeviceExtensions)
     {
         _indicesData = Vulkan::Utilities::FindQueueFamilies(_adapter->GetPhysicalDevice(), _surface);
 
@@ -198,8 +251,8 @@ namespace NovelRT::Graphics
 
     VulkanGraphicsDevice::GraphicsDevice(std::shared_ptr<VulkanGraphicsAdapter> adapter,
                                          std::shared_ptr<VulkanGraphicsSurfaceContext> surfaceContext,
-                                         std::vector<std::string> requiredDeviceExtensions,
-                                         std::vector<std::string> optionalDeviceExtensions)
+                                         std::vector<FeatureProviderExtensionGroup> requiredDeviceExtensions,
+                                         std::vector<FeatureProviderExtensionGroup> optionalDeviceExtensions)
         : _adapter(std::move(adapter)),
           _surfaceContext(std::move(surfaceContext)),
           _logger(NovelRT::Logging::CONSOLE_LOG_GFX),

--- a/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsAdapter.hpp
+++ b/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsAdapter.hpp
@@ -3,6 +3,7 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
+#include <NovelRT/Graphics/FeatureProviderExtensionGroup.hpp>
 #include <NovelRT/Graphics/GraphicsAdapter.hpp>
 #include <NovelRT/Utilities/Lazy.hpp>
 
@@ -51,7 +52,7 @@ namespace NovelRT::Graphics
 
         [[nodiscard]] std::shared_ptr<GraphicsDevice<Vulkan::VulkanGraphicsBackend>> CreateDevice(
             const std::shared_ptr<GraphicsSurfaceContext<Vulkan::VulkanGraphicsBackend>>& surfaceContext,
-            std::vector<std::string> requiredDeviceExtensions,
-            std::vector<std::string> optionalDeviceExtensions);
+            std::vector<FeatureProviderExtensionGroup> requiredDeviceExtensions,
+            std::vector<FeatureProviderExtensionGroup> optionalDeviceExtensions);
     };
 }

--- a/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsAdapterSelector.hpp
+++ b/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsAdapterSelector.hpp
@@ -20,16 +20,16 @@ namespace NovelRT::Graphics::Vulkan
         [[nodiscard]] int32_t RateDeviceSuitability(
             const GraphicsAdapter<Vulkan::VulkanGraphicsBackend>& adapter,
             const GraphicsSurfaceContext<Vulkan::VulkanGraphicsBackend>& surfaceContext,
-            const std::vector<std::string>& requiredDeviceExtensions,
-            const std::vector<std::string>& optionalDeviceExtensions) const;
+            const std::vector<FeatureProviderExtensionGroup>& requiredDeviceExtensions,
+            const std::vector<FeatureProviderExtensionGroup>& optionalDeviceExtensions) const;
 
     public:
         // NOLINTNEXTLINE(readability-convert-member-functions-to-static) - this is intentionally non-static
         [[nodiscard]] std::shared_ptr<GraphicsAdapter<VulkanGraphicsBackend>> GetDefaultRecommendedAdapter(
             const std::shared_ptr<GraphicsProvider<VulkanGraphicsBackend>>& provider,
             const std::shared_ptr<GraphicsSurfaceContext<VulkanGraphicsBackend>>& surfaceContext,
-            const std::vector<std::string>& requiredDeviceExtensions,
-            const std::vector<std::string>& optionalDeviceExtensions) const;
+            const std::vector<FeatureProviderExtensionGroup>& requiredDeviceExtensions,
+            const std::vector<FeatureProviderExtensionGroup>& optionalDeviceExtensions) const;
 
         // NOLINTNEXTLINE(readability-convert-member-functions-to-static) - this is intentionally non-static
         [[nodiscard]] std::shared_ptr<GraphicsAdapter<VulkanGraphicsBackend>> GetDefaultRecommendedAdapter(

--- a/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.hpp
+++ b/Graphics/Vulkan/include/NovelRT/Graphics/Vulkan/VulkanGraphicsDevice.hpp
@@ -5,6 +5,7 @@
 
 #include <oneapi/tbb/mutex.h>
 
+#include <NovelRT/Graphics/FeatureProviderExtensionGroup.hpp>
 #include <NovelRT/Graphics/GraphicsDevice.hpp>
 #include <NovelRT/Graphics/GraphicsSwapchain.hpp>
 #include <NovelRT/Graphics/Vulkan/QueueFamilyIndices.hpp>
@@ -54,16 +55,16 @@ namespace NovelRT::Graphics
         void OnGraphicsSurfaceSizeChanged(Maths::GeoVector2F newSize);
 
         [[nodiscard]] std::vector<std::string> GetFinalPhysicalDeviceExtensionSet(
-            std::vector<std::string> requiredDeviceExtensions,
-            std::vector<std::string> optionalDeviceExtensions) const;
-        VkDevice CreateLogicalDevice(std::vector<std::string> requiredDeviceExtensions,
-                                     std::vector<std::string> optionalDeviceExtensions);
+            std::vector<FeatureProviderExtensionGroup> requiredDeviceExtensions,
+            std::vector<FeatureProviderExtensionGroup> optionalDeviceExtensions) const;
+        VkDevice CreateLogicalDevice(std::vector<FeatureProviderExtensionGroup> requiredDeviceExtensions,
+                                     std::vector<FeatureProviderExtensionGroup> optionalDeviceExtensions);
 
     public:
         GraphicsDevice(std::shared_ptr<GraphicsAdapter<Vulkan::VulkanGraphicsBackend>> adapter,
                        std::shared_ptr<GraphicsSurfaceContext<Vulkan::VulkanGraphicsBackend>> surfaceContext,
-                       std::vector<std::string> requiredDeviceExtensions,
-                       std::vector<std::string> optionalDeviceExtensions);
+                       std::vector<FeatureProviderExtensionGroup> requiredDeviceExtensions,
+                       std::vector<FeatureProviderExtensionGroup> optionalDeviceExtensions);
 
         ~GraphicsDevice();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This resolves an issue where we were explicitly not using maintenance7 even if it exists in the case where nested command buffers didn't exist.

**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
nope.


**What is the current behavior?** (You can also link to an open issue here)
crash on intel iris.


**What is the new behavior (if this is a feature change)?**
hopefully(?) no more crash on intel iris.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes, APIs changed but none that we are using ourselves in initial release so I might sneak this into a bugfix version as opposed to a minor version.


**Other information**:
