### PR TITLE
Fix WAW sync hazard in legacy image barriers.

### DIFF
--- a/Graphics/Vulkan/VulkanGraphicsCmdList.cpp
+++ b/Graphics/Vulkan/VulkanGraphicsCmdList.cpp
@@ -370,7 +370,7 @@ namespace NovelRT::Graphics
 
         VkImageMemoryBarrier vulkanImageMemoryBarrier{};
         vulkanImageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-        vulkanImageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        vulkanImageMemoryBarrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
         vulkanImageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
         vulkanImageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
         vulkanImageMemoryBarrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;

--- a/Samples/Experimental/VulkanRender/main.cpp
+++ b/Samples/Experimental/VulkanRender/main.cpp
@@ -321,7 +321,7 @@ int main()
     auto wndProvider = std::make_shared<WindowProvider<Glfw::GlfwWindowingBackend>>();
     wndProvider->CreateWindow(NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F(400, 400));
 
-    auto gfxProvider = wndProvider->CreateGraphicsProvider<VulkanGraphicsBackend>(false);
+    auto gfxProvider = wndProvider->CreateGraphicsProvider<VulkanGraphicsBackend>(true);
     auto gfxSurfaceContext = std::make_shared<GraphicsSurfaceContext<VulkanGraphicsBackend>>(wndProvider, gfxProvider);
 
     VulkanGraphicsAdapterSelector selector{};

--- a/Samples/Experimental/VulkanRender/main.cpp
+++ b/Samples/Experimental/VulkanRender/main.cpp
@@ -321,7 +321,7 @@ int main()
     auto wndProvider = std::make_shared<WindowProvider<Glfw::GlfwWindowingBackend>>();
     wndProvider->CreateWindow(NovelRT::Windowing::WindowMode::Windowed, NovelRT::Maths::GeoVector2F(400, 400));
 
-    auto gfxProvider = wndProvider->CreateGraphicsProvider<VulkanGraphicsBackend>(true);
+    auto gfxProvider = wndProvider->CreateGraphicsProvider<VulkanGraphicsBackend>(false);
     auto gfxSurfaceContext = std::make_shared<GraphicsSurfaceContext<VulkanGraphicsBackend>>(wndProvider, gfxProvider);
 
     VulkanGraphicsAdapterSelector selector{};


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes a Write-after-write sync hazard in an older part of our Vulkan API.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
no.


**What is the current behavior?** (You can also link to an open issue here)
Vulkan validation warns of a WAW.


**What is the new behavior (if this is a feature change)?**
The WAW no longer occurs.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
N/A