### PR TITLE
Resolve windows only minimise crash.

### DIFF
--- a/LuaOnlyTargets/VisualNovel/main.cpp
+++ b/LuaOnlyTargets/VisualNovel/main.cpp
@@ -295,6 +295,13 @@ public:
     {
         provider->SizeChanged += [this](auto eventArgs)
         {
+            // it doesn't actually matter what the viewport sizes are if we are minimising.
+            // This is a Windows 11 specific fix. - Matt J.
+            if (eventArgs == NovelRT::Maths::GeoVector2F::Zero())
+            {
+                return;
+            }
+
             _size = eventArgs;
             _changedSize = true;
         };

--- a/Samples/Ecs/Audio/main.cpp
+++ b/Samples/Ecs/Audio/main.cpp
@@ -366,6 +366,13 @@ public:
     {
         provider->SizeChanged += [this](auto eventArgs)
         {
+            // it doesn't actually matter what the viewport sizes are if we are minimising.
+            // This is a Windows 11 specific fix. - Matt J.
+            if (eventArgs == NovelRT::Maths::GeoVector2F::Zero())
+            {
+                return;
+            }
+
             _size = eventArgs;
             _changedSize = true;
         };

--- a/Samples/Ecs/Scripting/main.cpp
+++ b/Samples/Ecs/Scripting/main.cpp
@@ -204,6 +204,13 @@ public:
     {
         provider->SizeChanged += [this](auto eventArgs)
         {
+            // it doesn't actually matter what the viewport sizes are if we are minimising.
+            // This is a Windows 11 specific fix. - Matt J.
+            if (eventArgs == NovelRT::Maths::GeoVector2F::Zero())
+            {
+                return;
+            }
+
             _size = eventArgs;
             _changedSize = true;
         };

--- a/Samples/Ecs/UI/main.cpp
+++ b/Samples/Ecs/UI/main.cpp
@@ -324,6 +324,13 @@ public:
     {
         provider->SizeChanged += [this](auto eventArgs)
         {
+            // it doesn't actually matter what the viewport sizes are if we are minimising.
+            // This is a Windows 11 specific fix. - Matt J.
+            if (eventArgs == NovelRT::Maths::GeoVector2F::Zero())
+            {
+                return;
+            }
+
             _size = eventArgs;
             _changedSize = true;
         };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This resolves the windows minimise crash that I think was getting disguised as a buffer overrun. No idea why. Ask windows event viewer.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
You crash when minimising on windows.


**What is the new behavior (if this is a feature change)?**
You no longer crash when minimising on windows.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope!


**Other information**:
