### PR TITLE
Change numeric constant to getSize

### DIFF
--- a/Ecs/Graphics/include/NovelRT/Ecs/Graphics/SpriteRendererSystem.hpp
+++ b/Ecs/Graphics/include/NovelRT/Ecs/Graphics/SpriteRendererSystem.hpp
@@ -167,14 +167,17 @@ namespace NovelRT::Ecs::Graphics
                     [this, assetId = sprite.assetId](Timing::Timestamp /*delta*/, Catalogue completionCatalogue,
                                                      ResourceManagement::TextureMetadata textureMetadata)
                     {
+
+                        auto texture2D = _memoryAllocator->CreateTexture2DRepeatGpuWriteOnly(textureMetadata.width,
+                                                                                             textureMetadata.height);
+
                         NovelRT::Graphics::GraphicsBufferCreateInfo bufferCreateInfo{
                             .cpuAccessKind = NovelRT::Graphics::GraphicsResourceAccess::Write,
                             .gpuAccessKind = NovelRT::Graphics::GraphicsResourceAccess::Read,
-                            .size = (static_cast<size_t>(textureMetadata.width) * textureMetadata.height * 4) * 2};
+                            .size = texture2D->GetSize()};
 
                         auto textureStagingBuffer = _memoryAllocator->CreateBuffer(bufferCreateInfo);
-                        auto texture2D = _memoryAllocator->CreateTexture2DRepeatGpuWriteOnly(textureMetadata.width,
-                                                                                             textureMetadata.height);
+
                         auto texture2DRegion = texture2D->Allocate(texture2D->GetSize(), 4);
                         auto textureStagingBufferRegion = textureStagingBuffer->Allocate(texture2D->GetSize(), 4);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/novelrt/NovelRT/blob/misc/templates/Contributing.md#pull-requests)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Documentation has been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


**Is there an open issue that this resolves? If so, please [link it here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).**
#646 


**What is the current behavior?** (You can also link to an open issue here)
#646 


**What is the new behavior (if this is a feature change)?**
Uses the size of the texture instead of a numeric constant


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Closes #646 