### PR TITLE
Resolve window sizing for variable monitor sizes.

### DIFF
--- a/LuaOnlyTargets/VisualNovel/main.cpp
+++ b/LuaOnlyTargets/VisualNovel/main.cpp
@@ -1,7 +1,6 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
-#include "NovelRT/Maths/GeoVector2F.hpp"
 #include <NovelRT/Ecs/Catalogue.hpp>
 #include <NovelRT/Ecs/ComponentBuffer.hpp>
 #include <NovelRT/Ecs/ComponentView.hpp>
@@ -11,6 +10,7 @@
 #include <NovelRT/Ecs/SparseSet.hpp>
 #include <NovelRT/Ecs/SystemSchedulerBuilder.hpp>
 #include <NovelRT/Exceptions/FileNotFoundException.hpp>
+#include <NovelRT/Maths/GeoVector2F.hpp>
 #include <nlohmann/json_fwd.hpp>
 
 #include <NovelRT/Ecs/Components/TransformComponent.hpp>

--- a/LuaOnlyTargets/VisualNovel/main.cpp
+++ b/LuaOnlyTargets/VisualNovel/main.cpp
@@ -1,6 +1,7 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
+#include "NovelRT/Maths/GeoVector2F.hpp"
 #include <NovelRT/Ecs/Catalogue.hpp>
 #include <NovelRT/Ecs/ComponentBuffer.hpp>
 #include <NovelRT/Ecs/ComponentView.hpp>
@@ -204,8 +205,14 @@ class InitialisationSystem : public IEcsSystem
 {
 private:
     bool _initialized = false;
+    NovelRT::Maths::GeoVector2F _dimensions;
 
 public:
+    explicit InitialisationSystem(NovelRT::Maths::GeoVector2F initialDimensions) noexcept
+        : _dimensions(initialDimensions)
+    {
+    }
+
     void Update(NovelRT::Timing::Timestamp /*delta*/, Catalogue catalogue) final
     {
         if (_initialized)
@@ -331,8 +338,11 @@ int main()
     SystemSchedulerBuilder builder{};
     SpriteRendererSystem<VulkanGraphicsBackend>::SpritePass passData{};
 
-    auto wndProvider = std::make_shared<WindowProvider<NovelRT::Windowing::Glfw::GlfwWindowingBackend>>(
-        NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F{1920, 1080});
+    auto wndProvider = std::make_shared<WindowProvider<NovelRT::Windowing::Glfw::GlfwWindowingBackend>>();
+
+    auto finalSize = wndProvider->GetAllVideoModeData().at(0).displayDimensions * 0.75f;
+
+    wndProvider->CreateWindow(NovelRT::Windowing::WindowMode::Windowed, finalSize);
 
     auto inputProvider = std::make_shared<InputProvider<NovelRT::Input::Glfw::GlfwInputBackend>>(wndProvider);
 
@@ -403,10 +413,10 @@ int main()
                       { unused(scheduler.RegisterSystem(defaultSpriteRenderer)); });
 
     builder.Configure(
-        [&wndProvider, &resourceLoader](SystemScheduler& scheduler)
+        [&wndProvider, &resourceLoader, finalSize = finalSize](SystemScheduler& scheduler)
         {
             unused(scheduler.RegisterSystem(std::make_shared<ViewportUpdateSystem>(wndProvider)));
-            unused(scheduler.RegisterSystem(std::make_shared<InitialisationSystem>()));
+            unused(scheduler.RegisterSystem(std::make_shared<InitialisationSystem>(finalSize)));
             unused(scheduler.RegisterSystem(std::make_shared<PoseToSpriteTranslationSystem>(resourceLoader)));
             unused(scheduler.RegisterSystem(std::make_shared<BranchTranslationSystem>()));
             unused(scheduler.RegisterSystem(std::make_shared<SpokenLineTranslationSystem>()));

--- a/Samples/Ecs/Audio/main.cpp
+++ b/Samples/Ecs/Audio/main.cpp
@@ -41,8 +41,8 @@
 
 #include <NovelRT/UI/ImGui/ImGuiUIProvider.hpp>
 
-#include <NovelRT/Ecs/Audio/EcsAudioBuilder.hpp>
 #include <NovelRT/Ecs/Audio/AudioSystem.hpp>
+#include <NovelRT/Ecs/Audio/EcsAudioBuilder.hpp>
 
 #include <NovelRT/Ecs/UI/Components/UIButton.hpp>
 #include <NovelRT/Ecs/UI/Components/UIClickEvent.hpp>
@@ -169,8 +169,7 @@ private:
     NovelRT::Maths::GeoVector2F _initialSize;
 
 public:
-    explicit UISetupSystem(NovelRT::Maths::GeoVector2F& initialSize)
-        : _initialSize(initialSize)
+    explicit UISetupSystem(NovelRT::Maths::GeoVector2F& initialSize) : _initialSize(initialSize)
     {
     }
 
@@ -233,7 +232,7 @@ public:
     }
 };
 
-template <typename TAudioBackend>
+template<typename TAudioBackend>
 class AudioSetupSystem : public IEcsSystem
 {
 private:
@@ -242,7 +241,8 @@ private:
     std::shared_ptr<Audio::AudioSystem<TAudioBackend>> _system;
 
 public:
-    AudioSetupSystem(std::filesystem::path soundDirectory, std::shared_ptr<Audio::AudioSystem<TAudioBackend>> audioSystem)
+    AudioSetupSystem(std::filesystem::path soundDirectory,
+                     std::shared_ptr<Audio::AudioSystem<TAudioBackend>> audioSystem)
         : _sndDirectory(soundDirectory), _system(std::move(audioSystem))
     {
     }
@@ -263,7 +263,8 @@ public:
 
         auto bgMusicEntityId = catalogue.CreateEntity();
         emitterView.AddComponent(bgMusicEntityId, AudioEmitterComponent{bgHandle, true, -1, 0.75f});
-        emitterStateView.AddComponent(bgMusicEntityId, AudioEmitterStateComponent{AudioEmitterState::ToFadeIn, 4.0f, 0.75f});        
+        emitterStateView.AddComponent(bgMusicEntityId,
+                                      AudioEmitterStateComponent{AudioEmitterState::ToFadeIn, 4.0f, 0.75f});
     }
 };
 
@@ -299,7 +300,8 @@ public:
                     UIText initialText{};
                     if (textView.TryGetComponent(id, initialText))
                     {
-                        textView.PushComponentUpdateInstruction(id, UIText{new std::string(_story[_strIndex]), initialText.colour});
+                        textView.PushComponentUpdateInstruction(
+                            id, UIText{new std::string(_story[_strIndex]), initialText.colour});
                     }
                 }
             }
@@ -409,8 +411,8 @@ int main()
     auto audioProvider = std::make_shared<AudioProvider<OpenAL::OpenALAudioBackend>>();
 
     auto windowSize = NovelRT::Maths::GeoVector2F(1280, 720);
-    auto wndProvider = std::make_shared<WindowProvider<NovelRT::Windowing::Glfw::GlfwWindowingBackend>>(
-        NovelRT::Windowing::WindowMode::Windowed, windowSize);
+    auto wndProvider = std::make_shared<WindowProvider<NovelRT::Windowing::Glfw::GlfwWindowingBackend>>();
+    wndProvider->CreateWindow(NovelRT::Windowing::WindowMode::Windowed, windowSize);
 
     auto inputProvider = std::make_shared<InputProvider<NovelRT::Input::Glfw::GlfwInputBackend>>(wndProvider);
 
@@ -464,9 +466,9 @@ int main()
     gfxBuilder.WithDefaultOrchestrator();
 
     auto& audioBuilder = AddAudio<OpenAL::OpenALAudioBackend>(builder)
-                            .WithResourceLoader(desktopResourceLoader)
-                            .WithAudioProvider(audioProvider)
-                            .WithDefaultAudioSystem();
+                             .WithResourceLoader(desktopResourceLoader)
+                             .WithAudioProvider(audioProvider)
+                             .WithDefaultAudioSystem();
 
     auto defaultSpriteRenderer = std::make_shared<SpriteRendererSystem<VulkanGraphicsBackend>>(
         gfxDevice, passData, desktopResourceLoader, memoryAllocator, gfxSurfaceContext);
@@ -477,7 +479,8 @@ int main()
     auto clickSystem = std::make_shared<UIInteractionSystem>();
 
     auto soundsDir = desktopResourceLoader->ResourcesRootDirectory() / "Sounds";
