### PR TITLE
Fix issue where initial dimensions were not passed properly.

### DIFF
--- a/LuaOnlyTargets/VisualNovel/main.cpp
+++ b/LuaOnlyTargets/VisualNovel/main.cpp
@@ -257,9 +257,9 @@ public:
                                                                            .isScreenSpace = true});
 
         viewports.PushComponentUpdateInstruction(
-            worldCameraEntity, NovelRT::Ecs::Graphics::Components::Viewport{.width = 1920, .height = 1080});
+            worldCameraEntity, NovelRT::Ecs::Graphics::Components::Viewport{.width = _dimensions.x, .height = _dimensions.y});
         viewports.PushComponentUpdateInstruction(
-            screenCameraEntity, NovelRT::Ecs::Graphics::Components::Viewport{.width = 1920, .height = 1080});
+            screenCameraEntity, NovelRT::Ecs::Graphics::Components::Viewport{.width = _dimensions.x, .height = _dimensions.y});
     }
 };
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This resolves an issue where the initial window dimensions were not being passed into the initialisation system.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
The dimensions are ignored.


**What is the new behavior (if this is a feature change)?**
The dimensions are respected.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no.


**Other information**:
