### PR TITLE
Add support for rudimentary system-based jobs.

### DIFF
--- a/Ecs/Core/Catalogue.cpp
+++ b/Ecs/Core/Catalogue.cpp
@@ -59,7 +59,7 @@ namespace NovelRT::Ecs
         return _scheduler.ScheduleSystemJob(std::move(jobFnPtr));
     }
 
-    void Catalogue::CancelSystemJob(SystemId jobId)
+    void Catalogue::CancelSystemJob(SystemId jobId) noexcept
     {
         _scheduler.CancelSystemJob(jobId);
     }

--- a/Ecs/Core/Catalogue.cpp
+++ b/Ecs/Core/Catalogue.cpp
@@ -8,6 +8,7 @@
 #include <NovelRT/Ecs/UnsafeComponentView.hpp>
 
 #include <algorithm>
+#include <utility>
 
 namespace NovelRT::Ecs
 {
@@ -51,5 +52,15 @@ namespace NovelRT::Ecs
     UnsafeComponentView Catalogue::GetComponentViewById(ComponentTypeId componentTypeId)
     {
         return UnsafeComponentView(_poolId, _componentCache.GetComponentBufferById(componentTypeId));
+    }
+
+    SystemId Catalogue::ScheduleSystemJob(std::function<bool(Timing::Timestamp, Catalogue)> jobFnPtr)
+    {
+        return _scheduler.ScheduleSystemJob(std::move(jobFnPtr));
+    }
+
+    void Catalogue::CancelSystemJob(SystemId jobId)
+    {
+        _scheduler.CancelSystemJob(jobId);
     }
 } // namespace NovelRT::Ecs

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -308,8 +308,7 @@ namespace NovelRT::Ecs
                             [&systemJob, this]()
                             {
                                 auto poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
-                                systemJob.isDone.store(systemJob.jobFnPtr(_currentDelta, Catalogue(poolId, *this)),
-                                                       std::memory_order_relaxed);
+                                systemJob.isDone = systemJob.jobFnPtr(_currentDelta, Catalogue(poolId, *this));
                             });
                     }
 
@@ -320,7 +319,7 @@ namespace NovelRT::Ecs
                     // a bit ugly, but couldn't think of a better way to do it right now - Matt J.
                     for (auto it = _systemJobs.begin(); it != _systemJobs.end();)
                     {
-                        if (it->second.isDone.load(std::memory_order_relaxed))
+                        if (it->second.isDone)
                         {
                             hadTombstones = true;
                             it = _systemJobs.unsafe_erase(it);

--- a/Ecs/Core/SystemScheduler.cpp
+++ b/Ecs/Core/SystemScheduler.cpp
@@ -1,6 +1,7 @@
 // Copyright © Matt Jones and Contributors. Licensed under the MIT Licence (MIT). See LICENCE.md in the repository root
 // for more information.
 
+#include "NovelRT/Timing/Timestamp.hpp"
 #include <NovelRT/Ecs/Catalogue.hpp>
 #include <NovelRT/Ecs/ComponentCache.hpp>
 #include <NovelRT/Ecs/EntityCache.hpp>
@@ -9,12 +10,30 @@
 #include <NovelRT/Maths/Utilities.hpp>
 #include <NovelRT/Utilities/Macros.hpp>
 
+#include <atomic>
 #include <cassert>
 #include <functional>
 #include <unordered_map>
+#include <utility>
 
 namespace NovelRT::Ecs
 {
+    SystemId SystemScheduler::ScheduleSystemJob(std::function<bool(Timing::Timestamp, Catalogue)> jobFnPtr)
+    {
+        static AtomFactory& systemIdFactory = AtomFactoryDatabase::GetFactory("SystemId");
+        SystemId id = systemIdFactory.GetNext();
+
+        _systemJobs.emplace(std::piecewise_construct, std::forward_as_tuple(id),
+                            std::forward_as_tuple(std::move(jobFnPtr)));
+
+        return id;
+    }
+
+    void SystemScheduler::CancelSystemJob(SystemId jobId)
+    {
+        _jobCancellations.emplace(jobId);
+    }
+
     void SystemScheduler::RebuildSystemDependencyTreeLayers()
     {
         // Special casing terminal systems e.g. the render orchestrator with this. - Matt J.
@@ -126,6 +145,8 @@ namespace NovelRT::Ecs
           _ecsTasks(std::make_unique<tbb::task_group>()),
           _asyncTasks(std::make_unique<tbb::task_group>()),
           _pendingCompletions(),
+          _systemJobs(),
+          _jobCancellations(),
           _currentDelta(NovelRT::Timing::TimeFromSeconds(0)),
           _hasExecutedAtLeastOnce(false)
     {
@@ -146,6 +167,8 @@ namespace NovelRT::Ecs
           _ecsTasks(std::move(other._ecsTasks)),
           _asyncTasks(std::move(other._asyncTasks)),
           _pendingCompletions(std::move(other._pendingCompletions)),
+          _systemJobs(std::move(other._systemJobs)),
+          _jobCancellations(std::move(other._jobCancellations)),
           _currentDelta(other._currentDelta),
           _hasExecutedAtLeastOnce(other._hasExecutedAtLeastOnce)
     {
@@ -163,8 +186,10 @@ namespace NovelRT::Ecs
         _asyncArena = std::move(other._asyncArena);
         _ecsTasks = std::move(other._ecsTasks);
         _asyncTasks = std::move(other._asyncTasks);
-        _currentDelta = other._currentDelta;
         _pendingCompletions = std::move(other._pendingCompletions);
+        _systemJobs = std::move(other._systemJobs);
+        _jobCancellations = std::move(other._jobCancellations);
+        _currentDelta = other._currentDelta;
         _hasExecutedAtLeastOnce = other._hasExecutedAtLeastOnce;
 
         return *this;
@@ -275,12 +300,58 @@ namespace NovelRT::Ecs
                         _entityCache.ApplyEntityDeletionRequestsToRegisteredEntities();
                     }
 
+                    for (auto& [_, systemJob] : _systemJobs)
+                    {
+                        unused(_);
+
+                        _ecsTasks->run(
+                            [&systemJob, this]()
+                            {
+                                auto poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
+                                systemJob.isDone.store(systemJob.jobFnPtr(_currentDelta, Catalogue(poolId, *this)),
+                                                       std::memory_order_relaxed);
+                            });
+                    }
+
+                    _ecsTasks->wait();
+
+                    bool hadTombstones = false;
+
+                    // a bit ugly, but couldn't think of a better way to do it right now - Matt J.
+                    for (auto it = _systemJobs.begin(); it != _systemJobs.end();)
+                    {
+                        if (it->second.isDone.load(std::memory_order_relaxed))
+                        {
+                            hadTombstones = true;
+                            it = _systemJobs.unsafe_erase(it);
+                        }
+                        else
+                        {
+                            it++;
+                        }
+                    }
+
+                    SystemId cancellationId = 0ULL;
+
+                    while (_jobCancellations.try_pop(cancellationId))
+                    {
+                        _systemJobs.unsafe_erase(cancellationId);
+                    }
+
+                    if (hadTombstones)
+                    {
+                        _componentCache.PrepAllBuffersForNextFrame(_entityCache.GetEntitiesToRemoveThisFrame());
+                        _entityCache.ProcessEntityRegistrationRequestsFromThreads();
+                        _entityCache.ProcessEntityDeletionRequestsFromThreads();
+                        _entityCache.ApplyEntityDeletionRequestsToRegisteredEntities();
+                    }
+
                     for (SystemId systemId : layer)
                     {
                         _ecsTasks->run(
                             [&, systemId]()
                             {
-                                size_t poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
+                                auto poolId = static_cast<size_t>(tbb::this_task_arena::current_thread_index());
                                 _systems[systemId](_currentDelta, Catalogue(poolId, *this));
                             });
                     }

--- a/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
@@ -8,7 +8,6 @@
 #include <NovelRT/Ecs/ImplDetail.hpp>
 
 #include <cstddef>
-#include <cstdint>
 #include <tuple>
 #include <vector>
 
@@ -140,6 +139,9 @@ namespace NovelRT::Ecs
         requires Detail::ValidScheduleWithCompletion<TWork, TCompletion> void ScheduleWithCompletion(
             TWork&& work,
             TCompletion&& completion) noexcept;
+
+        [[nodiscard]] SystemId ScheduleSystemJob(std::function<bool(Timing::Timestamp, Catalogue)> jobFnPtr);
+        void CancelSystemJob(SystemId jobId);
     };
 }
 

--- a/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/Catalogue.hpp
@@ -140,8 +140,22 @@ namespace NovelRT::Ecs
             TWork&& work,
             TCompletion&& completion) noexcept;
 
-        [[nodiscard]] SystemId ScheduleSystemJob(std::function<bool(Timing::Timestamp, Catalogue)> jobFnPtr);
-        void CancelSystemJob(SystemId jobId);
+        /**
+         * @brief Schedules a system-based job to run over one or more update cycles.
+         *
+         * @param jobFnptr a bound function, lambda, etc. that matches the signature of a regular system,
+         * which returns a boolean to indicate if the work is finished (true) or if it is ongoing (false).
+         *
+         * @return The SystemId that represents this system-based job.
+         */
+        SystemId ScheduleSystemJob(std::function<bool(Timing::Timestamp, Catalogue)> jobFnPtr);
+
+        /**
+         * @brief Cancels a currently running system-based job based on the given ID.
+         *
+         * @param The ID of the system-based job to cancel.
+         */
+        void CancelSystemJob(SystemId jobId) noexcept;
     };
 }
 

--- a/Ecs/Core/include/NovelRT/Ecs/EcsUtils.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/EcsUtils.hpp
@@ -13,6 +13,7 @@ namespace NovelRT::Ecs
 {
     using EntityId = NovelRT::Atom;
     using ComponentTypeId = NovelRT::Atom;
+    using SystemId = NovelRT::Atom;
 
     std::unordered_map<std::type_index, ComponentTypeId>& GetComponentTypeIds() noexcept;
 

--- a/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
@@ -10,7 +10,6 @@
 #include <NovelRT/Exceptions/KeyNotFoundException.hpp>
 #include <NovelRT/Timing/Timestamp.hpp>
 
-#include <atomic>
 #include <functional>
 #include <memory>
 #include <span>
@@ -43,7 +42,7 @@ namespace NovelRT::Ecs
         struct SystemJobInfo
         {
             std::function<bool(Timing::Timestamp, Catalogue)> jobFnPtr;
-            std::atomic_bool isDone{false};
+            bool isDone = false;
 
             explicit SystemJobInfo(std::function<bool(Timing::Timestamp, Catalogue)> job) noexcept
                 : jobFnPtr(std::move(job))

--- a/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
+++ b/Ecs/Core/include/NovelRT/Ecs/SystemScheduler.hpp
@@ -4,21 +4,22 @@
 // for more information.
 
 #include <NovelRT/Ecs/ComponentCache.hpp>
+#include <NovelRT/Ecs/EcsUtils.hpp>
 #include <NovelRT/Ecs/EntityCache.hpp>
 #include <NovelRT/Ecs/ImplDetail.hpp>
 #include <NovelRT/Exceptions/KeyNotFoundException.hpp>
 #include <NovelRT/Timing/Timestamp.hpp>
-#include <NovelRT/Utilities/Atom.hpp>
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <span>
-#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include <oneapi/tbb/concurrent_queue.h>
+#include <oneapi/tbb/concurrent_unordered_map.h>
 #include <oneapi/tbb/task_arena.h>
 #include <oneapi/tbb/task_group.h>
 
@@ -28,8 +29,6 @@ namespace NovelRT::Ecs
     class ComponentCache;
     class EntityCache;
     class IEcsSystem;
-
-    using SystemId = Atom;
 
     /**
      * @brief Handles all thread and system scheduling related tasks. In a normal ECS instance, this is your root
@@ -41,6 +40,17 @@ namespace NovelRT::Ecs
         friend class Catalogue;
 
     private:
+        struct SystemJobInfo
+        {
+            std::function<bool(Timing::Timestamp, Catalogue)> jobFnPtr;
+            std::atomic_bool isDone{false};
+
+            explicit SystemJobInfo(std::function<bool(Timing::Timestamp, Catalogue)> job) noexcept
+                : jobFnPtr(std::move(job))
+            {
+            }
+        };
+
         std::vector<SystemId> _systemIds;
 
         static constexpr uint32_t DefaultBlindThreadLimit = 8;
@@ -61,6 +71,8 @@ namespace NovelRT::Ecs
         std::unique_ptr<tbb::task_group> _ecsTasks;
         std::unique_ptr<tbb::task_group> _asyncTasks;
         tbb::concurrent_queue<std::function<void(Timing::Timestamp, Catalogue)>> _pendingCompletions;
+        tbb::concurrent_unordered_map<SystemId, SystemJobInfo> _systemJobs;
+        tbb::concurrent_queue<SystemId> _jobCancellations;
 
         Timing::Timestamp _currentDelta;
 
@@ -72,6 +84,9 @@ namespace NovelRT::Ecs
         requires Detail::ValidScheduleWithCompletion<TWork, TCompletion> void ScheduleWithCompletion(
             TWork&& work,
             TCompletion&& completion) noexcept;
+
+        SystemId ScheduleSystemJob(std::function<bool(Timing::Timestamp, Catalogue)> jobFnPtr);
+        void CancelSystemJob(SystemId jobId);
 
         void RebuildSystemDependencyTreeLayers();
 

--- a/Samples/Ecs/Graphics/main.cpp
+++ b/Samples/Ecs/Graphics/main.cpp
@@ -48,6 +48,7 @@
 
 #include <NovelRT/Utilities/Macros.hpp>
 
+#include <iostream>
 #include <memory>
 #include <optional>
 
@@ -85,6 +86,13 @@ public:
         {
             return;
         }
+
+        unused(catalogue.ScheduleSystemJob(
+            [](auto, auto)
+            {
+                std::cout << "HELLO FROM JOB!\n";
+                return true;
+            }));
 
         auto [spriteView, transformView, graphView, cameraView, viewportView] = catalogue.GetComponentViews<
             NovelRT::Ecs::Graphics::Components::Sprite, NovelRT::Ecs::Components::TransformComponent,
@@ -161,7 +169,6 @@ int main()
     auto memoryAllocator = std::make_shared<GraphicsMemoryAllocator<VulkanGraphicsBackend>>(gfxDevice, gfxProvider);
 
     SystemSchedulerBuilder builder{};
-
 
     AddDefaults(builder);
     AddGraphics<Vulkan::VulkanGraphicsBackend>(builder)

--- a/ThirdParty/TBB/CMakeLists.txt
+++ b/ThirdParty/TBB/CMakeLists.txt
@@ -12,6 +12,16 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS OFF)
 
 FetchContent_MakeAvailable(TBB)
 
+# OneTBB is being stupid, and is setting off our compiler warnings in its own headers.
+# This shuts it up by making them system includes, basically.
+# God is dead. - Matt J.
+get_target_property(tbb_include_dirs tbb INTERFACE_INCLUDE_DIRECTORIES)
+if(tbb_include_dirs)
+  set_target_properties(tbb PROPERTIES
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${tbb_include_dirs}"
+  )
+endif()
+
 # Unset the output directories for TBB so that they are generated in the correct location.
 foreach(output_type LIBRARY ARCHIVE PDB RUNTIME)
   if(CMAKE_BUILD_TYPE)

--- a/ThirdParty/TBB/CMakeLists.txt
+++ b/ThirdParty/TBB/CMakeLists.txt
@@ -12,16 +12,6 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS OFF)
 
 FetchContent_MakeAvailable(TBB)
 
-# OneTBB is being stupid, and is setting off our compiler warnings in its own headers.
-# This shuts it up by making them system includes, basically.
-# God is dead. - Matt J.
-get_target_property(tbb_include_dirs tbb INTERFACE_INCLUDE_DIRECTORIES)
-if(tbb_include_dirs)
-  set_target_properties(tbb PROPERTIES
-    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${tbb_include_dirs}"
-  )
-endif()
-
 # Unset the output directories for TBB so that they are generated in the correct location.
 foreach(output_type LIBRARY ARCHIVE PDB RUNTIME)
   if(CMAKE_BUILD_TYPE)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces a new API for creating ECS based jobs, by allowing us to have temporary systems. These systems do not have dependencies, and run once per tick. They return false when not finished, and true when they are. I have also added an explicit API to cancel a job.


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
No.


**What is the current behavior?** (You can also link to an open issue here)
This feature doesn't exist so things like animations etc. are very hard to do.


**What is the new behavior (if this is a feature change)?**
It is now possible to begin figuring out animation support.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope!


**Other information**:
This was only tested in a very barebones way, so we might run into problems as we use it.