-    auto audioSetupSystem = std::make_shared<AudioSetupSystem<OpenAL::OpenALAudioBackend>>(soundsDir, audioBuilder.GetEcsAudioSystem());
+    auto audioSetupSystem =
+        std::make_shared<AudioSetupSystem<OpenAL::OpenALAudioBackend>>(soundsDir, audioBuilder.GetEcsAudioSystem());
 
     builder.Configure([defaultSpriteRenderer](SystemScheduler& scheduler)
                       { unused(scheduler.RegisterSystem(defaultSpriteRenderer)); });
@@ -486,7 +489,8 @@ int main()
     builder.Configure([clickSystem](SystemScheduler& scheduler) { unused(scheduler.RegisterSystem(clickSystem)); });
     builder.Configure([viewportUpdater](SystemScheduler& scheduler)
                       { unused(scheduler.RegisterSystem(viewportUpdater)); });
-    builder.Configure([audioSetupSystem](SystemScheduler& scheduler) { unused(scheduler.RegisterSystem(audioSetupSystem)); });
+    builder.Configure([audioSetupSystem](SystemScheduler& scheduler)
+                      { unused(scheduler.RegisterSystem(audioSetupSystem)); });
 
     SystemScheduler scheduler = builder.Build();
     StepTimer timer{};

--- a/Samples/Ecs/Graphics/main.cpp
+++ b/Samples/Ecs/Graphics/main.cpp
@@ -148,8 +148,9 @@ int main()
     resourceLoader
         ->InitAssetDatabase(); // TODO: Hack because this was originally called by the legacy plugin provider stuff.
 
-    auto wndProvider = std::make_shared<WindowProvider<Glfw::GlfwWindowingBackend>>(
-        NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F(1920.0f, 1080.0f) / 2.0f);
+    auto wndProvider = std::make_shared<WindowProvider<Glfw::GlfwWindowingBackend>>();
+    wndProvider->CreateWindow(NovelRT::Windowing::WindowMode::Windowed,
+                              NovelRT::Maths::GeoVector2F(1920.0f, 1080.0f) / 2.0f);
 
     auto gfxProvider = wndProvider->CreateGraphicsProvider<VulkanGraphicsBackend>(false);
     auto gfxSurfaceContext = std::make_shared<GraphicsSurfaceContext<VulkanGraphicsBackend>>(wndProvider, gfxProvider);

--- a/Samples/Ecs/Scripting/main.cpp
+++ b/Samples/Ecs/Scripting/main.cpp
@@ -240,8 +240,8 @@ int main()
     SystemSchedulerBuilder builder{};
     SpriteRendererSystem<VulkanGraphicsBackend>::SpritePass passData{};
 
-    auto wndProvider = std::make_shared<WindowProvider<NovelRT::Windowing::Glfw::GlfwWindowingBackend>>(
-        NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F{1920, 1080});
+    auto wndProvider = std::make_shared<WindowProvider<NovelRT::Windowing::Glfw::GlfwWindowingBackend>>();
+    wndProvider->CreateWindow(NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F{1920, 1080});
 
     auto inputProvider = std::make_shared<InputProvider<NovelRT::Input::Glfw::GlfwInputBackend>>(wndProvider);
 

--- a/Samples/Ecs/UI/main.cpp
+++ b/Samples/Ecs/UI/main.cpp
@@ -161,8 +161,7 @@ private:
     NovelRT::Maths::GeoVector2F _initialSize;
 
 public:
-    explicit UISetupSystem(NovelRT::Maths::GeoVector2F& initialSize)
-        : _initialSize(initialSize)
+    explicit UISetupSystem(NovelRT::Maths::GeoVector2F& initialSize) : _initialSize(initialSize)
     {
     }
 
@@ -257,7 +256,8 @@ public:
                     UIText initialText{};
                     if (textView.TryGetComponent(id, initialText))
                     {
-                        textView.PushComponentUpdateInstruction(id, UIText{new std::string(_story[_strIndex]), initialText.colour});
+                        textView.PushComponentUpdateInstruction(
+                            id, UIText{new std::string(_story[_strIndex]), initialText.colour});
                     }
                 }
             }
@@ -365,8 +365,8 @@ int main()
     desktopResourceLoader->InitAssetDatabase();
 
     auto windowSize = NovelRT::Maths::GeoVector2F(1280, 720);
-    auto wndProvider = std::make_shared<WindowProvider<NovelRT::Windowing::Glfw::GlfwWindowingBackend>>(
-        NovelRT::Windowing::WindowMode::Windowed, windowSize);
+    auto wndProvider = std::make_shared<WindowProvider<NovelRT::Windowing::Glfw::GlfwWindowingBackend>>();
+    wndProvider->CreateWindow(NovelRT::Windowing::WindowMode::Windowed, windowSize);
 
     auto inputProvider = std::make_shared<InputProvider<NovelRT::Input::Glfw::GlfwInputBackend>>(wndProvider);
 

--- a/Samples/Experimental/ImGui/main.cpp
+++ b/Samples/Experimental/ImGui/main.cpp
@@ -411,8 +411,8 @@ int main()
     logger.setLogLevel(LogLevel::Info);
 
     // Windowing Setup
-    auto wndProvider = std::make_shared<WindowProvider<NovelRT::Windowing::Glfw::GlfwWindowingBackend>>(
-        NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F(400, 400));
+    auto wndProvider = std::make_shared<WindowProvider<NovelRT::Windowing::Glfw::GlfwWindowingBackend>>();
+    wndProvider->CreateWindow(NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F(400, 400));
 
     auto desktopResourceLoader = std::make_shared<NovelRT::ResourceManagement::Desktop::DesktopResourceLoader>();
     desktopResourceLoader->InitAssetDatabase();

--- a/Samples/Experimental/VulkanRender/main.cpp
+++ b/Samples/Experimental/VulkanRender/main.cpp
@@ -318,8 +318,8 @@ int main()
     LoggingService logger{};
     logger.setLogLevel(LogLevel::Info);
 
-    auto wndProvider = std::make_shared<WindowProvider<Glfw::GlfwWindowingBackend>>(
-        NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F(400, 400));
+    auto wndProvider = std::make_shared<WindowProvider<Glfw::GlfwWindowingBackend>>();
+    wndProvider->CreateWindow(NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F(400, 400));
 
     auto gfxProvider = wndProvider->CreateGraphicsProvider<VulkanGraphicsBackend>(false);
     auto gfxSurfaceContext = std::make_shared<GraphicsSurfaceContext<VulkanGraphicsBackend>>(wndProvider, gfxProvider);

--- a/Windowing/Core/CMakeLists.txt
+++ b/Windowing/Core/CMakeLists.txt
@@ -6,6 +6,7 @@ NovelRTBuildSystem_DeclareModule(LIBRARY NovelRT::Windowing::Core
 
   HEADERS
     PUBLIC
+      include/NovelRT/Windowing/VideoModeData.hpp
       include/NovelRT/Windowing/WindowMode.hpp
       include/NovelRT/Windowing/WindowProvider.hpp
 )

--- a/Windowing/Core/include/NovelRT/Windowing/VideoModeData.hpp
+++ b/Windowing/Core/include/NovelRT/Windowing/VideoModeData.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+// Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
+// for more information.
+
+#include <NovelRT/Maths/GeoVector2F.hpp>
+
+namespace NovelRT::Windowing
+{
+    struct VideoModeData
+    {
+        Maths::GeoVector2F displayDimensions;
+    };
+}

--- a/Windowing/Core/include/NovelRT/Windowing/WindowProvider.hpp
+++ b/Windowing/Core/include/NovelRT/Windowing/WindowProvider.hpp
@@ -5,23 +5,29 @@
 #include <NovelRT/Graphics/GraphicsProvider.hpp>
 #include <NovelRT/Graphics/IGraphicsSurface.hpp>
 #include <NovelRT/Maths/GeoVector2F.hpp>
+#include <NovelRT/Windowing/VideoModeData.hpp>
+#include <NovelRT/Windowing/WindowMode.hpp>
 
 #include <string>
+#include <vector>
 
 namespace NovelRT::Windowing
 {
     template<typename TBackend>
-    class WindowProvider : public Graphics::IGraphicsSurface
+    class WindowProvider final : public Graphics::IGraphicsSurface
     {
     public:
         WindowProvider() = delete;
-        ~WindowProvider() = default;
+        ~WindowProvider() noexcept final = default;
+
+        [[nodiscard]] std::vector<VideoModeData> GetAllVideoModeData();
+
+        void CreateWindow(NovelRT::Windowing::WindowMode windowMode, Maths::GeoVector2F desiredWindowSize);
 
         void ProcessAllMessages();
 
         [[nodiscard]] bool IsVisible() const noexcept;
         [[nodiscard]] bool ShouldClose() const noexcept;
-
         [[nodiscard]] std::string GetWindowTitle() const noexcept;
         [[nodiscard]] const char* GetClipboardText() const;
         [[nodiscard]] NovelRT::Maths::GeoVector2F GetWindowScale() const noexcept;

--- a/Windowing/Glfw/GlfwWindowProvider.cpp
+++ b/Windowing/Glfw/GlfwWindowProvider.cpp
@@ -1,7 +1,7 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
-#include "GLFW/glfw3.h"
+#include <GLFW/glfw3.h>
 #include <NovelRT/Exceptions/InitialisationFailureException.hpp>
 #include <NovelRT/Exceptions/NotSupportedException.hpp>
 
@@ -13,14 +13,32 @@ namespace NovelRT::Windowing
 {
     using GlfwWindowProvider = WindowProvider<Glfw::GlfwWindowingBackend>;
 
-    GlfwWindowProvider::WindowProvider(NovelRT::Windowing::WindowMode windowMode, Maths::GeoVector2F desiredWindowSize)
+    std::vector<VideoModeData> GlfwWindowProvider::GetAllVideoModeData()
     {
+        GLFWmonitor* primary = glfwGetPrimaryMonitor();
+        const GLFWvidmode* mode = glfwGetVideoMode(primary);
+
+        std::vector<VideoModeData> returnData{};
+
+        returnData.emplace_back(Maths::GeoVector2F(static_cast<float>(mode->width), static_cast<float>(mode->height)));
+
+        return returnData;
+    }
+
+    GlfwWindowProvider::WindowProvider() : _window(nullptr)
+    {
+
         if (glfwInit() == GLFW_FALSE)
         {
             const char* output = nullptr;
             glfwGetError(&output);
             throw Exceptions::InitialisationFailureException("GLFW3 failed to initialise.", std::string(output));
         }
+    }
+
+    void GlfwWindowProvider::CreateWindow(NovelRT::Windowing::WindowMode windowMode,
+                                          Maths::GeoVector2F desiredWindowSize)
+    {
 
         glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
         GLFWmonitor* monitor = nullptr;

--- a/Windowing/Glfw/include/NovelRT/Windowing/Glfw/GlfwWindowProvider.hpp
+++ b/Windowing/Glfw/include/NovelRT/Windowing/Glfw/GlfwWindowProvider.hpp
@@ -6,6 +6,7 @@
 #include <NovelRT/Graphics/GraphicsSurfaceKind.hpp>
 #include <NovelRT/Maths/GeoVector2F.hpp>
 #include <NovelRT/Utilities/Event.hpp>
+#include <NovelRT/Windowing/VideoModeData.hpp>
 #include <NovelRT/Windowing/WindowMode.hpp>
 #include <NovelRT/Windowing/WindowProvider.hpp>
 
@@ -49,11 +50,16 @@ namespace NovelRT::Windowing
         Maths::GeoVector2F _currentSize;
 
     public:
-        WindowProvider(NovelRT::Windowing::WindowMode windowMode, Maths::GeoVector2F desiredWindowSize);
+        WindowProvider();
         ~WindowProvider() noexcept final;
 
+        [[nodiscard]] std::vector<VideoModeData> GetAllVideoModeData();
+
+        void CreateWindow(NovelRT::Windowing::WindowMode windowMode, Maths::GeoVector2F desiredWindowSize);
+
         template<typename TBackend>
-        std::shared_ptr<Graphics::GraphicsProvider<TBackend>> CreateGraphicsProvider(bool enableDebugMode);
+        [[nodiscard]] std::shared_ptr<Graphics::GraphicsProvider<TBackend>> CreateGraphicsProvider(
+            bool enableDebugMode);
 
         void ProcessAllMessages();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This changes introduces a new LLAPI for window management. I will want to flesh it out in the future but right now I put the minimal skeleton in to fix the associated bug.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
Resolves #693 


**What is the current behavior?** (You can also link to an open issue here)
The window in the VisualNovel binary will always open at a 1080p resolution even if the monitor can't realistically handle it.


**What is the new behavior (if this is a feature change)?**
The VisualNovel binary will now only use 75% of the screen size. In theory.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes but it is a LLAPI that basically nobody aside from maintainers is using so this will be going in a bug fix version either way.


**Other information**:
